### PR TITLE
feat(loop): add optional tool_call kwarg to check_done

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -117,6 +117,22 @@ class MinimumEvidenceGate:
         return None  # allow done()
 ```
 
+`check_done` accepts an optional `tool_call` kwarg carrying the
+candidate `done()` invocation (and its proposed final answer). Hooks
+that opt in can reject `done()` based on the answer itself, not just
+the surrounding state:
+
+```python
+class GroundedAnswerGate:
+    def check_done(self, state, session_log, context, step_num, tool_call):
+        if "fabricated" in str(tool_call.args.get("answer", "")):
+            return "answer mentions a value the agent never observed"
+        return None
+```
+
+The loop dispatches with or without `tool_call` based on the hook's
+signature, so legacy 4-arg implementations keep working unchanged.
+
 ### 3. Deduplication Warning
 
 Warn when the agent repeats the same tool call:

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -194,11 +194,19 @@ class LoopHook(Protocol):
         session_log: SessionLog,
         context: Any,
         step_num: int,
+        tool_call: "ToolCall | None" = None,
     ) -> str | None:
         """Called when the agent calls done().
 
         Returns a rejection message (string) to block premature stopping,
         or None to allow termination.
+
+        ``tool_call`` carries the candidate ``done()`` invocation (with
+        its proposed final-answer arguments) so quality gates can
+        inspect the agent's pending answer. The loop dispatches with or
+        without this kwarg based on the hook's signature, so existing
+        ``check_done(self, state, session_log, context, step_num)``
+        implementations continue to work unchanged.
         """
         ...
 
@@ -832,6 +840,51 @@ def _init_event_method_equiv() -> None:
 
 
 _init_event_method_equiv()
+
+
+# ── check_done dispatch (backward-compatible tool_call kwarg) ───
+
+_CHECK_DONE_ACCEPTS_TOOL_CALL: dict[int, bool] = {}
+"""Per-method cache mapping ``id(check_done)`` to whether the bound
+method accepts a ``tool_call`` keyword argument. Populated lazily.
+Cached by id so we never re-inspect the same method object twice."""
+
+
+def _accepts_tool_call_kwarg(method: Any) -> bool:
+    key = id(method)
+    cached = _CHECK_DONE_ACCEPTS_TOOL_CALL.get(key)
+    if cached is not None:
+        return cached
+    import inspect  # noqa: PLC0415
+
+    try:
+        sig = inspect.signature(method)
+    except (TypeError, ValueError):
+        accepts = False
+    else:
+        params = sig.parameters
+        accepts = "tool_call" in params or any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+    _CHECK_DONE_ACCEPTS_TOOL_CALL[key] = accepts
+    return accepts
+
+
+def _call_check_done(
+    hook: Any,
+    state: Any,
+    session_log: Any,
+    context: Any,
+    step_num: int,
+    tool_call: Any,
+) -> Any:
+    """Invoke a hook's ``check_done`` with or without the ``tool_call``
+    kwarg depending on its signature. Lets new gates inspect the agent's
+    pending ``done()`` answer without breaking legacy hooks."""
+    method = hook.check_done
+    if _accepts_tool_call_kwarg(method):
+        return method(state, session_log, context, step_num, tool_call=tool_call)
+    return method(state, session_log, context, step_num)
 
 
 # ── Hook method names (for typo detection) ──────────────────────
@@ -1938,7 +1991,7 @@ def composable_loop(
             gate_warning: str | None = None
             for hook in hooks:
                 if hasattr(hook, "check_done"):
-                    w = hook.check_done(state, session_log, context, step_num)
+                    w = _call_check_done(hook, state, session_log, context, step_num, tool_call)
                     _decision = normalize_hook_return(w, slot="check_done")
                     if _decision is not None and _decision.is_block():
                         gate_warning = _decision.block or "blocked by hook"

--- a/tests/test_check_done_payload.py
+++ b/tests/test_check_done_payload.py
@@ -1,0 +1,159 @@
+"""Tests for the additive ``tool_call`` kwarg on ``check_done``.
+
+The loop dispatches ``check_done`` with or without the ``tool_call``
+kwarg depending on the hook's signature, so existing legacy hooks
+(``check_done(self, state, session_log, context, step_num)``) keep
+working unchanged while new quality gates can inspect the candidate
+``done()`` payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from looplet import (
+    BaseToolRegistry,
+    Block,
+    DefaultState,
+    LoopConfig,
+    composable_loop,
+)
+from looplet.testing import MockLLMBackend
+from looplet.tools import ToolSpec
+from looplet.types import ToolCall
+
+
+def _tools() -> BaseToolRegistry:
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="lookup",
+            description="lookup",
+            parameters={"key": "str"},
+            execute=lambda *, key: {"key": key, "value": {"x": 1}.get(key, "MISSING")},
+        )
+    )
+    reg.register(
+        ToolSpec(
+            name="done",
+            description="done",
+            parameters={"answer": "str"},
+            execute=lambda *, answer: {"answer": answer},
+        )
+    )
+    return reg
+
+
+def _run(responses: list[str], hooks: list[Any]) -> list[Any]:
+    return list(
+        composable_loop(
+            llm=MockLLMBackend(responses=responses),
+            tools=_tools(),
+            state=DefaultState(max_steps=8),
+            hooks=hooks,
+            config=LoopConfig(max_steps=8),
+        )
+    )
+
+
+def test_legacy_check_done_signature_still_works() -> None:
+    """A hook with the original 4-arg signature must keep working."""
+    seen: list[int] = []
+
+    class Legacy:
+        def check_done(self, state, session_log, context, step_num):
+            seen.append(step_num)
+            return None
+
+    steps = _run(
+        ['{"tool":"done","args":{"answer":"x"},"reasoning":""}'],
+        [Legacy()],
+    )
+
+    assert len(steps) == 1
+    assert steps[0].tool_call.tool == "done"
+    assert seen, "check_done was not called"
+
+
+def test_check_done_receives_candidate_tool_call() -> None:
+    """A hook that accepts ``tool_call`` sees the candidate done() call."""
+    captured: list[ToolCall] = []
+
+    class Inspector:
+        def check_done(self, state, session_log, context, step_num, tool_call):
+            captured.append(tool_call)
+            return None
+
+    _run(
+        ['{"tool":"done","args":{"answer":"hello"},"reasoning":""}'],
+        [Inspector()],
+    )
+
+    assert len(captured) == 1
+    assert captured[0].tool == "done"
+    assert captured[0].args == {"answer": "hello"}
+
+
+def test_check_done_can_block_unsupported_answer() -> None:
+    """A done-gate using ``tool_call`` can reject a fabricated claim
+    and the loop should re-prompt the agent (which then submits a
+    grounded answer)."""
+
+    class GroundedGate:
+        def __init__(self) -> None:
+            self.observed_facts: set[str] = set()
+
+        def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+            if isinstance(tool_result.data, dict):
+                for k, v in tool_result.data.items():
+                    self.observed_facts.add(f"{k}={v}")
+            return None
+
+        def check_done(self, state, session_log, context, step_num, tool_call):
+            answer = str(tool_call.args.get("answer", ""))
+            for fragment in answer.split(" and "):
+                f = fragment.strip()
+                if "=" in f and f not in self.observed_facts:
+                    return Block(
+                        f"unsupported claim: {f!r} not in observed facts {sorted(self.observed_facts)}"
+                    )
+            return None
+
+    gate = GroundedGate()
+    steps = _run(
+        [
+            '{"tool":"lookup","args":{"key":"x"},"reasoning":""}',
+            # Agent fabricates y=99 — should be blocked.
+            '{"tool":"done","args":{"answer":"key=x and value=1 and y=99"},"reasoning":""}',
+            # On retry, agent submits a grounded answer.
+            '{"tool":"done","args":{"answer":"key=x and value=1"},"reasoning":""}',
+        ],
+        [gate],
+    )
+
+    final_done_steps = [s for s in steps if s.tool_call.tool == "done"]
+    assert len(final_done_steps) >= 2
+    rejected = final_done_steps[0]
+    assert rejected.tool_result.data.get("rejected") is True
+    accepted = final_done_steps[-1]
+    assert accepted.tool_result.data.get("rejected") is not True
+    assert accepted.tool_call.args["answer"] == "key=x and value=1"
+
+
+def test_check_done_with_var_kwargs_signature() -> None:
+    """A hook using ``**kwargs`` should also receive ``tool_call``."""
+    captured: list[Any] = []
+
+    class Vararg:
+        def check_done(self, state, session_log, context, step_num, **kwargs):
+            captured.append(kwargs.get("tool_call"))
+            return None
+
+    _run(
+        ['{"tool":"done","args":{"answer":"ok"},"reasoning":""}'],
+        [Vararg()],
+    )
+
+    assert len(captured) == 1
+    assert captured[0] is not None
+    assert captured[0].tool == "done"


### PR DESCRIPTION
## What

Adds an optional `tool_call` kwarg to `LoopHook.check_done`. The loop dispatches with or without it based on each hook's signature (cached per-method lookup), so existing 4-arg implementations keep working unchanged.

```python
class GroundedAnswerGate:
    def check_done(self, state, session_log, context, step_num, tool_call):
        if 'fabricated' in str(tool_call.args.get('answer', '')):
            return 'answer mentions a value the agent never observed'
        return None

class LegacyGate:
    # Still works, never receives tool_call
    def check_done(self, state, session_log, context, step_num):
        if len(state.steps) < 3:
            return 'need more evidence'
        return None
```

`**kwargs` signatures also receive `tool_call`.

## Why

Today `check_done` fires before `done()` dispatches, but the candidate `tool_call` carrying the agent's proposed final answer is not passed in. `done()` also bypasses `pre_dispatch` and `PRE_TOOL_USE`, so there is *no other clean hook point* to inspect the pending answer. This makes claim-citation / unsupported-answer gates essentially impossible to express in a hook today — surfaced when end-to-end dogfooding a credit-ledger gate against the existing API.

## Scope

Strictly additive, fully backward-compatible:
- One new optional kwarg in the `LoopHook` protocol.
- One small dispatch helper (`_call_check_done`) using cached `inspect.signature` lookup so we pay the introspection cost once per hook, not per call.
- All 1547 master tests still pass; +4 new tests covering legacy 4-arg signature, new kwarg signature, end-to-end blocking + retry of a fabricated answer, and `**kwargs` dispatch.

## Notes

This is the smallest fix to a real friction surfaced when integrating PRs #19-22 (metadata, HOOK_DECISION, DONE_ACCEPTED, harness_snapshot) and trying to wire a real done-gate. End-to-end the integrated build (all six PRs) now lets a gate hook block a fabricated `y=99` claim with the agent retrying to `x=1`.