### PR TITLE
feat(provenance): add serialize_harness helper and harness_snapshot kwarg on TrajectoryRecorder

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -183,6 +183,24 @@ for step in composable_loop(llm=llm, tools=tools, state=state, hooks=[hook]):
 hook.save("traces/run_1/")     # writes trajectory.json + steps/*.json
 ```
 
+### Recording the harness snapshot
+
+Use `serialize_harness()` to record the harness genome that produced a
+trajectory without changing the trajectory schema:
+
+```python
+from looplet import serialize_harness
+from looplet.provenance import TrajectoryRecorder
+
+snapshot = serialize_harness(config=config, tools=tools, hooks=hooks, llm=llm)
+hook = TrajectoryRecorder(harness_snapshot=snapshot)
+
+for step in composable_loop(llm=llm, tools=tools, state=state, hooks=[hook]):
+    ...
+
+assert hook.trajectory.metadata["harness_snapshot"]["schema_version"] == 1
+```
+
 ### Linking steps to LLM calls
 
 Pair `TrajectoryRecorder` with `RecordingLLMBackend` and every

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -79,6 +79,7 @@ from looplet.evals import (
     save_case,
 )
 from looplet.events import EventPayload, LifecycleEvent
+from looplet.harness_snapshot import serialize_harness
 from looplet.hook_decision import (
     Allow,
     Block,
@@ -242,6 +243,7 @@ __all__ = [
     "TrajectoryRecorder",
     "ProvenanceSink",
     "replay_loop",
+    "serialize_harness",
     "StreamingHook",
     "Tracer",
     "TracingHook",

--- a/src/looplet/harness_snapshot.py
+++ b/src/looplet/harness_snapshot.py
@@ -1,0 +1,89 @@
+"""Stable, JSON-friendly harness snapshots for provenance metadata."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from looplet.loop import LoopConfig
+    from looplet.tools import BaseToolRegistry
+
+__all__ = ["serialize_harness"]
+
+_MAX_SYSTEM_PROMPT_CHARS = 4000
+_MISSING = object()
+
+
+def _truncate_system_prompt(prompt: str) -> str:
+    if len(prompt) <= _MAX_SYSTEM_PROMPT_CHARS:
+        return prompt
+    keep = _MAX_SYSTEM_PROMPT_CHARS - 40
+    return prompt[:keep] + f"\n... [truncated {len(prompt) - keep} chars] ..."
+
+
+def _getattr_present(obj: Any, name: str) -> Any:
+    value = getattr(obj, name, _MISSING)
+    if value is None:
+        return _MISSING
+    return value
+
+
+def _tool_specs(tools: Any) -> list[Any]:
+    specs = getattr(tools, "_specs", None)
+    if specs is None:
+        specs = getattr(tools, "_tools", None)
+    if specs is None:
+        return []
+    values = specs.values() if hasattr(specs, "values") else specs
+    return list(values)
+
+
+def serialize_harness(
+    *,
+    config: "LoopConfig | None" = None,
+    hooks: list[Any] | None = None,
+    tools: "BaseToolRegistry | None" = None,
+    memory_sources: list[Any] | None = None,
+    llm: Any | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a stable, JSON-friendly snapshot of the agent harness."""
+    snapshot: dict[str, Any] = {
+        "schema_version": 1,
+        "extra": dict(extra) if extra is not None else {},
+    }
+
+    if config is not None:
+        system_prompt = _getattr_present(config, "system_prompt")
+        if system_prompt is not _MISSING:
+            snapshot["system_prompt"] = _truncate_system_prompt(str(system_prompt))
+        for key in (
+            "max_steps",
+            "max_tokens",
+            "temperature",
+            "use_native_tools",
+            "concurrent_dispatch",
+            "done_tool",
+        ):
+            value = _getattr_present(config, key)
+            if value is not _MISSING:
+                snapshot[key] = value
+
+    if tools is not None:
+        snapshot["tools"] = [
+            {
+                "name": getattr(spec, "name"),
+                "description": getattr(spec, "description", ""),
+            }
+            for spec in _tool_specs(tools)
+            if getattr(spec, "name", None) is not None
+        ]
+
+    if hooks is not None:
+        snapshot["hooks"] = [type(h).__name__ for h in hooks]
+    if memory_sources is not None:
+        snapshot["memory_sources"] = [type(s).__name__ for s in memory_sources]
+    if llm is not None:
+        snapshot["llm_backend"] = type(llm).__name__
+
+    return snapshot

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -555,6 +555,7 @@ class TrajectoryRecorder:
         capture_context: bool = True,
         tracer: Tracer | None = None,
         output_dir: str | Path | None = None,
+        harness_snapshot: dict[str, Any] | None = None,
     ) -> None:
         self.trajectory = Trajectory(
             run_id=uuid4().hex[:12],
@@ -568,6 +569,7 @@ class TrajectoryRecorder:
         self._pending_llm_start: int = 0
         self._step_start_time: float = 0.0
         self._output_dir: Path | None = Path(output_dir) if output_dir is not None else None
+        self._harness_snapshot = dict(harness_snapshot) if harness_snapshot is not None else None
 
     # ── hook methods ────────────────────────────────────────────
 
@@ -652,6 +654,8 @@ class TrajectoryRecorder:
 
     def on_loop_end(self, state: Any, session_log: Any, context: Any, llm: Any) -> int:
         self.trajectory.ended_at = time.time()
+        if self._harness_snapshot is not None:
+            self.trajectory.metadata["harness_snapshot"] = dict(self._harness_snapshot)
         if self._recording_llm is not None:
             self.trajectory.llm_calls = list(self._recording_llm.calls)
         if self._tracer is not None and self._loop_span is not None:

--- a/tests/test_harness_snapshot.py
+++ b/tests/test_harness_snapshot.py
@@ -1,0 +1,101 @@
+"""Tests for harness snapshot provenance helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from looplet import serialize_harness
+from looplet.provenance import TrajectoryRecorder
+
+
+def test_serialize_harness_defaults_to_schema_and_empty_extra():
+    assert serialize_harness() == {"schema_version": 1, "extra": {}}
+
+
+def test_serialize_harness_captures_config_and_component_names():
+    class FakeConfig:
+        system_prompt = "You are careful."
+        max_steps = 5
+        max_tokens = 1000
+        temperature = 0.1
+        use_native_tools = True
+        concurrent_dispatch = False
+        done_tool = "finish"
+
+    class GuardHook:
+        pass
+
+    class MemorySource:
+        pass
+
+    class Backend:
+        pass
+
+    @dataclass
+    class FakeSpec:
+        name: str
+        description: str
+
+    class FakeTools:
+        _specs = {
+            "search": FakeSpec(name="search", description="Search docs."),
+            "read": FakeSpec(name="read", description="Read a file."),
+        }
+
+    snap = serialize_harness(
+        config=FakeConfig(),
+        hooks=[GuardHook()],
+        tools=FakeTools(),
+        memory_sources=[MemorySource()],
+        llm=Backend(),
+        extra={"variant": "a"},
+    )
+
+    assert snap == {
+        "schema_version": 1,
+        "extra": {"variant": "a"},
+        "system_prompt": "You are careful.",
+        "max_steps": 5,
+        "max_tokens": 1000,
+        "temperature": 0.1,
+        "use_native_tools": True,
+        "concurrent_dispatch": False,
+        "done_tool": "finish",
+        "tools": [
+            {"name": "search", "description": "Search docs."},
+            {"name": "read", "description": "Read a file."},
+        ],
+        "hooks": ["GuardHook"],
+        "memory_sources": ["MemorySource"],
+        "llm_backend": "Backend",
+    }
+    json.dumps(snap)
+
+
+def test_serialize_harness_truncates_long_system_prompt():
+    class FakeConfig:
+        system_prompt = "x" * 5000
+
+    snap = serialize_harness(config=FakeConfig())
+
+    assert len(snap["system_prompt"]) < 5000
+    assert "truncated" in snap["system_prompt"]
+
+
+def test_trajectory_recorder_stores_harness_snapshot_on_loop_end():
+    snap = {"schema_version": 1, "extra": {"variant": "baseline"}}
+    recorder = TrajectoryRecorder(harness_snapshot=snap)
+
+    recorder.on_loop_end(None, None, None, None)
+
+    assert recorder.trajectory.metadata["harness_snapshot"] == snap
+    assert recorder.trajectory.metadata["harness_snapshot"] is not snap
+
+
+def test_trajectory_recorder_without_harness_snapshot_leaves_metadata_empty():
+    recorder = TrajectoryRecorder()
+
+    recorder.on_loop_end(None, None, None, None)
+
+    assert recorder.trajectory.metadata == {}


### PR DESCRIPTION
## What

Adds `looplet.serialize_harness(...)` — a stable, JSON-friendly serializer for the agent harness genome (system prompt, hook class names, tool list with descriptions, memory sources, key `LoopConfig` fields, LLM backend type). Adds an optional `harness_snapshot` kwarg on `TrajectoryRecorder` that stores the snapshot under `trajectory.metadata['harness_snapshot']` with `schema_version: 1`.

```python
from looplet import serialize_harness
from looplet.provenance import TrajectoryRecorder

snap = serialize_harness(config=config, hooks=hooks, tools=tools, llm=llm)
rec = TrajectoryRecorder(harness_snapshot=snap)
```

## Why

Every harness-evolution / GEPA-style experiment needs to know exactly which `phi` (prompts, tools, hooks, memory policy, …) produced a trajectory. Without this, you can't attribute regressions to specific harness changes, replay a winning genome later, or do meaningful Pareto selection. The Trajectory `metadata` dict already exists; this just standardizes a high-value entry.

System prompts longer than 4000 chars are truncated with an elision marker to keep the snapshot bounded.

## Scope

Strictly additive:
- New file `src/looplet/harness_snapshot.py` (~90 lines).
- One new optional kwarg on `TrajectoryRecorder.__init__`.
- One re-export from `looplet/__init__.py`.
- Trajectory schema unchanged (uses existing `metadata` dict).
- All 1547 master tests still pass; +5 new tests covering missing kwargs, truncation, and trajectory persistence.