### PR TITLE
feat(examples): port dep_doctor + git_detective to v2 workspace

### DIFF
--- a/examples/dep_doctor.workspace/config.yaml
+++ b/examples/dep_doctor.workspace/config.yaml
@@ -1,0 +1,4 @@
+max_steps: 25
+max_tokens: 2000
+temperature: 0.2
+done_tool: done

--- a/examples/dep_doctor.workspace/hooks/00_StagnationHook/config.yaml
+++ b/examples/dep_doctor.workspace/hooks/00_StagnationHook/config.yaml
@@ -1,0 +1,4 @@
+class_name: StagnationHook
+kwargs:
+  threshold: 3
+  ignore_tools: ["think", "done"]

--- a/examples/dep_doctor.workspace/hooks/00_StagnationHook/hook.py
+++ b/examples/dep_doctor.workspace/hooks/00_StagnationHook/hook.py
@@ -1,0 +1,5 @@
+from looplet import StagnationHook as _StagnationHook
+
+
+class StagnationHook(_StagnationHook):
+    pass

--- a/examples/dep_doctor.workspace/hooks/01_PerToolLimitHook/config.yaml
+++ b/examples/dep_doctor.workspace/hooks/01_PerToolLimitHook/config.yaml
@@ -1,0 +1,6 @@
+class_name: PerToolLimitHook
+kwargs:
+  default_limit: 15
+  limits:
+    check_package: 12
+    find_alternatives: 4

--- a/examples/dep_doctor.workspace/hooks/01_PerToolLimitHook/hook.py
+++ b/examples/dep_doctor.workspace/hooks/01_PerToolLimitHook/hook.py
@@ -1,0 +1,5 @@
+from looplet.limits import PerToolLimitHook as _PerToolLimitHook
+
+
+class PerToolLimitHook(_PerToolLimitHook):
+    pass

--- a/examples/dep_doctor.workspace/prompts/system.md
+++ b/examples/dep_doctor.workspace/prompts/system.md
@@ -1,0 +1,11 @@
+You are a dependency security auditor.
+
+Steps:
+1. detect_dep_files(project_dir=...) to find dependency files
+2. parse_deps(file_path=...) for each dependency file found
+3. check_package(package_name=...) for each dependency
+4. find_alternatives(package_name=...) for any flagged risky package
+5. check_license_compat(project_license=..., dep_license=...) for compatibility
+6. done(report=...) with a clear audit summary
+
+Be thorough but efficient. Don't re-check packages you've already analyzed.

--- a/examples/dep_doctor.workspace/tools/check_license_compat/execute.py
+++ b/examples/dep_doctor.workspace/tools/check_license_compat/execute.py
@@ -1,0 +1,5 @@
+"""check_license_compat — re-import from examples.dep_doctor.agent."""
+
+from examples.dep_doctor.agent import check_license_compat as _spec
+
+execute = _spec.execute

--- a/examples/dep_doctor.workspace/tools/check_license_compat/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/check_license_compat/tool.yaml
@@ -1,0 +1,9 @@
+name: check_license
+description: Check if a dependency license is compatible with the project license.
+parameters:
+  project_license:
+    type: string
+    description: SPDX-style identifier for the project's license.
+  dep_license:
+    type: string
+    description: SPDX-style identifier for the dependency's license.

--- a/examples/dep_doctor.workspace/tools/check_package/execute.py
+++ b/examples/dep_doctor.workspace/tools/check_package/execute.py
@@ -1,0 +1,5 @@
+"""check_package — re-import from examples.dep_doctor.agent."""
+
+from examples.dep_doctor.agent import check_package as _spec
+
+execute = _spec.execute

--- a/examples/dep_doctor.workspace/tools/check_package/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/check_package/tool.yaml
@@ -1,0 +1,7 @@
+name: check_package
+description: Check a package's health — latest version, release date, CVEs, license, maintainer activity.
+parameters:
+  package_name:
+    type: string
+    description: PyPI / npm package name.
+concurrent_safe: true

--- a/examples/dep_doctor.workspace/tools/detect_dep_files/execute.py
+++ b/examples/dep_doctor.workspace/tools/detect_dep_files/execute.py
@@ -1,0 +1,5 @@
+"""detect_dep_files — re-import from examples.dep_doctor.agent."""
+
+from examples.dep_doctor.agent import detect_dep_files as _spec
+
+execute = _spec.execute

--- a/examples/dep_doctor.workspace/tools/detect_dep_files/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/detect_dep_files/tool.yaml
@@ -1,0 +1,7 @@
+name: detect_files
+description: Scan a project directory for dependency files.
+parameters:
+  project_dir:
+    type: string
+    description: Path to the project root.
+concurrent_safe: true

--- a/examples/dep_doctor.workspace/tools/done/execute.py
+++ b/examples/dep_doctor.workspace/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(*, report: str) -> dict:
+    return {"status": "completed", "report": report}

--- a/examples/dep_doctor.workspace/tools/done/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/done/tool.yaml
@@ -1,0 +1,6 @@
+name: done
+description: Signal that the audit is complete.
+parameters:
+  report:
+    type: string
+    description: Audit summary.

--- a/examples/dep_doctor.workspace/tools/find_alternatives/execute.py
+++ b/examples/dep_doctor.workspace/tools/find_alternatives/execute.py
@@ -1,0 +1,5 @@
+"""find_alternatives — re-import from examples.dep_doctor.agent."""
+
+from examples.dep_doctor.agent import find_alternatives as _spec
+
+execute = _spec.execute

--- a/examples/dep_doctor.workspace/tools/find_alternatives/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/find_alternatives/tool.yaml
@@ -1,0 +1,6 @@
+name: find_alternatives
+description: Suggest alternative packages for a risky dependency using LLM reasoning.
+parameters:
+  package_name:
+    type: string
+    description: Package to find alternatives for.

--- a/examples/dep_doctor.workspace/tools/parse_deps/execute.py
+++ b/examples/dep_doctor.workspace/tools/parse_deps/execute.py
@@ -1,0 +1,5 @@
+"""parse_deps — re-import from examples.dep_doctor.agent."""
+
+from examples.dep_doctor.agent import parse_deps as _spec
+
+execute = _spec.execute

--- a/examples/dep_doctor.workspace/tools/parse_deps/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/parse_deps/tool.yaml
@@ -1,0 +1,7 @@
+name: parse_deps
+description: Parse a dependency file and extract package names plus version constraints.
+parameters:
+  file_path:
+    type: string
+    description: Path to a dependency file (requirements.txt, pyproject.toml, package.json, etc.).
+concurrent_safe: true

--- a/examples/dep_doctor.workspace/tools/think/execute.py
+++ b/examples/dep_doctor.workspace/tools/think/execute.py
@@ -1,0 +1,2 @@
+def execute(*, thought: str) -> dict:
+    return {"thought": thought, "noted": True}

--- a/examples/dep_doctor.workspace/tools/think/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/think/tool.yaml
@@ -1,0 +1,8 @@
+name: think
+description: Record an analytical step. No side effects.
+parameters:
+  thought:
+    type: string
+    description: Brief reasoning note.
+free: true
+concurrent_safe: true

--- a/examples/dep_doctor.workspace/workspace.json
+++ b/examples/dep_doctor.workspace/workspace.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "name": "dep-doctor",
+  "description": "Workspace-native dependency security auditor. Detects, parses, and checks project dependencies for security and license issues.",
+  "metadata": {
+    "tags": ["security", "dependencies", "workspace-native"]
+  }
+}

--- a/examples/git_detective.workspace/config.yaml
+++ b/examples/git_detective.workspace/config.yaml
@@ -1,0 +1,4 @@
+max_steps: 12
+max_tokens: 2000
+temperature: 0.2
+done_tool: done

--- a/examples/git_detective.workspace/hooks/00_StagnationHook/config.yaml
+++ b/examples/git_detective.workspace/hooks/00_StagnationHook/config.yaml
@@ -1,0 +1,4 @@
+class_name: StagnationHook
+kwargs:
+  threshold: 3
+  ignore_tools: ["think", "done"]

--- a/examples/git_detective.workspace/hooks/00_StagnationHook/hook.py
+++ b/examples/git_detective.workspace/hooks/00_StagnationHook/hook.py
@@ -1,0 +1,5 @@
+from looplet import StagnationHook as _StagnationHook
+
+
+class StagnationHook(_StagnationHook):
+    pass

--- a/examples/git_detective.workspace/hooks/01_PerToolLimitHook/config.yaml
+++ b/examples/git_detective.workspace/hooks/01_PerToolLimitHook/config.yaml
@@ -1,0 +1,3 @@
+class_name: PerToolLimitHook
+kwargs:
+  default_limit: 5

--- a/examples/git_detective.workspace/hooks/01_PerToolLimitHook/hook.py
+++ b/examples/git_detective.workspace/hooks/01_PerToolLimitHook/hook.py
@@ -1,0 +1,5 @@
+from looplet.limits import PerToolLimitHook as _PerToolLimitHook
+
+
+class PerToolLimitHook(_PerToolLimitHook):
+    pass

--- a/examples/git_detective.workspace/prompts/system.md
+++ b/examples/git_detective.workspace/prompts/system.md
@@ -1,0 +1,18 @@
+You are a senior software engineer analyzing the git history of a repository.
+
+Your task: produce a comprehensive codebase health report.
+
+Work systematically:
+1. Get repo overview (repo_overview)
+2. Analyze contributors and bus factor (contributor_stats)
+3. Check recent activity (recent_activity)
+4. Find file hotspots (file_hotspots)
+5. Detect coupled files (coupled_files)
+6. Analyze commit patterns (commit_patterns) — this uses LLM to score quality
+7. Call done() with a structured health report including:
+   - Health Score (A-F grade)
+   - Key Metrics (bus factor, commit frequency, hotspot count)
+   - Findings (what's good, what's concerning)
+   - Recommendations
+
+Use each tool once. Be thorough but efficient.

--- a/examples/git_detective.workspace/resources/repo_config.py
+++ b/examples/git_detective.workspace/resources/repo_config.py
@@ -1,0 +1,19 @@
+"""Shared repo_config — points at the git repository to analyze.
+
+setup.py replaces ``path`` at workspace load time using the host
+CLI's ``--repo`` arg. Every git_detective tool reads this via the
+module global ``REPO_CONFIG`` (set by setup.py from
+``"@repo_config"``) so the same workspace can be pointed at any
+repo by changing one line in setup.py.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class RepoConfig:
+    path: str = "."
+
+
+def build():
+    return RepoConfig(path=".")

--- a/examples/git_detective.workspace/setup.py
+++ b/examples/git_detective.workspace/setup.py
@@ -1,0 +1,12 @@
+"""Wire shared repo_config into every git tool module so the
+closure-built tool registry uses the right repository path."""
+
+
+def setup(preset, resources, tool_modules, hook_modules):
+    repo_config = resources.get("repo_config")
+    if repo_config is None:
+        return preset
+    for name, module in tool_modules.items():
+        if hasattr(module, "REPO_CONFIG"):
+            module.REPO_CONFIG = repo_config
+    return preset

--- a/examples/git_detective.workspace/tools/commit_patterns/execute.py
+++ b/examples/git_detective.workspace/tools/commit_patterns/execute.py
@@ -1,0 +1,15 @@
+"""commit_patterns — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["commit_patterns"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/commit_patterns/tool.yaml
+++ b/examples/git_detective.workspace/tools/commit_patterns/tool.yaml
@@ -1,0 +1,3 @@
+name: commit_patterns
+description: Analyze commit message patterns, conventions, and quality (uses LLM).
+parameters: {}

--- a/examples/git_detective.workspace/tools/contributor_stats/execute.py
+++ b/examples/git_detective.workspace/tools/contributor_stats/execute.py
@@ -1,0 +1,15 @@
+"""contributor_stats — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["contributor_stats"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/contributor_stats/tool.yaml
+++ b/examples/git_detective.workspace/tools/contributor_stats/tool.yaml
@@ -1,0 +1,4 @@
+name: contributor_stats
+description: Get contributor stats — who committed how much.
+parameters: {}
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/coupled_files/execute.py
+++ b/examples/git_detective.workspace/tools/coupled_files/execute.py
@@ -1,0 +1,15 @@
+"""coupled_files — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["coupled_files"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/coupled_files/tool.yaml
+++ b/examples/git_detective.workspace/tools/coupled_files/tool.yaml
@@ -1,0 +1,8 @@
+name: coupled_files
+description: Find files that often change together (co-change coupling).
+parameters:
+  min_coupling:
+    type: string
+    description: Minimum coupling count (e.g. "3").
+    default: "3"
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/directory_structure/execute.py
+++ b/examples/git_detective.workspace/tools/directory_structure/execute.py
@@ -1,0 +1,15 @@
+"""directory_structure — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["directory_structure"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/directory_structure/tool.yaml
+++ b/examples/git_detective.workspace/tools/directory_structure/tool.yaml
@@ -1,0 +1,4 @@
+name: directory_structure
+description: Top-level directory structure with file counts.
+parameters: {}
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/done/execute.py
+++ b/examples/git_detective.workspace/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(*, report: str) -> dict:
+    return {"status": "completed", "report": report}

--- a/examples/git_detective.workspace/tools/done/tool.yaml
+++ b/examples/git_detective.workspace/tools/done/tool.yaml
@@ -1,0 +1,6 @@
+name: done
+description: Signal completion with the final report.
+parameters:
+  report:
+    type: string
+    description: Codebase health report.

--- a/examples/git_detective.workspace/tools/file_age_analysis/execute.py
+++ b/examples/git_detective.workspace/tools/file_age_analysis/execute.py
@@ -1,0 +1,15 @@
+"""file_age_analysis — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["file_age_analysis"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/file_age_analysis/tool.yaml
+++ b/examples/git_detective.workspace/tools/file_age_analysis/tool.yaml
@@ -1,0 +1,4 @@
+name: file_age_analysis
+description: Find oldest unchanged files and newest additions.
+parameters: {}
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/file_hotspots/execute.py
+++ b/examples/git_detective.workspace/tools/file_hotspots/execute.py
@@ -1,0 +1,15 @@
+"""file_hotspots — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["file_hotspots"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/file_hotspots/tool.yaml
+++ b/examples/git_detective.workspace/tools/file_hotspots/tool.yaml
@@ -1,0 +1,8 @@
+name: file_hotspots
+description: Find most frequently changed files (churn hotspots).
+parameters:
+  top_n:
+    type: string
+    description: How many top files (e.g. "15").
+    default: "15"
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/recent_activity/execute.py
+++ b/examples/git_detective.workspace/tools/recent_activity/execute.py
@@ -1,0 +1,15 @@
+"""recent_activity — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["recent_activity"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/recent_activity/tool.yaml
+++ b/examples/git_detective.workspace/tools/recent_activity/tool.yaml
@@ -1,0 +1,8 @@
+name: recent_activity
+description: Get commit activity for the last N days.
+parameters:
+  days:
+    type: string
+    description: Number of days back (e.g. "30").
+    default: "30"
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/repo_overview/execute.py
+++ b/examples/git_detective.workspace/tools/repo_overview/execute.py
@@ -1,0 +1,15 @@
+"""repo_overview — bridges to the closure-built tool from
+examples.git_detective.agent.make_tools(REPO_CONFIG.path)."""
+
+from examples.git_detective.agent import make_tools
+
+REPO_CONFIG = None
+_REGISTRY = None
+
+
+def execute(**kwargs):
+    global _REGISTRY
+    if _REGISTRY is None:
+        repo_path = REPO_CONFIG.path if REPO_CONFIG is not None else "."
+        _REGISTRY = make_tools(repo_path)
+    return _REGISTRY._tools["repo_overview"].execute(**kwargs)

--- a/examples/git_detective.workspace/tools/repo_overview/tool.yaml
+++ b/examples/git_detective.workspace/tools/repo_overview/tool.yaml
@@ -1,0 +1,4 @@
+name: repo_overview
+description: Get basic repo info — name, branch, total commits, age.
+parameters: {}
+concurrent_safe: true

--- a/examples/git_detective.workspace/tools/think/execute.py
+++ b/examples/git_detective.workspace/tools/think/execute.py
@@ -1,0 +1,2 @@
+def execute(*, thought: str) -> dict:
+    return {"thought": thought, "noted": True}

--- a/examples/git_detective.workspace/tools/think/tool.yaml
+++ b/examples/git_detective.workspace/tools/think/tool.yaml
@@ -1,0 +1,8 @@
+name: think
+description: Analytical reasoning step. No side effects.
+parameters:
+  thought:
+    type: string
+    description: Brief note.
+free: true
+concurrent_safe: true

--- a/examples/git_detective.workspace/workspace.json
+++ b/examples/git_detective.workspace/workspace.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "name": "git-detective",
+  "description": "Workspace-native git history analyst. Inspects contributors, hotspots, coupling patterns, commit quality.",
+  "metadata": {"tags": ["git", "analysis", "workspace-native"]}
+}

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -545,3 +545,52 @@ def test_threat_intel_workspace_loads() -> None:
         "StagnationHook",
         "PerToolLimitHook",
     ]
+
+
+def test_dep_doctor_workspace_loads() -> None:
+    """examples/dep_doctor.workspace migration."""
+    from pathlib import Path as _P
+
+    workspace_dir = _P(__file__).resolve().parents[1] / "examples" / "dep_doctor.workspace"
+    preset = workspace_to_preset(workspace_dir, strict=True)
+    # detect_dep_files / check_license_compat dirs map via tool.yaml `name`
+    # to detect_files / check_license respectively (the original @tool name).
+    assert sorted(preset.tools._tools.keys()) == [
+        "check_license",
+        "check_package",
+        "detect_files",
+        "done",
+        "find_alternatives",
+        "parse_deps",
+        "think",
+    ]
+    assert [type(h).__name__ for h in preset.hooks] == [
+        "StagnationHook",
+        "PerToolLimitHook",
+    ]
+
+
+def test_git_detective_workspace_loads() -> None:
+    """examples/git_detective.workspace migration. Uses lazy
+    closure-registry via ``make_tools(REPO_CONFIG.path)`` with
+    setup.py injecting the shared repo_config resource."""
+    from pathlib import Path as _P
+
+    workspace_dir = _P(__file__).resolve().parents[1] / "examples" / "git_detective.workspace"
+    preset = workspace_to_preset(workspace_dir, strict=True)
+    assert sorted(preset.tools._tools.keys()) == [
+        "commit_patterns",
+        "contributor_stats",
+        "coupled_files",
+        "directory_structure",
+        "done",
+        "file_age_analysis",
+        "file_hotspots",
+        "recent_activity",
+        "repo_overview",
+        "think",
+    ]
+    assert [type(h).__name__ for h in preset.hooks] == [
+        "StagnationHook",
+        "PerToolLimitHook",
+    ]


### PR DESCRIPTION
Migrates the last two example cartridges to the workspace format from #25/#26/#27.

## dep_doctor.workspace
Tools were already top-level @tool functions, so each execute.py is a one-line re-import.

## git_detective.workspace
Tools were closures from `make_tools(repo_path)`. Each execute.py uses a **lazy-registry pattern**: calls `make_tools(REPO_CONFIG.path)` on first invocation, dispatches by name. setup.py wires REPO_CONFIG from the shared @repo_config resource.

## Verification
- 1618 tests pass (1616 baseline + 2 new regressions)
- Lint + pyright clean
- All 4 cartridges (coder, threat_intel, dep_doctor, git_detective) now have v2 workspace siblings

## What this completes
The migration of every example cartridge to the workspace format. Next:
- Deprecate `SkillBundle` (alias for one release)
- Rewrite docs to lead with the workspace pattern