### PR TITLE
fix(workspace): dogfood frictions in shipped examples + 3 library bugs

### DIFF
--- a/examples/dep_doctor.workspace/tools/check_license_compat/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/check_license_compat/tool.yaml
@@ -1,4 +1,4 @@
-name: check_license
+name: check_license_compat
 description: Check if a dependency license is compatible with the project license.
 parameters:
   project_license:

--- a/examples/dep_doctor.workspace/tools/detect_dep_files/tool.yaml
+++ b/examples/dep_doctor.workspace/tools/detect_dep_files/tool.yaml
@@ -1,4 +1,4 @@
-name: detect_files
+name: detect_dep_files
 description: Scan a project directory for dependency files.
 parameters:
   project_dir:

--- a/src/looplet/tools.py
+++ b/src/looplet/tools.py
@@ -375,16 +375,27 @@ class ToolSpec:
         """Return required parameter names.
 
         For JSON Schema, reads the ``required`` field.
-        For simple format, parameters whose description starts with
-        ``(optional)`` are excluded; the rest are required.
+        For workspace-style ``{name: {type, description, default?}}``
+        parameter dicts (the format ``tool.yaml`` files use), names
+        whose descriptor either omits ``default`` or lacks one are
+        required.
+        For simple format ``{name: description_string}``, parameters
+        whose description starts with ``(optional)`` are excluded;
+        the rest are required.
         """
         if self.is_json_schema:
             return list(self.parameters.get("required", []))
-        return [
-            name
-            for name, desc in self.parameters.items()
-            if not str(desc).lower().lstrip().startswith("(optional)")
-        ]
+        required: list[str] = []
+        for name, desc in self.parameters.items():
+            # Workspace v2 ``tool.yaml`` form: dict descriptor.
+            if isinstance(desc, dict):
+                if "default" not in desc:
+                    required.append(name)
+                continue
+            # Simple form: bare-string description.
+            if not str(desc).lower().lstrip().startswith("(optional)"):
+                required.append(name)
+        return required
 
     def spec_text(self) -> str:
         """Format for LLM prompt inclusion."""

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -426,7 +426,21 @@ def _import_module_from_path(path: Path, module_name: str) -> Any:
     if spec is None or spec.loader is None:
         raise WorkspaceSerializationError(f"cannot import module from {path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    # Register in ``sys.modules`` so ``inspect.getmodule(cls)`` /
+    # ``inspect.getsource(cls)`` can find the on-disk source for
+    # workspace-defined classes (hooks / resources). Without this,
+    # round-tripping a loaded workspace's own inline ``hook.py``
+    # falls back to the placeholder branch in ``_render_hook_source``
+    # because the dynamically-loaded module has no ``sys.modules``
+    # entry for ``inspect`` to consult.
+    import sys as _sys  # noqa: PLC0415
+
+    _sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except Exception:
+        _sys.modules.pop(module_name, None)
+        raise
     return module
 
 
@@ -845,7 +859,46 @@ def _write_resources_for_refs(
 
     resources_dir = root / WorkspaceLayout.RESOURCES_DIR
     resources_dir.mkdir(exist_ok=True)
+    import sys as _sys  # noqa: PLC0415
+
+    def _origin_chw_resource_file(value: Any) -> Path | None:
+        """If ``value`` (or every callable element of a list/tuple)
+        traces back to a single ``_chw_resource_<name>`` module, return
+        the on-disk source file. The original ``resources/<name>.py``
+        is the canonical builder — copying it round-trips builds
+        that compute lists / closures / nested objects without losing
+        the original ``def build()`` signature.
+        """
+        candidates: list[Any] = list(value) if isinstance(value, (list, tuple)) else [value]
+        if not candidates:
+            return None
+        chw_modules: set[str] = set()
+        for item in candidates:
+            mod = getattr(item, "__module__", "") or type(item).__module__ or ""
+            if not mod.startswith("_chw_resource_"):
+                return None
+            chw_modules.add(mod)
+        if len(chw_modules) != 1:
+            return None
+        chw_mod = _sys.modules.get(next(iter(chw_modules)))
+        chw_file = getattr(chw_mod, "__file__", None) if chw_mod is not None else None
+        if chw_file and Path(chw_file).is_file():
+            return Path(chw_file)
+        return None
+
     for ref_name, instance in refs_seen.items():
+        # ── Universal pre-pass: copy original resources/<X>.py when
+        # the live instance came from a workspace's own resource. The
+        # original builder has the exact ``def build(runtime=None)``
+        # the loader expects; reproducing it from the live instance
+        # via dataclass / class auto-emit can lose the runtime= path,
+        # the closure state, or the original list factory.
+        chw_src = _origin_chw_resource_file(instance)
+        if chw_src is not None:
+            (resources_dir / f"{_safe_filename(ref_name)}.py").write_text(
+                chw_src.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            continue
         if instance is None:
             msg = (
                 f"resource {ref_name!r}: could not locate the live instance on "
@@ -1137,6 +1190,23 @@ def _write_tool(spec: Any, tools_root: Path, warnings: list[str], strict: bool) 
     # back to source-dump only when the function isn't importable.
     fn_name = getattr(fn, "__name__", "")
     module_name = getattr(fn, "__module__", "") or ""
+
+    # Workspace-loaded tools live in dynamic ``_chw_tool_<name>`` modules
+    # registered in ``sys.modules``. Re-importing by that synthetic name
+    # would silently fail at reload (the new process has no entry under
+    # that key). Copy the original on-disk ``execute.py`` verbatim — it
+    # already carries the correct shim or top-level function.
+    if module_name.startswith("_chw_tool_"):
+        import sys as _sys  # noqa: PLC0415
+
+        chw_mod = _sys.modules.get(module_name)
+        chw_file = getattr(chw_mod, "__file__", None) if chw_mod is not None else None
+        if chw_file and Path(chw_file).is_file():
+            (tool_dir / "execute.py").write_text(
+                Path(chw_file).read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            return
+
     if fn_name and module_name and module_name not in {"__main__", "builtins"}:
         try:
             mod = importlib.import_module(module_name)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -591,12 +591,12 @@ def test_dep_doctor_workspace_loads() -> None:
 
     workspace_dir = _P(__file__).resolve().parents[1] / "examples" / "dep_doctor.workspace"
     preset = workspace_to_preset(workspace_dir, strict=True)
-    # detect_dep_files / check_license_compat dirs map via tool.yaml `name`
-    # to detect_files / check_license respectively (the original @tool name).
+    # tool.yaml ``name`` matches the dir name so the registered tool
+    # name is the same as the workspace directory.
     assert sorted(preset.tools._tools.keys()) == [
-        "check_license",
+        "check_license_compat",
         "check_package",
-        "detect_files",
+        "detect_dep_files",
         "done",
         "find_alternatives",
         "parse_deps",
@@ -1442,3 +1442,114 @@ def test_dataclass_auto_emit_reproduces_field_state(tmp_path: Path) -> None:
         PermissionDecision.DENY,
         PermissionDecision.ALLOW,
     ]
+
+
+# ── v2 tool.yaml optional-default + _chw_* dynamic-module round-trip ──
+
+
+def test_v2_tool_yaml_default_marks_param_optional(tmp_path: Path) -> None:
+    """``tool.yaml`` parameters declared as
+    ``{name: {type, description, default}}`` (the format every shipped
+    workspace uses) must treat ``default``-bearing entries as optional.
+    Previously the loader fell into the simple-format branch which
+    only recognised the ``"(optional) ..."`` description prefix, so
+    every dict-shaped param was reported missing on dispatch."""
+    from looplet import ToolSpec
+
+    spec = ToolSpec(
+        name="lst",
+        description="d",
+        parameters={
+            "path": {"type": "string", "description": "p"},
+            "depth": {"type": "integer", "description": "d", "default": 2},
+        },
+        execute=lambda **k: k,
+    )
+    assert spec.required_parameters() == ["path"]
+
+
+def test_chw_resource_round_trip_copies_original_source(tmp_path: Path) -> None:
+    """When a hook holds a live instance whose class came from the
+    workspace's own ``_chw_resource_<name>`` dynamic module, the
+    snapshot writer must copy the original ``resources/<name>.py`` file
+    verbatim instead of dropping a None-stub. Catches the case where
+    a workspace defines a custom resource class inline (e.g.
+    ``GreetingLog`` in the hello example)."""
+    src = tmp_path / "src_ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "src_ws"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "resources").mkdir()
+    custom_src = (
+        '"""Custom inline resource — exists only inside this workspace."""\n'
+        "class CustomLog:\n"
+        "    def __init__(self):\n"
+        "        self.entries = []\n"
+        "def build():\n"
+        "    return CustomLog()\n"
+    )
+    (src / "resources/custom_log.py").write_text(custom_src)
+    (src / "hooks" / "00_LogHook").mkdir(parents=True)
+    (src / "hooks/00_LogHook/hook.py").write_text(
+        "class LogHook:\n"
+        "    def __init__(self, *, log): self.log = log\n"
+        "    def to_config(self): return {'log': '@custom_log'}\n"
+    )
+    (src / "hooks/00_LogHook/config.yaml").write_text(
+        'class_name: LogHook\nkwargs:\n  log: "@custom_log"\n'
+    )
+
+    preset = workspace_to_preset(src, strict=True)
+    snap = tmp_path / "snap"
+    ws = preset_to_workspace(preset, snap, name="snap", strict=False)
+    # Resource source must come back verbatim — no None-stub warnings.
+    assert not any("custom_log" in w for w in ws.serialization_warnings), (
+        f"unexpected warnings: {ws.serialization_warnings}"
+    )
+    snap_resource = (snap / "resources" / "custom_log.py").read_text()
+    assert snap_resource == custom_src
+
+    # Reload the snapshot — the LogHook's log attribute must be a fresh
+    # CustomLog instance (not None).
+    reloaded = workspace_to_preset(snap, strict=True)
+    assert type(reloaded.hooks[0].log).__name__ == "CustomLog"
+
+
+def test_chw_hook_inline_class_round_trips(tmp_path: Path) -> None:
+    """When a hook's class is defined inline in the workspace's own
+    ``hooks/<name>/hook.py`` (not subclassing an installed class), the
+    re-snapshot writer must copy the on-disk source instead of falling
+    back to ``class X: pass``."""
+    src = tmp_path / "src_ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "src_ws"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "hooks" / "00_GateHook").mkdir(parents=True)
+    hook_src = (
+        '"""Inline gate hook with a meaningful body."""\n'
+        "class GateHook:\n"
+        "    SENTINEL = 'inline-marker-XYZ'\n"
+        "    def to_config(self): return {}\n"
+    )
+    (src / "hooks/00_GateHook/hook.py").write_text(hook_src)
+
+    preset = workspace_to_preset(src, strict=True)
+    snap = tmp_path / "snap"
+    preset_to_workspace(preset, snap, name="snap", strict=True)
+    snap_hook = (snap / "hooks" / "00_GateHook" / "hook.py").read_text()
+    # Must contain the inline marker — proves source was preserved.
+    assert "inline-marker-XYZ" in snap_hook


### PR DESCRIPTION
## Summary

Ran every shipped `examples/*.workspace/` end-to-end via a scripted `MockLLMBackend` loop + bidirectional snapshot round-trip. **8 frictions surfaced; 6 are real fixes shipped here** (3 library bugs + 1 workspace-content drift + 2 covered by the same fix). The 2 remaining `coder.workspace` snapshot warnings are inherent Python limitations (closure callables in `coder_lib_wiring.py` cannot be re-imported across processes — correctly warned).

## Library bugs fixed

### 1. `tool.yaml` parameters with `default:` were treated as required

Every shipped workspace declares params as `{name: {type, description, default?}}`, but `ToolSpec.required_parameters()` only recognised JSON Schema's `required: [...]` list or the simple-format `'(optional) ...'` description prefix. Dict-shaped descriptors fell into the simple-format branch and `str({...})` never starts with `(optional)`, so dispatch rejected calls that omitted any default-bearing kwarg.

**Fix:** added a third branch — dict descriptor with no `default` key → required; with one → optional.

### 2. Workspace-defined inline classes lost their source on re-snapshot

`_import_module_from_path` did not register the loaded module in `sys.modules`, so `inspect.getmodule(cls)` / `inspect.getsource(cls)` returned None for any class defined inline in `hooks/<name>/hook.py` or `resources/<name>.py`. The writer's MRO walk found no importable ancestor (the class was inline, not a subclass) and dropped to the `# AUTOGENERATED PLACEHOLDER` branch, producing `class X: pass`.

**Fix:** register dynamically-loaded modules in `sys.modules` so `inspect` can find their `__file__`. The fallback module-source dump in step 3 of `_render_hook_source` now actually fires for inline workspace classes.

### 3. Workspace-defined resources lost their original `def build()` on re-snapshot

Auto-emit rebuilt them via the dataclass / class branches, which lose closure state, custom `runtime=` handling, and the original list/dict factory shape.

**Fix:** at the top of `_write_resources_for_refs`, when the live instance (or every list/tuple element) traces back to a `_chw_resource_<name>` module, copy the original `resources/<name>.py` verbatim. Same pre-pass added to `_write_tool` for tools whose `execute` came from `_chw_tool_<name>` (caught after the `sys.modules` registration change exposed the synthetic module name).

## Workspace content fixes

### 4. `dep_doctor.workspace` tool.yaml name drift

- `tools/check_license_compat/tool.yaml` declared `name: check_license`
- `tools/detect_dep_files/tool.yaml` declared `name: detect_files`

Both now match the directory name (and the `dep_doctor_lib` symbol). Test `test_dep_doctor_workspace_loads` updated to expect the correct names.

## Tests (+3)

- `test_v2_tool_yaml_default_marks_param_optional`
- `test_chw_resource_round_trip_copies_original_source`
- `test_chw_hook_inline_class_round_trips`

**1595 tests pass** (was 1592 + 3 new). Lint + pyright clean.

## Verification

End-to-end dogfood script (not committed): hello / threat_intel / dep_doctor / git_detective / coder all load + scripted-loop dispatch + snapshot round-trip without warnings. The 2 remaining `coder.workspace` snapshot warnings are inherent Python limitations:

- `build_default_memory_sources(workspace, max_steps)` returns `CallableMemorySource(fn=lambda state: ...)` that closes over `project_ctx` / `max_steps` — fundamentally non-portable.
- `make_test_collector(workspace)` returns a closure for the same reason.

Both are correctly warned in loose mode and would raise in strict mode.
