### PR TITLE
docs: add 'why not LangGraph' FAQ entry (restored from #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Not a usage reference.
 | [docs/provenance.md](docs/provenance.md) | Capturing prompts + trajectories |
 | [docs/recipes.md](docs/recipes.md) | Ollama, OTel, MCP, cost accounting, checkpoints |
 | [docs/benchmarks.md](docs/benchmarks.md) | Cold-import time & dep footprint vs alternatives |
+| [docs/faq.md](docs/faq.md) | FAQ, including "why not LangGraph?" |
 | [ROADMAP.md](ROADMAP.md) | What's planned, what's frozen, what's out of scope |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, conventions, PR checklist |
 | [CHANGELOG.md](CHANGELOG.md) | Release notes |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,46 @@
+# FAQ
+
+## Why not LangGraph?
+
+LangGraph is the right tool for a lot of agent work, and for some projects it's
+a better fit than `looplet`. Here's the honest comparison so you can pick
+deliberately instead of by vibes.
+
+### Use LangGraph when
+
+- **Your agent is a multi-node graph, not a loop.** A triage node hands off
+  to a research branch and a coding branch, each branch has its own state,
+  and they join again at a review node. That's the shape LangGraph is
+  designed around. Trying to express it as a single `for step in loop(...)`
+  with hooks is fighting the tool.
+- **You want durable checkpointing as a first-class feature.** LangGraph has
+  built-in checkpointer backends (SQLite, Postgres, Redis) with interrupt
+  and resume semantics tied directly to node boundaries. `looplet` lets you
+  build that — `ProvenanceSink` dumps every step and a hook can persist
+  state — but LangGraph gives it to you out of the box.
+- **You're already in the LangChain ecosystem.** Your prompts are
+  `ChatPromptTemplate`s, your retrievers are LangChain retrievers, your
+  streaming consumers expect LangChain events. Bridging all of that through
+  `looplet` adds friction.
+- **You need the graph visualiser.** LangGraph's Studio / `.get_graph()` view
+  is genuinely useful for explaining a multi-agent system to someone who
+  doesn't want to read Python.
+
+### Use looplet when
+
+- **Your agent really is a loop.** One LLM calling tools until it's done.
+  That's ~80% of real agent work, and a graph for it is overkill.
+- **You want to see every prompt the LLM saw, in order, without a debugger.**
+  `step.pretty()` and `ProvenanceSink` are the whole point.
+- **You want to shape behaviour without forking.** A 10-line hook that
+  redacts PII, injects docs, or rewrites tool args composes with everything
+  else — no class hierarchy, no node refactor.
+- **Cold-import time and dependency footprint matter.** Core `looplet` pulls
+  in zero third-party packages; see [Benchmarks](benchmarks.md).
+- **You want your debug trace and your eval harness to be the same
+  artifact.** The pytest-style `eval_*` helpers read `ProvenanceSink`
+  output directly.
+
+If you're building a research swarm or a multi-stage ETL with a literal DAG,
+use LangGraph. If you're building an agent that reasons and calls tools
+until it's done, the loop is the product and `looplet` stays out of your way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Roadmap: roadmap.md
   - Contributing: contributing.md
   - Good first issues: good-first-issues.md
+  - FAQ: faq.md
   - Demo script: demo-script.md
   - Changelog: changelog.md
 


### PR DESCRIPTION
Restores #16 from @mvanhorn — unfortunately closed automatically because I force-pushed master earlier today (rewriting 29 commits to fix a git-identity attribution problem), which left the fork branch with no common ancestor with master, and GitHub refused to let the PR reopen.

Commit `012ccb9` is a clean cherry-pick of @mvanhorn's original commit `77b4a0f` onto current master — authorship preserved (Matt Van Horn <455140+mvanhorn@users.noreply.github.com>), diff unchanged.

Fixes #11.
Supersedes #16 (which I'll close and cross-link).

---

Original PR body below:

## Summary
Add `docs/faq.md` with a "why not LangGraph" entry, wire it into the mkdocs nav between `good-first-issues.md` and `demo-script.md`, and link it from the docs table in `README.md` - all three steps from issue #11's acceptance criteria.

## Why this matters
Issue #11 frames the point well: credibility comes from telling people when *not* to use you. `looplet`'s README already explains "why it exists" in abstract design terms, but a user trying to pick between `looplet` and LangGraph doesn't get a decision-ready answer. The new FAQ is structured as two symmetric lists - "Use LangGraph when" and "Use looplet when" - so the reader picks deliberately.

## Changes
- `docs/faq.md` (new)
- `mkdocs.yml`: add `- FAQ: faq.md` to `nav`
- `README.md`: new row in the docs table

This contribution was developed with AI assistance (Claude Code).