### PR TITLE
feat(workspace): runtime= kwarg + template substitution

### DIFF
--- a/examples/coder.workspace/resources/file_cache.py
+++ b/examples/coder.workspace/resources/file_cache.py
@@ -8,12 +8,14 @@ All three (read_file/write_file/edit_file tools, FileCacheHook,
 StaleFileHook) reference this via ``"@file_cache"`` so they share
 one instance. Without the @ref shared registry each would silently
 get its own empty cache and the staleness detection would break.
+
+Reads ``runtime["workspace"]`` so the FileCache is bound to the same
+path the host CLI gave the workspace.
 """
 
 from examples.coder.tools import FileCache
 
 
-def build():
-    # Workspace path defaults to "." — setup.py can replace this with
-    # a runtime-aware FileCache when the host CLI knows the real path.
-    return FileCache(workspace=".")
+def build(runtime=None):
+    runtime = runtime or {}
+    return FileCache(workspace=str(runtime.get("workspace", ".")))

--- a/examples/coder.workspace/resources/workspace_config.py
+++ b/examples/coder.workspace/resources/workspace_config.py
@@ -1,9 +1,10 @@
 """Shared workspace_config — the workspace dir the coder operates in.
 
-setup.py overwrites the ``path`` attribute at load time based on
-the ``runtime`` arg (set by the host CLI). Tools and hooks that
-need the workspace path read it through the registry at
-``"@workspace_config"``.
+The host calls ``workspace_to_preset(path, runtime={"workspace": "/path/to/repo"})``
+and this builder reads ``runtime["workspace"]`` to set the path. Tools
+and hooks that need the workspace root read it through the @ref
+registry as ``"@workspace_config"`` so the same workspace can be
+pointed at any repo by changing one runtime kwarg.
 
 Defaults to "." so the workspace can be exercised against the
 current working directory in tests / one-off runs.
@@ -22,5 +23,6 @@ class WorkspaceConfig:
         return Path(self.path)
 
 
-def build():
-    return WorkspaceConfig(path=".")
+def build(runtime=None):
+    runtime = runtime or {}
+    return WorkspaceConfig(path=str(runtime.get("workspace", ".")))

--- a/examples/git_detective.workspace/resources/repo_config.py
+++ b/examples/git_detective.workspace/resources/repo_config.py
@@ -1,10 +1,10 @@
 """Shared repo_config — points at the git repository to analyze.
 
-setup.py replaces ``path`` at workspace load time using the host
-CLI's ``--repo`` arg. Every git_detective tool reads this via the
-module global ``REPO_CONFIG`` (set by setup.py from
-``"@repo_config"``) so the same workspace can be pointed at any
-repo by changing one line in setup.py.
+The host calls ``workspace_to_preset(path, runtime={"repo": "/path/to/repo"})``
+and this builder reads ``runtime["repo"]``. Every git_detective tool
+reads this via the module global ``REPO_CONFIG`` (set by setup.py
+from ``"@repo_config"``) so the same workspace can be pointed at
+any repo by changing one runtime kwarg.
 """
 
 from dataclasses import dataclass
@@ -15,5 +15,6 @@ class RepoConfig:
     path: str = "."
 
 
-def build():
-    return RepoConfig(path=".")
+def build(runtime=None):
+    runtime = runtime or {}
+    return RepoConfig(path=str(runtime.get("repo", ".")))

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -409,18 +409,22 @@ def _import_module_from_path(path: Path, module_name: str) -> Any:
     return module
 
 
-def _load_resources(root: Path) -> dict[str, Any]:
+def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[str, Any]:
     """Build the shared-resource registry from ``resources/<name>.py`` files.
 
-    Each resource module must define ``def build() -> Any`` (or
-    ``def build(runtime) -> Any`` — runtime is the ``state_factory``
-    arg, currently unused inside resource builders). The returned
-    object is shared by every ``"@<name>"`` reference in hook /
-    tool kwargs.
+    Each resource module must define a builder named ``build``. The
+    loader inspects the signature: ``build()`` (zero-arg) keeps the
+    legacy contract; ``build(runtime)`` lets the resource read the
+    host-supplied ``runtime`` dict (e.g. ``runtime['workspace']`` for
+    the coder cartridge). Resources are shared by every ``"@<name>"``
+    reference in hook / tool kwargs.
     """
+    import inspect as _inspect  # noqa: PLC0415
+
     resources_dir = root / WorkspaceLayout.RESOURCES_DIR
     if not resources_dir.is_dir():
         return {}
+    runtime_dict = dict(runtime or {})
     resources: dict[str, Any] = {}
     for resource_file in sorted(resources_dir.glob("*.py")):
         name = resource_file.stem
@@ -430,7 +434,16 @@ def _load_resources(root: Path) -> dict[str, Any]:
             raise WorkspaceSerializationError(
                 f"resource {name!r} ({resource_file}) must define `def build() -> Any`"
             )
-        resources[name] = builder()
+        # Pass runtime only when the builder accepts it, so legacy
+        # zero-arg builders keep working unchanged.
+        try:
+            sig = _inspect.signature(builder)
+            accepts_runtime = "runtime" in sig.parameters or any(
+                p.kind == _inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+        except (TypeError, ValueError):
+            accepts_runtime = False
+        resources[name] = builder(runtime=runtime_dict) if accepts_runtime else builder()
     return resources
 
 
@@ -462,6 +475,33 @@ def _resolve_refs(value: Any, resources: dict[str, Any]) -> Any:
 def _safe_filename(name: str) -> str:
     """Sanitise an arbitrary string into a directory-safe filename."""
     return re.sub(r"[^A-Za-z0-9_.-]+", "_", name) or "unnamed"
+
+
+_RUNTIME_PLACEHOLDER = re.compile(r"\$\{runtime\.([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _apply_runtime_substitutions(text: str, runtime: dict[str, Any]) -> str:
+    """Replace ``${runtime.<key>}`` placeholders in ``text`` with the
+    string form of ``runtime[<key>]``.
+
+    Used on ``config.yaml`` (and any other plain-text workspace file the
+    loader passes through this) so workspace authors can parameterise
+    paths and other host-supplied values without writing a setup.py.
+
+    Unknown keys raise :class:`WorkspaceSerializationError` so a typo
+    fails loudly at load time rather than silently leaving the
+    placeholder string in the running config.
+    """
+
+    def _sub(match: "re.Match[str]") -> str:
+        key = match.group(1)
+        if key not in runtime:
+            raise WorkspaceSerializationError(
+                f"unresolved ${{runtime.{key}}} placeholder; known runtime keys: {sorted(runtime)}"
+            )
+        return str(runtime[key])
+
+    return _RUNTIME_PLACEHOLDER.sub(_sub, text)
 
 
 def _hook_class(hook: Any) -> type:
@@ -797,6 +837,7 @@ def workspace_to_preset(
     *,
     state_factory: Callable[[int], Any] | None = None,
     strict: bool = False,
+    runtime: dict[str, Any] | None = None,
 ) -> "AgentPreset":
     """Read a CHW directory and materialise an :class:`AgentPreset`.
 
@@ -810,6 +851,15 @@ def workspace_to_preset(
             When ``False`` (default), drop the offender, log a warning,
             and continue. Use ``strict=True`` for round-trip
             verification and CI lint.
+        runtime: Optional dict of host-supplied runtime values
+            (e.g. ``{"workspace": "/tmp/myrepo"}`` for the coder
+            cartridge). Three integration points read it:
+              * ``${runtime.<key>}`` placeholders in ``config.yaml``
+                are substituted before constructing ``LoopConfig``.
+              * ``resources/<name>.py`` builders that declare
+                ``def build(runtime)`` (or ``**kwargs``) receive it.
+              * ``setup.py``'s ``setup(...)`` receives it via the
+                ``runtime`` kwarg when its signature accepts it.
     """
     from looplet.loop import LoopConfig  # noqa: PLC0415
     from looplet.presets import AgentPreset  # noqa: PLC0415
@@ -828,13 +878,19 @@ def workspace_to_preset(
     # strings throughout hook / tool kwargs. Lets two hooks share the
     # same live object (e.g. a FileCache) on reload, instead of
     # silently splitting into two independent instances.
-    resources = _load_resources(root)
+    runtime_dict = dict(runtime or {})
+    resources = _load_resources(root, runtime_dict)
 
     # Config
     cfg_kwargs: dict[str, Any] = {}
     cfg_path = root / WorkspaceLayout.CONFIG_YAML
     if cfg_path.is_file():
-        cfg_kwargs.update(_load_yaml(cfg_path.read_text(encoding="utf-8")) or {})
+        raw_cfg_text = cfg_path.read_text(encoding="utf-8")
+        # Apply ``${runtime.<key>}`` substitution before YAML parsing so
+        # workspace authors can parameterise config.yaml without needing
+        # a setup.py for the common cases.
+        raw_cfg_text = _apply_runtime_substitutions(raw_cfg_text, runtime_dict)
+        cfg_kwargs.update(_load_yaml(raw_cfg_text) or {})
 
     sys_prompt_path = root / WorkspaceLayout.SYSTEM_PROMPT_MD
     if sys_prompt_path.is_file():
@@ -990,6 +1046,8 @@ def workspace_to_preset(
             kwargs["tool_modules"] = tool_modules
         if "hook_modules" in sig_params:
             kwargs["hook_modules"] = hook_modules
+        if "runtime" in sig_params:
+            kwargs["runtime"] = runtime_dict
         result = setup_fn(preset, resources, **kwargs)
         if isinstance(result, AgentPreset):
             preset = result

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -594,3 +594,112 @@ def test_git_detective_workspace_loads() -> None:
         "StagnationHook",
         "PerToolLimitHook",
     ]
+
+
+# ── runtime= kwarg + ${runtime.x} substitution ────────────────
+
+
+def test_runtime_substitution_in_config_yaml(tmp_path):
+    """${runtime.<key>} placeholders in config.yaml get replaced with
+    the host-supplied runtime value before LoopConfig is constructed."""
+    out = tmp_path / "ws"
+    out.mkdir()
+    (out / "workspace.json").write_text(json.dumps({"name": "x", "schema_version": 1}))
+    (out / "config.yaml").write_text("max_steps: 5\ncheckpoint_dir: ${runtime.cp_dir}\n")
+
+    preset = workspace_to_preset(out, strict=True, runtime={"cp_dir": "/tmp/my-cp"})
+    assert preset.config.max_steps == 5
+    assert preset.config.checkpoint_dir == "/tmp/my-cp"
+
+
+def test_runtime_substitution_unknown_key_raises(tmp_path):
+    """Typos in ${runtime.<key>} fail loudly at load time, not silently."""
+    out = tmp_path / "ws"
+    out.mkdir()
+    (out / "workspace.json").write_text(json.dumps({"name": "x", "schema_version": 1}))
+    (out / "config.yaml").write_text("max_steps: ${runtime.nonexistent}\n")
+
+    with pytest.raises(WorkspaceSerializationError, match="unresolved"):
+        workspace_to_preset(out, strict=True, runtime={"actual_key": 5})
+
+
+def test_resource_builder_receives_runtime(tmp_path):
+    """resources/<name>.py builders that declare def build(runtime)
+    get the host-supplied runtime dict; legacy zero-arg build()
+    keeps working."""
+    out = tmp_path / "ws"
+    out.mkdir()
+    (out / "workspace.json").write_text(json.dumps({"name": "x", "schema_version": 1}))
+    (out / "resources").mkdir()
+    (out / "resources" / "tagged.py").write_text(
+        "def build(runtime=None):\n"
+        "    runtime = runtime or {}\n"
+        "    return {'tag': runtime.get('tag', 'default')}\n"
+    )
+
+    hook_dir = out / "hooks" / "00_TagReader"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "hook.py").write_text(
+        "class TagReader:\n    def __init__(self, *, source):\n        self.source = source\n"
+    )
+    (hook_dir / "config.yaml").write_text('class_name: TagReader\nkwargs:\n  source: "@tagged"\n')
+
+    preset = workspace_to_preset(out, strict=True, runtime={"tag": "from-runtime"})
+    assert preset.hooks[0].source == {"tag": "from-runtime"}
+
+
+def test_setup_py_receives_runtime_kwarg(tmp_path):
+    """setup.py's setup() gets runtime= when its signature accepts it."""
+    out = tmp_path / "ws"
+    out.mkdir()
+    (out / "workspace.json").write_text(json.dumps({"name": "x", "schema_version": 1}))
+    (out / "setup.py").write_text(
+        "def setup(preset, resources, runtime=None):\n"
+        "    runtime = runtime or {}\n"
+        "    preset.config.system_prompt = runtime.get('prompt', 'default')\n"
+        "    return preset\n"
+    )
+
+    preset = workspace_to_preset(out, strict=True, runtime={"prompt": "from-runtime"})
+    assert preset.config.system_prompt == "from-runtime"
+
+
+def test_coder_workspace_runtime_kwarg_routes_files(tmp_path):
+    """End-to-end regression for the runtime= kwarg in coder.workspace:
+    write_file via composable_loop must land in the runtime-supplied
+    workspace, NOT in the test cwd. The previous code wrote to cwd
+    because there was no way to point a workspace at a runtime path."""
+    import json as _json
+    from pathlib import Path as _P
+
+    from looplet import composable_loop
+    from looplet.testing import MockLLMBackend
+
+    workspace_dir = _P(__file__).resolve().parents[1] / "examples" / "coder.workspace"
+    target = tmp_path / "target-repo"
+    target.mkdir()
+
+    preset = workspace_to_preset(workspace_dir, strict=True, runtime={"workspace": str(target)})
+    llm = MockLLMBackend(
+        responses=[
+            _json.dumps(
+                {
+                    "thought": "write",
+                    "tool": "write_file",
+                    "args": {"file_path": "hello.py", "content": "print('hi')\n"},
+                }
+            ),
+            _json.dumps({"thought": "finish", "tool": "done", "args": {"summary": "ok"}}),
+        ]
+    )
+    list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=preset.state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"q": "write hello.py"},
+        )
+    )
+    assert (target / "hello.py").read_text().strip() == "print('hi')"


### PR DESCRIPTION
Closes the host-parameterization gap discovered when dogfooding `coder.workspace`: there was no public, ergonomic way for the host to point a workspace at a runtime path. Files written by `write_file` landed in `cwd` instead of the host-supplied workspace because resource builders had no access to host-supplied values.

## What's new

1. `workspace_to_preset(path, *, runtime: dict | None = None)` — host passes a free-form dict of runtime values (e.g. `{'workspace': '/tmp/repo', 'repo': '/git/path'}`).

2. `resources/<name>.py` builders that declare `def build(runtime)` (or `**kwargs`) receive the runtime dict. Legacy zero-arg `build()` keeps working unchanged via signature inspection.

3. `${runtime.<key>}` placeholders in `config.yaml` are substituted before YAML parsing. Unknown keys raise `WorkspaceSerializationError` so typos fail loud.

4. `setup.py`'s `setup()` receives `runtime=` when its signature accepts it (alongside `resources`, `tool_modules`, `hook_modules` — all optional via signature inspection).

## Workspace updates

- `coder.workspace`: `workspace_config` + `file_cache` builders read `runtime['workspace']`. `write_file` now correctly writes to the host-supplied workspace path instead of cwd.
- `git_detective.workspace`: `repo_config` builder reads `runtime['repo']`.

## Tests (+5)

- `test_runtime_substitution_in_config_yaml`
- `test_runtime_substitution_unknown_key_raises` 
- `test_resource_builder_receives_runtime`
- `test_setup_py_receives_runtime_kwarg`
- `test_coder_workspace_runtime_kwarg_routes_files` (end-to-end: loop runs scripted, `write_file` lands in target, NOT in cwd)

1623 tests pass (1618 baseline + 5 new). Lint + pyright clean.
