### PR TITLE
feat(workspace): EvalHook declarative + 13-pattern harness stress test

### DIFF
--- a/examples/coder.workspace/hooks/07_EvalHook/config.yaml
+++ b/examples/coder.workspace/hooks/07_EvalHook/config.yaml
@@ -1,0 +1,4 @@
+class_name: EvalHook
+kwargs:
+  evaluators: "@eval_evaluators"
+  collectors: "@eval_collectors"

--- a/examples/coder.workspace/hooks/07_EvalHook/hook.py
+++ b/examples/coder.workspace/hooks/07_EvalHook/hook.py
@@ -1,0 +1,16 @@
+"""EvalHook subclass exposing both evaluators and collectors via @ref.
+
+Both kwargs round-trip through to_config so the workspace snapshot
+captures them as ``@eval_evaluators`` / ``@eval_collectors`` refs.
+The corresponding builders live in resources/.
+"""
+
+from looplet import EvalHook as _EvalHook
+
+
+class EvalHook(_EvalHook):
+    def to_config(self) -> dict:
+        return {
+            "evaluators": "@eval_evaluators",
+            "collectors": "@eval_collectors",
+        }

--- a/examples/coder.workspace/resources/eval_collectors.py
+++ b/examples/coder.workspace/resources/eval_collectors.py
@@ -1,0 +1,14 @@
+"""Collectors for the coder workspace's EvalHook.
+
+Re-uses the v1 cartridge's ``make_test_collector`` so the v2
+workspace surfaces the same outcome-grounded artifacts. Reads
+``runtime['workspace']`` for the project root.
+"""
+
+from examples.coder.wiring import make_test_collector
+
+
+def build(runtime=None):
+    runtime = runtime or {}
+    workspace = str(runtime.get("workspace", "."))
+    return [make_test_collector(workspace)]

--- a/examples/coder.workspace/resources/eval_evaluators.py
+++ b/examples/coder.workspace/resources/eval_evaluators.py
@@ -1,0 +1,29 @@
+"""Evaluators for the coder workspace's EvalHook.
+
+Re-uses the v1 cartridge's ``build_eval_hook`` evaluators so the
+v2 workspace produces identical scores. The list lands in
+``hooks/07_EvalHook/config.yaml`` via the ``@eval_evaluators`` ref.
+"""
+
+from looplet import EvalContext, EvalResult
+
+
+def eval_tests_passed(ctx: EvalContext):
+    if "tests_passing" not in ctx.artifacts:
+        return EvalResult(
+            name="eval_tests_passed",
+            label="skipped",
+            explanation=(
+                "no Python project (pyproject.toml/setup.py) detected "
+                "in workspace; collector cannot re-run tests"
+            ),
+        )
+    return bool(ctx.artifacts["tests_passing"])
+
+
+def eval_completed(ctx: EvalContext):
+    return ctx.completed
+
+
+def build(runtime=None):
+    return [eval_tests_passed, eval_completed]

--- a/examples/coder.workspace/setup.py
+++ b/examples/coder.workspace/setup.py
@@ -1,6 +1,7 @@
-"""Wire shared resources + callable-graph hooks for the coder workspace.
+"""Wire shared resources + non-declarative bits for the coder workspace.
 
-Three jobs run here, all driven by the host-supplied ``runtime`` dict:
+After PR #30 + the harness-search dogfooding the deferred work shrunk
+to two jobs that genuinely need real Python at load time:
 
 1. **Inject shared resources into tool module globals** — tools
    accept their kwargs from the LLM, so the @ref registry alone
@@ -8,19 +9,18 @@ Three jobs run here, all driven by the host-supplied ``runtime`` dict:
    walks ``tool_modules`` and writes ``WORKSPACE_CONFIG`` /
    ``FILE_CACHE`` into each tool that declares those globals.
 
-2. **Append callable-graph hooks** — LinterHook (needs runtime
-   workspace), EvalHook (needs evaluator + collector callables),
-   and an optional StreamingHook (needs an emitter callable) all
-   carry callables that don't round-trip through YAML. They get
-   appended to ``preset.hooks`` here so the resulting preset
-   matches the v1 cartridge feature-for-feature.
+2. **Attach the compaction service** — ``compact_service`` is a
+   non-JSON-able callable, so it can't go in config.yaml. Same
+   chain the v1 cartridge uses.
 
-3. **Attach the compaction service** — the v1 cartridge wires
-   ``compact_service=compact_chain(PruneToolResults(keep_recent=10),
-   TruncateCompact(keep_recent=5))``. We re-use the same chain.
+3. **Append the live-state CallableMemorySource** — the v1
+   cartridge's project-context briefing uses a callable that reads
+   ``state.step_count`` per step. CallableMemorySource isn't
+   round-trippable through YAML.
 
-Plus a callable memory source for the live project-context briefing
-that gets appended to ``config.memory_sources``.
+Every other piece (LinterHook, EvalHook, evaluators, collectors,
+PerToolLimitHook, StagnationHook, ThresholdCompactHook, the @ref
+shared FileCache) is now declarative under hooks/ and resources/.
 """
 
 from __future__ import annotations
@@ -39,16 +39,7 @@ def setup(preset, resources, tool_modules, hook_modules, runtime=None):
         if file_cache is not None and hasattr(module, "FILE_CACHE"):
             module.FILE_CACHE = file_cache
 
-    # 2. Append callable-graph hooks. EvalHook needs collector +
-    # evaluator callables that don't round-trip through YAML — those
-    # stay in setup.py. LinterHook is loaded declaratively from
-    # hooks/06_LinterHook/config.yaml using ``${runtime.workspace}``
-    # template substitution (no setup.py wiring needed).
-    from examples.coder.wiring import build_eval_hook  # noqa: PLC0415
-
-    preset.hooks.append(build_eval_hook(workspace_path))
-
-    # 3. Attach the compaction service.
+    # 2. Attach the compaction service.
     from looplet.compact import (  # noqa: PLC0415
         PruneToolResults,
         TruncateCompact,
@@ -60,7 +51,7 @@ def setup(preset, resources, tool_modules, hook_modules, runtime=None):
         TruncateCompact(keep_recent=5),
     )
 
-    # 4. Append the live-state callable memory source the v1 cartridge
+    # 3. Append the live-state CallableMemorySource the v1 cartridge
     #    uses for project-context briefing.
     from examples.coder.wiring import build_default_memory_sources  # noqa: PLC0415
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -748,7 +748,10 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
     # runtime['workspace']; pass it on reload.
     reloaded = workspace_to_preset(snap_dir, runtime={"workspace": str(target)})
 
-    # All 7 declarative hooks survive the round-trip.
+    # All 8 declarative hooks survive the round-trip — including
+    # EvalHook now that its evaluators + collectors live in
+    # resources/eval_evaluators.py and resources/eval_collectors.py
+    # (referenced via @ref instead of injected via setup.py).
     reloaded_names = [type(h).__name__ for h in reloaded.hooks]
     assert reloaded_names == [
         "TestGuardHook",
@@ -758,6 +761,7 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
         "ThresholdCompactHook",
         "PerToolLimitHook",
         "LinterHook",
+        "EvalHook",
     ]
     assert sorted(reloaded.tools._tools.keys()) == [
         "bash",
@@ -823,3 +827,171 @@ def test_runtime_substitution_in_hook_config(tmp_path) -> None:
 
     preset = workspace_to_preset(out, strict=True, runtime={"workspace": "/tmp/some-path"})
     assert preset.hooks[0].path == "/tmp/some-path"
+
+
+# ── Harness-shape stress tests (PR #31) ───────────────────────
+
+
+def test_permission_engine_via_at_ref(tmp_path) -> None:
+    """PermissionEngine + PermissionHook compose via @ref. Lets users
+    declare permission policy in resources/perm_engine.py and reference
+    it from hooks/00_PermissionHook/config.yaml."""
+    import json as _json
+    from pathlib import Path as _P
+
+    ws = tmp_path
+    (ws / "workspace.json").write_text(_json.dumps({"name": "x", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 5\n")
+    (ws / "tools/echo").mkdir(parents=True)
+    (ws / "tools/echo/tool.yaml").write_text("name: echo\nparameters:\n  msg:\n    type: string\n")
+    (ws / "tools/echo/execute.py").write_text("def execute(*, msg): return {'echoed': msg}\n")
+    (ws / "tools/done").mkdir(parents=True)
+    (ws / "tools/done/tool.yaml").write_text("name: done\nparameters:\n  s:\n    type: string\n")
+    (ws / "tools/done/execute.py").write_text(
+        "def execute(*, s): return {'status': 'completed', 's': s}\n"
+    )
+    (ws / "resources").mkdir()
+    (ws / "resources/perm_engine.py").write_text(
+        "from looplet import PermissionEngine, PermissionDecision\n"
+        "def build(runtime=None):\n"
+        "    eng = PermissionEngine(default=PermissionDecision.ALLOW)\n"
+        "    eng.deny('echo', arg_matcher=lambda a: a.get('msg', '').startswith('SECRET'))\n"
+        "    return eng\n"
+    )
+    (ws / "hooks/00_PermissionHook").mkdir(parents=True)
+    (ws / "hooks/00_PermissionHook/hook.py").write_text(
+        "from looplet import PermissionHook as _PH\n"
+        "class PermissionHook(_PH):\n"
+        "    def to_config(self): return {'engine': '@perm_engine'}\n"
+    )
+    (ws / "hooks/00_PermissionHook/config.yaml").write_text(
+        'class_name: PermissionHook\nkwargs:\n  engine: "@perm_engine"\n'
+    )
+
+    from looplet import composable_loop
+    from looplet.testing import MockLLMBackend
+
+    preset = workspace_to_preset(ws, strict=True)
+    llm = MockLLMBackend(
+        responses=[
+            _json.dumps({"thought": "ok", "tool": "echo", "args": {"msg": "hello"}}),
+            _json.dumps({"thought": "block", "tool": "echo", "args": {"msg": "SECRET-leak"}}),
+            _json.dumps({"thought": "f", "tool": "done", "args": {"s": "ok"}}),
+        ]
+    )
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=preset.state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"q": "x"},
+        )
+    )
+    assert steps[0].tool_result.error is None
+    assert steps[1].tool_result.error and "permission" in steps[1].tool_result.error.lower()
+
+
+def test_eval_hook_declarative_via_at_ref(tmp_path) -> None:
+    """EvalHook with declarative evaluators + collectors via @ref.
+    Confirms callable-graph hooks are NOT a permanent setup.py
+    requirement — when callables are exposed as resource builders
+    that return them, the @ref registry resolves them just like any
+    other shared resource."""
+    import json as _json
+
+    ws = tmp_path
+    (ws / "workspace.json").write_text(_json.dumps({"name": "x", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 3\n")
+    (ws / "tools/done").mkdir(parents=True)
+    (ws / "tools/done/tool.yaml").write_text("name: done\nparameters:\n  s:\n    type: string\n")
+    (ws / "tools/done/execute.py").write_text(
+        "def execute(*, s): return {'status': 'completed', 's': s}\n"
+    )
+    (ws / "resources").mkdir()
+    (ws / "resources/evaluators.py").write_text(
+        "def eval_completed(ctx): return ctx.completed\n"
+        "def build(runtime=None): return [eval_completed]\n"
+    )
+    (ws / "hooks/00_EvalHook").mkdir(parents=True)
+    (ws / "hooks/00_EvalHook/hook.py").write_text(
+        "from looplet import EvalHook as _EH\n"
+        "class EvalHook(_EH):\n"
+        "    def to_config(self): return {'evaluators': '@evaluators'}\n"
+    )
+    (ws / "hooks/00_EvalHook/config.yaml").write_text(
+        'class_name: EvalHook\nkwargs:\n  evaluators: "@evaluators"\n'
+    )
+
+    preset = workspace_to_preset(ws, strict=True)
+    eh = preset.hooks[0]
+    evals = getattr(eh, "evaluators", None) or getattr(eh, "_evaluators", None)
+    assert evals and len(evals) == 1
+
+
+def test_streaming_hook_declarative_via_at_ref(tmp_path) -> None:
+    """StreamingHook with declarative emitter via @ref."""
+    import json as _json
+
+    ws = tmp_path
+    (ws / "workspace.json").write_text(_json.dumps({"name": "x", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 3\n")
+    (ws / "tools/done").mkdir(parents=True)
+    (ws / "tools/done/tool.yaml").write_text("name: done\nparameters:\n  s:\n    type: string\n")
+    (ws / "tools/done/execute.py").write_text(
+        "def execute(*, s): return {'status': 'completed', 's': s}\n"
+    )
+    (ws / "resources").mkdir()
+    (ws / "resources/emitter.py").write_text(
+        "from looplet.streaming import CallbackEmitter\n"
+        "EVENTS = []\n"
+        "def build(runtime=None): return CallbackEmitter(EVENTS.append)\n"
+    )
+    (ws / "hooks/00_StreamingHook").mkdir(parents=True)
+    (ws / "hooks/00_StreamingHook/hook.py").write_text(
+        "from looplet import StreamingHook as _SH\n"
+        "class StreamingHook(_SH):\n"
+        "    def to_config(self): return {'emitter': '@emitter'}\n"
+    )
+    (ws / "hooks/00_StreamingHook/config.yaml").write_text(
+        'class_name: StreamingHook\nkwargs:\n  emitter: "@emitter"\n'
+    )
+
+    preset = workspace_to_preset(ws, strict=True)
+    hook = preset.hooks[0]
+    emitter = getattr(hook, "emitter", None) or getattr(hook, "_emitter", None)
+    assert emitter is not None
+
+
+def test_workspace_extends_other_workspace(tmp_path) -> None:
+    """A workspace's setup.py can load another workspace and merge
+    its tools/hooks. Demonstrates inheritance/composition between
+    cartridges without forking the loop."""
+    import json as _json
+
+    base = tmp_path / "base"
+    ext = tmp_path / "ext"
+    (base / "tools/done").mkdir(parents=True)
+    (base / "workspace.json").write_text(_json.dumps({"name": "base", "schema_version": 1}))
+    (base / "config.yaml").write_text("max_steps: 5\n")
+    (base / "tools/done/tool.yaml").write_text("name: done\nparameters:\n  s:\n    type: string\n")
+    (base / "tools/done/execute.py").write_text(
+        "def execute(*, s): return {'status': 'completed', 's': s}\n"
+    )
+
+    (ext / "tools").mkdir(parents=True)
+    (ext / "workspace.json").write_text(_json.dumps({"name": "ext", "schema_version": 1}))
+    (ext / "config.yaml").write_text("max_steps: 10\n")
+    (ext / "setup.py").write_text(
+        "from looplet import workspace_to_preset\n"
+        f"BASE = {str(base)!r}\n"
+        "def setup(preset, resources, runtime=None):\n"
+        "    base = workspace_to_preset(BASE)\n"
+        "    for name, spec in base.tools._tools.items():\n"
+        "        if name not in preset.tools._tools:\n"
+        "            preset.tools.register(spec)\n"
+        "    return preset\n"
+    )
+    preset = workspace_to_preset(ext, strict=True)
+    assert "done" in preset.tools._tools


### PR DESCRIPTION
Stress-tested the v2 workspace against 13 advanced harness patterns users would build on top of looplet. **All 13 work today** — no fixes needed for any of them — but the dogfood revealed that EvalHook can go declarative via `@ref` instead of staying in setup.py. Same for StreamingHook.

## What changed

1. **`coder.workspace` gains `hooks/07_EvalHook/`** as a declarative hook that pulls its evaluators + collectors from two new resource builders:
   - `resources/eval_evaluators.py`: returns the v1 cartridge's `eval_tests_passed` + `eval_completed` callable list
   - `resources/eval_collectors.py`: returns `[make_test_collector(workspace)]` reading `runtime['workspace']`
   
   The `EvalHook` subclass overrides `to_config` to emit `{'evaluators': '@eval_evaluators', 'collectors': '@eval_collectors'}`.

2. **`setup.py` shrinks**: EvalHook lives in YAML now. setup.py only does what genuinely needs Python at load time — module-global injection for tools, compact_service attachment, and the live-state CallableMemorySource.

3. **Bidirectional round-trip test now expects 8 hooks** (was 7) since EvalHook survives reload via the @ref-resolved resources.

## Verification: 13 advanced harness shapes — all pass

| # | Pattern | Status |
|---|---|---|
| 1 | PermissionEngine with declarative rules + @ref | ✅ |
| 2 | Two hooks share a stateful resource via @ref | ✅ |
| 3 | Sub-loop dispatched from a tool | ✅ |
| 4 | Async loop variant | ✅ |
| 5 | Tool calls `ctx.llm.generate()` mid-execution | ✅ |
| 6 | Custom DomainAdapter via setup.py | ✅ |
| 7 | setup.py customizes config via runtime override | ✅ |
| A | Custom hook with arbitrary state, no base class | ✅ |
| B | Host-side LLM strategy switching (no v2 concern) | ✅ |
| C | EvalHook with declarative evaluators | ✅ |
| D | StreamingHook with declarative emitter | ✅ |
| E | compact_service via setup.py | ✅ |
| F | Workspace inherits another via setup.py | ✅ |

4 new regression tests pin the most impactful patterns:
- `test_permission_engine_via_at_ref`
- `test_eval_hook_declarative_via_at_ref`
- `test_streaming_hook_declarative_via_at_ref`
- `test_workspace_extends_other_workspace`

**1632 tests pass** (was 1628 + 4 new). Lint + pyright clean.

## Key insight

The "callable-graph hooks need setup.py" framing from #30 was overly conservative. **Anything callable can be a resource builder** — the @ref registry resolves callables and lists of callables just like it resolves data. The real setup.py-only cases are:
- Module-global injection into top-level tool functions (tools don't accept constructor kwargs)
- Live-state callables that must close over runtime values (CallableMemorySource that reads `state.step_count`)
- Non-JSON-able `LoopConfig` fields (compact_service, domain)

Everything else can live in YAML + resources/.
