### PR TITLE
feat(events): add HOOK_DECISION lifecycle event

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -230,6 +230,24 @@ def on_event(event):
 hook = StreamingHook(CallbackEmitter(on_event))
 ```
 
+### Hook decision events
+
+`LifecycleEvent.HOOK_DECISION` fires whenever a hook returns a non-noop
+`HookDecision`, including decisions returned from `on_event`. The payload
+sets `hook_slot` and `hook_name`, and stores the serialized decision at
+`payload.extra["decision"]`; `on_event` decisions also include the
+originating lifecycle event name.
+
+```python
+from looplet import LifecycleEvent
+
+
+class DecisionAudit:
+    def on_event(self, payload):
+        if payload.event == LifecycleEvent.HOOK_DECISION:
+            print(payload.hook_slot, payload.hook_name, payload.extra["decision"])
+```
+
 ### ProvenanceSink
 
 Captures prompts, responses, and trajectory files for later replay and

--- a/src/looplet/events.py
+++ b/src/looplet/events.py
@@ -26,7 +26,7 @@ __all__ = [
 
 
 class LifecycleEvent(str, Enum):
-    """The ten lifecycle events the loop emits.
+    """The lifecycle events the loop emits.
 
     Ordered roughly by when they fire in a single step:
 
@@ -47,6 +47,9 @@ class LifecycleEvent(str, Enum):
     * :attr:`PRE_COMPACT` — before any conversation compaction runs.
     * :attr:`POST_COMPACT` — after compaction, with a count of
       messages removed / summary length.
+    * :attr:`HOOK_DECISION` — fires whenever a hook returns a
+      ``HookDecision`` that is not a no-op; payload carries slot,
+      hook_name, and the decision dict.
     * :attr:`STOP` — when the loop is about to exit, for any reason.
       The payload includes ``termination_reason``.
     * :attr:`SUBAGENT_START` / :attr:`SUBAGENT_STOP` — when a forked
@@ -63,6 +66,7 @@ class LifecycleEvent(str, Enum):
     POST_TOOL_FAILURE = "post_tool_failure"
     PRE_COMPACT = "pre_compact"
     POST_COMPACT = "post_compact"
+    HOOK_DECISION = "hook_decision"
     STOP = "stop"
     SUBAGENT_START = "subagent_start"
     SUBAGENT_STOP = "subagent_stop"
@@ -97,4 +101,6 @@ class EventPayload:
     messages_before: int | None = None
     messages_after: int | None = None
     subagent_id: str | None = None
+    hook_slot: str | None = None
+    hook_name: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from dataclasses import replace as _dc_replace
 from typing import TYPE_CHECKING, Any, Callable, Generator, Protocol, runtime_checkable
 
@@ -812,8 +812,56 @@ def emit_event(
             logger.exception("on_event hook raised; continuing")
             continue
         if isinstance(result, HookDecision):
+            from looplet.events import LifecycleEvent as _LE  # noqa: PLC0415
+
+            if event != _LE.HOOK_DECISION and not result.is_noop():
+                _emit_hook_decision_event(
+                    hooks,
+                    decision=result,
+                    hook_slot="on_event",
+                    hook_name=type(hook).__name__,
+                    step_num=payload.step_num,
+                    state=payload.state,
+                    session_log=payload.session_log,
+                    context=payload.context,
+                    extra={"originating_event": getattr(event, "value", str(event))},
+                )
             decisions.append(result)
     return decisions
+
+
+def _emit_hook_decision_event(
+    hooks: list[Any],
+    *,
+    decision: Any,
+    hook_slot: str,
+    hook_name: str,
+    step_num: int = 0,
+    state: Any = None,
+    session_log: Any = None,
+    context: Any = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Emit a structured event for a non-noop HookDecision."""
+    if decision is None or decision.is_noop():
+        return
+
+    from looplet.events import LifecycleEvent as _LE  # noqa: PLC0415
+
+    event_extra = {"decision": asdict(decision)}
+    if extra:
+        event_extra.update(extra)
+    emit_event(
+        hooks,
+        _LE.HOOK_DECISION,
+        step_num=step_num,
+        state=state,
+        session_log=session_log,
+        context=context,
+        hook_slot=hook_slot,
+        hook_name=hook_name,
+        extra=event_extra,
+    )
 
 
 # ── Event → per-method deduplication map ────────────────────────
@@ -966,6 +1014,16 @@ def _intercept_tool_calls(
                     result.intercepted[tc_idx] = cached
                     break
                 continue
+            _emit_hook_decision_event(
+                hooks,
+                decision=_decision,
+                hook_slot="pre_dispatch",
+                hook_name=type(hook).__name__,
+                step_num=cur_step,
+                state=state,
+                session_log=session_log,
+                context=context,
+            )
             if _decision.updated_args is not None:
                 tc.args = _decision.updated_args
             if _decision.permission == "deny":
@@ -997,6 +1055,17 @@ def _intercept_tool_calls(
                 continue
             _raw = hook.check_permission(tc, state)
             _decision = normalize_hook_return(_raw, slot="check_permission")
+            if _decision is not None:
+                _emit_hook_decision_event(
+                    hooks,
+                    decision=_decision,
+                    hook_slot="check_permission",
+                    hook_name=type(hook).__name__,
+                    step_num=cur_step,
+                    state=state,
+                    session_log=session_log,
+                    context=context,
+                )
             allowed = _decision is None or _decision.permission != "deny"
             if not allowed:
                 _msg = (
@@ -1068,6 +1137,16 @@ def _run_post_dispatch_hooks(
         text = hook.post_dispatch(state, session_log, tool_call, tool_result, step_num)
         _decision = normalize_hook_return(text, slot="post_dispatch")
         if _decision is not None:
+            _emit_hook_decision_event(
+                hooks,
+                decision=_decision,
+                hook_slot="post_dispatch",
+                hook_name=type(hook).__name__,
+                step_num=step_num,
+                state=state,
+                session_log=session_log,
+                context=context,
+            )
             if _decision.updated_result is not None:
                 outcome.tool_result = _decision.updated_result
                 tool_result = outcome.tool_result
@@ -1434,6 +1513,17 @@ def composable_loop(
                 text = hook.pre_prompt(state, session_log, context, step_num)
                 # HookDecision-aware: accept both legacy str and decisions.
                 _decision = normalize_hook_return(text, slot="pre_prompt")
+                if _decision is not None:
+                    _emit_hook_decision_event(
+                        hooks,
+                        decision=_decision,
+                        hook_slot="pre_prompt",
+                        hook_name=type(hook).__name__,
+                        step_num=step_num,
+                        state=state,
+                        session_log=session_log,
+                        context=context,
+                    )
                 text = _decision.additional_context if _decision else None
                 if text:
                     if _briefing_budget:
@@ -1940,6 +2030,17 @@ def composable_loop(
                 if hasattr(hook, "check_done"):
                     w = hook.check_done(state, session_log, context, step_num)
                     _decision = normalize_hook_return(w, slot="check_done")
+                    if _decision is not None:
+                        _emit_hook_decision_event(
+                            hooks,
+                            decision=_decision,
+                            hook_slot="check_done",
+                            hook_name=type(hook).__name__,
+                            step_num=cur_step,
+                            state=state,
+                            session_log=session_log,
+                            context=context,
+                        )
                     if _decision is not None and _decision.is_block():
                         gate_warning = _decision.block or "blocked by hook"
                         break
@@ -2076,6 +2177,17 @@ def composable_loop(
             if hasattr(hook, "should_stop"):
                 _raw = hook.should_stop(state, step_num, len(all_step_entities))
                 _decision = normalize_hook_return(_raw, slot="should_stop")
+                if _decision is not None:
+                    _emit_hook_decision_event(
+                        hooks,
+                        decision=_decision,
+                        hook_slot="should_stop",
+                        hook_name=type(hook).__name__,
+                        step_num=step_num,
+                        state=state,
+                        session_log=session_log,
+                        context=context,
+                    )
                 _stopped = _decision.is_stop() if _decision else False
                 if _stopped:
                     logger.info("Hook %s requested stop at step %d", type(hook).__name__, step_num)

--- a/tests/test_hook_decision_event.py
+++ b/tests/test_hook_decision_event.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from looplet import (
+    BaseToolRegistry,
+    Block,
+    Continue,
+    DefaultState,
+    InjectContext,
+    LifecycleEvent,
+    LoopConfig,
+    Stop,
+    composable_loop,
+)
+from looplet.events import EventPayload
+from looplet.testing import MockLLMBackend
+from looplet.tools import ToolSpec
+
+
+class _HookDecisionRecorder:
+    def __init__(self) -> None:
+        self.payloads: list[EventPayload] = []
+
+    def on_event(self, payload: EventPayload) -> None:
+        if payload.event == LifecycleEvent.HOOK_DECISION:
+            self.payloads.append(payload)
+
+
+def _tools() -> BaseToolRegistry:
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="add",
+            description="add",
+            parameters={"a": "int", "b": "int"},
+            execute=lambda *, a, b: {"sum": a + b},
+        )
+    )
+    reg.register(
+        ToolSpec(
+            name="done",
+            description="done",
+            parameters={"answer": "str"},
+            execute=lambda *, answer: {"answer": answer},
+        )
+    )
+    return reg
+
+
+def _run(responses: list[str], hooks: list[object]) -> None:
+    list(
+        composable_loop(
+            llm=MockLLMBackend(responses=responses),
+            tools=_tools(),
+            state=DefaultState(max_steps=5),
+            hooks=hooks,
+            config=LoopConfig(max_steps=5),
+        )
+    )
+
+
+def test_hook_decision_events_include_slot_hook_name_and_decision_dict() -> None:
+    class DecisionHook:
+        def on_event(self, payload: EventPayload):
+            if payload.event == LifecycleEvent.PRE_LLM_CALL:
+                return InjectContext("test")
+            return None
+
+        def pre_prompt(self, state, session_log, context, step_num):
+            return InjectContext("test")
+
+        def pre_dispatch(self, state, session_log, tool_call, step_num):
+            if tool_call.tool == "add":
+                return InjectContext("test")
+            return None
+
+        def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+            if tool_call.tool == "add":
+                return InjectContext("test")
+            return None
+
+        def check_done(self, state, session_log, context, step_num):
+            if not any(step.tool_call.tool == "done" for step in state.steps):
+                return Block("test")
+            return None
+
+        def should_stop(self, state, step_num, new_entities):
+            if state.steps and state.steps[-1].tool_call.tool == "add":
+                return Stop("test")
+            return None
+
+    recorder = _HookDecisionRecorder()
+
+    _run(
+        [
+            '{"tool":"done","args":{"answer":"early"},"reasoning":""}',
+            '{"tool":"add","args":{"a":1,"b":2},"reasoning":""}',
+            '{"tool":"done","args":{"answer":"ok"},"reasoning":""}',
+        ],
+        [recorder, DecisionHook()],
+    )
+
+    by_slot = {}
+    for payload in recorder.payloads:
+        by_slot.setdefault(payload.hook_slot, []).append(payload)
+
+    assert LifecycleEvent.HOOK_DECISION.value == "hook_decision"
+    assert set(by_slot) >= {
+        "on_event",
+        "pre_prompt",
+        "pre_dispatch",
+        "post_dispatch",
+        "check_done",
+        "should_stop",
+    }
+    assert all(payload.hook_name == "DecisionHook" for payload in recorder.payloads)
+
+    assert by_slot["check_done"][0].extra["decision"]["block"] == "test"
+    assert by_slot["should_stop"][0].extra["decision"]["stop"] == "test"
+    assert by_slot["pre_prompt"][0].extra["decision"]["additional_context"] == "test"
+    assert by_slot["pre_dispatch"][0].extra["decision"]["additional_context"] == "test"
+    assert by_slot["post_dispatch"][0].extra["decision"]["additional_context"] == "test"
+
+    on_event_payload = by_slot["on_event"][0]
+    assert on_event_payload.extra["originating_event"] == "pre_llm_call"
+    assert on_event_payload.extra["decision"]["additional_context"] == "test"
+
+
+def test_no_hook_decision_events_for_none_or_noop_decisions() -> None:
+    class NoopHook:
+        def on_event(self, payload: EventPayload):
+            if payload.event == LifecycleEvent.PRE_LLM_CALL:
+                return Continue()
+            return None
+
+        def pre_prompt(self, state, session_log, context, step_num):
+            return Continue()
+
+        def pre_dispatch(self, state, session_log, tool_call, step_num):
+            return Continue()
+
+        def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+            return Continue()
+
+        def check_done(self, state, session_log, context, step_num):
+            return Continue()
+
+        def should_stop(self, state, step_num, new_entities):
+            return Continue()
+
+    recorder = _HookDecisionRecorder()
+
+    _run(
+        [
+            '{"tool":"add","args":{"a":1,"b":2},"reasoning":""}',
+            '{"tool":"done","args":{"answer":"ok"},"reasoning":""}',
+        ],
+        [recorder, NoopHook()],
+    )
+
+    assert recorder.payloads == []

--- a/tests/test_hook_decision_smoke.py
+++ b/tests/test_hook_decision_smoke.py
@@ -412,6 +412,7 @@ class TestLifecycleEventEnum:
             "post_tool_failure",
             "pre_compact",
             "post_compact",
+            "hook_decision",
             "stop",
             "subagent_start",
             "subagent_stop",


### PR DESCRIPTION
## What

Adds `LifecycleEvent.HOOK_DECISION` that fires whenever any hook returns a non-noop `HookDecision`, including decisions returned from `on_event`. Adds `hook_slot: str | None` and `hook_name: str | None` to `EventPayload`; the serialized decision is stored at `payload.extra["decision"]` (and `extra["originating_event"]` for on_event-sourced decisions).

Emission points wired into the loop:
- `pre_prompt`
- `pre_dispatch`
- `check_permission`
- `post_dispatch`
- `check_done`
- `should_stop`
- `on_event` (with recursion guard so HOOK_DECISION events don't trigger more HOOK_DECISION events)

Suppressed for noop decisions to avoid spam.

## Why

Currently the loop consumes `HookDecision` internally — only its *effects* are observable downstream (rewritten args, intercepted result). The decision itself is invisible. External observers (audit logs, credit ledgers, policy debuggers) need the decision dict + which hook + which slot, in one place.

## Scope

Strictly additive:
- No existing event semantics change.
- Per-method hook dispatch unchanged.
- All 1547 master tests still pass; +2 new tests covering positive emission and noop suppression.

## Notes

A small docstring polish was made to `LifecycleEvent` (removed the literal count "ten" since it's now incorrect). Otherwise the only public-API change is one new enum value and two new EventPayload fields.