### PR TITLE
feat(provenance): add metadata dict to StepRecord and LLMCall

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -121,6 +121,7 @@ Each entry in `llm.calls` exposes:
 | `max_tokens` | `int` | As passed |
 | `step_num` | `int \| None` | Set by `TrajectoryRecorder` to link calls to loop steps |
 | `error` | `str \| None` | `f"{type(e).__name__}: {e}"` if the wrapped backend raised |
+| `metadata` | `dict[str, Any]` | Free-form annotations for external hooks; defaults to `{}` |
 
 ### Safety knobs
 
@@ -214,6 +215,7 @@ for i in indices:
 | `tool_result` | `ToolResult.to_dict()` (truncated safely) |
 | `context_before` | The briefing shown to the LLM before this step's prompt |
 | `llm_call_indices` | Into `trajectory.llm_calls` (empty if no recording backend) |
+| `metadata` | Free-form annotations for external hooks; defaults to `{}` |
 
 ### Termination inference
 

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -101,6 +101,7 @@ class LLMCall:
     ``"tool:<name>"`` means the call was made inside a tool via
     ``ctx.llm.generate()``.  Used by provenance consumers to group
     and filter calls by origin."""
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -117,6 +118,7 @@ class LLMCall:
             "step_num": self.step_num,
             "error": self.error,
             "scope": self.scope,
+            "metadata": dict(self.metadata),
         }
         return d
 
@@ -489,6 +491,7 @@ class StepRecord:
     tool_result: dict[str, Any]
     context_before: str = ""
     llm_call_indices: list[int] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -500,6 +503,7 @@ class StepRecord:
             "tool_result": self.tool_result,
             "context_before": self.context_before,
             "llm_call_indices": list(self.llm_call_indices),
+            "metadata": dict(self.metadata),
         }
 
 

--- a/tests/test_provenance_smoke.py
+++ b/tests/test_provenance_smoke.py
@@ -226,6 +226,76 @@ class TestProvenanceSinkSmoke:
 
 
 class TestDataclassSmoke:
+    def test_llm_call_metadata_defaults_empty(self):
+        c = LLMCall(
+            index=0,
+            timestamp=1.0,
+            duration_ms=5.0,
+            method="generate",
+            prompt="p",
+            system_prompt="",
+            response="r",
+        )
+        assert c.metadata == {}
+
+    def test_step_record_metadata_defaults_empty(self):
+        s = StepRecord(
+            step_num=1,
+            timestamp=1.0,
+            duration_ms=2.0,
+            pretty="#1 ✓",
+            tool_call={"tool": "x"},
+            tool_result={"tool": "x"},
+        )
+        assert s.metadata == {}
+
+    def test_metadata_round_trips_through_json(self):
+        c = LLMCall(
+            index=0,
+            timestamp=1.0,
+            duration_ms=5.0,
+            method="generate",
+            prompt="p",
+            system_prompt="",
+            response="r",
+        )
+        s = StepRecord(
+            step_num=1,
+            timestamp=1.0,
+            duration_ms=2.0,
+            pretty="#1 ✓",
+            tool_call={"tool": "x"},
+            tool_result={"tool": "x"},
+        )
+
+        c.metadata["claim_id"] = "claim-1"
+        s.metadata["ledger_node_id"] = "node-1"
+
+        assert json.loads(json.dumps(c.to_dict()))["metadata"] == {"claim_id": "claim-1"}
+        assert json.loads(json.dumps(s.to_dict()))["metadata"] == {"ledger_node_id": "node-1"}
+
+    def test_metadata_fields_appear_in_to_dict_output(self):
+        c = LLMCall(
+            index=0,
+            timestamp=1.0,
+            duration_ms=5.0,
+            method="generate",
+            prompt="p",
+            system_prompt="",
+            response="r",
+        )
+        s = StepRecord(
+            step_num=1,
+            timestamp=1.0,
+            duration_ms=2.0,
+            pretty="#1 ✓",
+            tool_call={"tool": "x"},
+            tool_result={"tool": "x"},
+        )
+
+        assert "metadata" in c.to_dict()
+        assert "metadata" in s.to_dict()
+
     def test_llm_call_to_dict(self):
         c = LLMCall(
             index=0,


### PR DESCRIPTION
## What

Adds an additive `metadata: dict[str, Any]` field to `StepRecord` and `LLMCall`, defaulting to `{}`. Both `to_dict()` implementations now include the metadata key.

## Why

Lets external hooks (e.g. credit-ledger / observability layers built outside Looplet) attach arbitrary annotations to specific steps and LLM calls — claim ids, ledger node ids, harness variant ids, policy versions — without maintaining parallel sidecar maps keyed by `step_num` / call `index`.

## Scope

Strictly additive:
- No existing field semantics change.
- Default empty dict means existing trajectories serialize identically apart from the new key.
- All 1547 master tests still pass (verified locally).
- 4 new tests cover defaults, JSON round-tripping, and to_dict output.

## Notes

Best paired with [feat/tool-metadata-passthrough](https://github.com/hsaghir/looplet/pull/new/feat/tool-metadata-passthrough), which adds matching `metadata` fields to `ToolCall` and `ToolResult` so hooks have a natural way to populate it that flows through automatically.