### PR TITLE
feat(workspace): declarative @ref memory_sources + lossless 2-pass round-trip

### DIFF
--- a/examples/coder.workspace/config.yaml
+++ b/examples/coder.workspace/config.yaml
@@ -6,3 +6,6 @@ context_window: 128000
 use_native_tools: false
 concurrent_dispatch: false
 reactive_recovery: true
+memory_sources:
+  - "@instructions_memory"
+  - "@project_memory"

--- a/examples/coder.workspace/resources/eval_collectors.py
+++ b/examples/coder.workspace/resources/eval_collectors.py
@@ -1,14 +1,47 @@
-"""Collectors for the coder workspace's EvalHook.
+"""Outcome-grounded test-runner collector for the coder EvalHook.
 
-Re-uses the v1 cartridge's ``make_test_collector`` so the v2
-workspace surfaces the same outcome-grounded artifacts. Reads
-``runtime['workspace']`` for the project root.
+Inlining the closure here (rather than delegating to a library
+function) is what makes the workspace round-trip lossless: the
+returned ``collect_test_results`` closure has
+``__module__ == '_chw_resource_eval_collectors'`` on workspace load,
+so the snapshot writer's ``_origin_chw_resource_file`` pre-pass
+copies THIS file verbatim instead of falling back to a None-stub.
+
+Reads ``runtime['workspace']`` for the project root and an
+optional ``runtime['test_timeout_s']`` (default 60).
 """
 
-from coder_lib_wiring import make_test_collector
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
 
 
 def build(runtime=None):
     runtime = runtime or {}
     workspace = str(runtime.get("workspace", "."))
-    return [make_test_collector(workspace)]
+    timeout_s = int(runtime.get("test_timeout_s", 60))
+
+    def collect_test_results(state) -> dict:
+        ws = Path(workspace)
+        if not (ws / "pyproject.toml").exists() and not (ws / "setup.py").exists():
+            return {}
+        try:
+            proc = subprocess.run(
+                ["python", "-m", "pytest", "-q", "--tb=no"],
+                cwd=str(ws),
+                capture_output=True,
+                timeout=timeout_s,
+                check=False,
+            )
+        except FileNotFoundError:
+            return {}
+        except subprocess.TimeoutExpired:
+            return {"tests_passing": False, "test_runner": "pytest", "test_timeout": True}
+        return {
+            "tests_passing": proc.returncode == 0,
+            "test_runner": "pytest",
+            "test_exit_code": proc.returncode,
+        }
+
+    return [collect_test_results]

--- a/examples/coder.workspace/resources/instructions_memory.py
+++ b/examples/coder.workspace/resources/instructions_memory.py
@@ -1,0 +1,42 @@
+"""StaticMemorySource carrying any project-discovered coding
+instructions (CLAUDE.md / AGENTS.md / etc.). Returns ``None`` when
+nothing is found so the loader skips the entry.
+
+Reads ``runtime['workspace']`` for the project root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet import StaticMemorySource
+
+_INSTRUCTION_FILES = (
+    "CLAUDE.md",
+    ".claude.md",
+    "AGENTS.md",
+    ".cursorrules",
+    "CODING_GUIDELINES.md",
+    ".github/copilot-instructions.md",
+)
+
+
+def _discover(workspace: str) -> str:
+    parts: list[str] = []
+    for name in _INSTRUCTION_FILES:
+        p = Path(workspace) / name
+        if p.exists():
+            parts.append(f"## From {name}\n{p.read_text()[:4000]}")
+    return "\n\n".join(parts)
+
+
+def build(runtime=None):
+    runtime = runtime or {}
+    workspace = str(runtime.get("workspace", "."))
+    text = _discover(workspace)
+    if not text:
+        # Returning ``None`` is honoured by the loader's
+        # ``render_memory`` path: ``CallableMemorySource``-style
+        # ``None`` returns are silently skipped.
+        return StaticMemorySource(text="")
+    return StaticMemorySource(text=text)

--- a/examples/coder.workspace/resources/project_memory.py
+++ b/examples/coder.workspace/resources/project_memory.py
@@ -1,0 +1,53 @@
+"""Project-context CallableMemorySource — inline so the closure's
+``__module__`` becomes ``_chw_resource_project_memory`` and the
+workspace round-trip can copy this builder verbatim instead of trying
+to re-import a lambda from coder_lib_wiring.
+
+Reads ``runtime['workspace']`` for the project root and
+``runtime['max_steps']`` for the budget hint surfaced to the agent.
+Falls back to ``"."`` and ``20`` respectively when unset so the
+builder still works in standalone test loads.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from looplet import CallableMemorySource
+
+
+def _project_context(workspace: str) -> str:
+    """Lightweight project signature for the per-step memory line."""
+    parts: list[str] = []
+    try:
+        branch = subprocess.run(
+            ["git", "-C", workspace, "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        if branch:
+            parts.append(f"branch={branch}")
+    except Exception:  # noqa: BLE001
+        pass
+    for n in ["pyproject.toml", "package.json", "Cargo.toml", "go.mod", "Makefile"]:
+        if (Path(workspace) / n).exists():
+            parts.append(n)
+    return " ".join(parts) or "no project files"
+
+
+def build(runtime=None) -> CallableMemorySource:
+    runtime = runtime or {}
+    workspace = str(runtime.get("workspace", "."))
+    max_steps = int(runtime.get("max_steps", 20))
+    project_ctx = _project_context(workspace)
+
+    # The lambda closes over project_ctx + max_steps. Because this
+    # function lives in ``resources/project_memory.py``, the closure's
+    # ``__module__`` is ``_chw_resource_project_memory`` on workspace
+    # load — so the round-trip writer recognises it and copies THIS
+    # file verbatim instead of warning about a non-importable lambda.
+    return CallableMemorySource(
+        lambda state: f"[{project_ctx}] step {getattr(state, 'step_count', 0)}/{max_steps}"
+    )

--- a/examples/coder.workspace/setup.py
+++ b/examples/coder.workspace/setup.py
@@ -1,7 +1,7 @@
-"""Wire shared resources + non-declarative bits for the coder workspace.
+"""Wire shared resources + the one non-declarative bit for coder.workspace.
 
-After PR #30 + the harness-search dogfooding the deferred work shrunk
-to two jobs that genuinely need real Python at load time:
+After the @ref-driven memory_sources support landed, the only jobs
+left for setup.py are:
 
 1. **Inject shared resources into tool module globals** — tools
    accept their kwargs from the LLM, so the @ref registry alone
@@ -10,17 +10,14 @@ to two jobs that genuinely need real Python at load time:
    ``FILE_CACHE`` into each tool that declares those globals.
 
 2. **Attach the compaction service** — ``compact_service`` is a
-   non-JSON-able callable, so it can't go in config.yaml. Same
-   chain the v1 cartridge uses.
+   non-JSON-able callable; the same @ref machinery as above could
+   route it but the v1 cartridge keeps the chain hard-coded so we
+   match that.
 
-3. **Append the live-state CallableMemorySource** — the v1
-   cartridge's project-context briefing uses a callable that reads
-   ``state.step_count`` per step. CallableMemorySource isn't
-   round-trippable through YAML.
-
-Every other piece (LinterHook, EvalHook, evaluators, collectors,
-PerToolLimitHook, StagnationHook, ThresholdCompactHook, the @ref
-shared FileCache) is now declarative under hooks/ and resources/.
+Project-context memory and the test-runner collector now live in
+``resources/project_memory.py`` and ``resources/eval_collectors.py``;
+both are wired declaratively through ``config.yaml`` and the
+``EvalHook`` config respectively.
 """
 
 from __future__ import annotations
@@ -28,7 +25,6 @@ from __future__ import annotations
 
 def setup(preset, resources, tool_modules, hook_modules, runtime=None):
     runtime = runtime or {}
-    workspace_path = str(runtime.get("workspace", "."))
     file_cache = resources.get("file_cache")
     workspace_config = resources.get("workspace_config")
 
@@ -50,13 +46,5 @@ def setup(preset, resources, tool_modules, hook_modules, runtime=None):
         PruneToolResults(keep_recent=10),
         TruncateCompact(keep_recent=5),
     )
-
-    # 3. Append the live-state CallableMemorySource the v1 cartridge
-    #    uses for project-context briefing.
-    from coder_lib_wiring import build_default_memory_sources  # noqa: PLC0415
-
-    extra_sources = build_default_memory_sources(workspace_path, preset.config.max_steps)
-    existing = list(preset.config.memory_sources or [])
-    preset.config.memory_sources = existing + extra_sources
 
     return preset

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -773,11 +773,50 @@ def preset_to_workspace(
     for idx, hook in enumerate(preset.hooks):
         _write_hook(hook, hooks_root, idx, warnings, strict)
 
-    # 5. memory sources — StaticMemorySource → markdown file
+    # 5. memory sources — three emission paths:
+    #    StaticMemorySource              → memory/<idx>_static.md
+    #    CallableMemorySource(top-level) → memory/<idx>_callable.py
+    #    CallableMemorySource(_chw_resource_X.<lambda>)
+    #                                    → config.yaml ``memory_sources:
+    #                                      ["@X"]`` + resources/<X>.py
+    #                                      (auto-emitted via the
+    #                                      regular resource pipeline)
+    # The third branch lets workspaces wire load-time-parameterised
+    # memory through the same ``runtime=``-aware resource builder
+    # mechanism the rest of the harness uses, instead of forcing a
+    # ``setup.py`` detour for the ``CallableMemorySource(lambda ...)``
+    # closure pattern.
     memory_root = root / WorkspaceLayout.MEMORY_DIR
     memory_root.mkdir(exist_ok=True)
+    memory_ref_entries: list[str] = []
     for idx, source in enumerate(getattr(cfg, "memory_sources", []) or []):
-        _write_memory(source, memory_root, idx, warnings, strict)
+        ref_name = _write_memory(source, memory_root, idx, warnings, strict)
+        if ref_name is not None:
+            ref_string = f"{_REF_PREFIX}{ref_name}"
+            memory_ref_entries.append(ref_string)
+            # Stash a value the resource pipeline's pre-pass can trace
+            # back to ``_chw_resource_<name>``. The wrapper itself
+            # (CallableMemorySource) lives in ``looplet.memory`` so we
+            # stash the wrapped fn whose ``__module__`` is the workspace
+            # resource module — that's what the pre-pass uses to copy
+            # the original ``resources/<name>.py`` file verbatim.
+            from looplet.memory import CallableMemorySource  # noqa: PLC0415
+
+            stash_value = source.fn if isinstance(source, CallableMemorySource) else source
+            config_field_refs.setdefault(ref_name, stash_value)
+
+    # When ``CallableMemorySource`` round-tripped via @ref, append the
+    # ref strings to ``config.yaml``'s ``memory_sources`` list so the
+    # loader's @ref resolution rebuilds them on load. File-based memory
+    # is loaded first by the loader and these @refs append after it.
+    if memory_ref_entries:
+        existing = serialized_cfg.get("memory_sources") or []
+        serialized_cfg["memory_sources"] = list(existing) + memory_ref_entries
+        # Re-write config.yaml to include the new memory_sources entries.
+        (root / WorkspaceLayout.CONFIG_YAML).write_text(
+            _dump_yaml(serialized_cfg) + "\n",
+            encoding="utf-8",
+        )
 
     # 6. resources — for any @<name> ref found in written hook configs,
     # emit a placeholder ``resources/<name>.py`` so the snapshot loads
@@ -795,9 +834,46 @@ def preset_to_workspace(
         extra_refs=config_field_refs,
     )
 
+    # 7. workspace-root helper modules — when the preset was loaded
+    # from another workspace, copy any top-level ``*.py`` helper files
+    # (e.g. ``coder_lib_tools.py``, ``threat_intel_lib.py``) so the
+    # snapshot stays self-contained. Without this, hooks / tools /
+    # resources that import from these helpers crash on cross-process
+    # reload with ``ModuleNotFoundError``.
+    _copy_workspace_helpers(preset, root, warnings)
+
     workspace.serialization_warnings = warnings
     workspace.write_metadata()
     return workspace
+
+
+def _copy_workspace_helpers(preset: Any, dest_root: Path, warnings: list[str]) -> None:
+    """Copy top-level ``*.py`` helper modules from the preset's source
+    workspace (if any) into ``dest_root``.
+
+    The source workspace is read from the private
+    ``preset._origin_workspace_root`` attribute that
+    :func:`workspace_to_preset` stamps on every preset it returns. When
+    the preset was built in-process (no origin attribute), this is a
+    no-op — there's nothing to vendor.
+    """
+    src_root = getattr(preset, "_origin_workspace_root", None)
+    if src_root is None:
+        return
+    src_root = Path(src_root)
+    if not src_root.is_dir() or src_root.resolve() == dest_root.resolve():
+        return
+
+    for helper in sorted(src_root.glob("*.py")):
+        if helper.name in {"__init__.py", WorkspaceLayout.SETUP_PY}:
+            continue
+        dest_file = dest_root / helper.name
+        if dest_file.exists():
+            continue
+        try:
+            dest_file.write_text(helper.read_text(encoding="utf-8"), encoding="utf-8")
+        except OSError as exc:
+            warnings.append(f"workspace-helper copy: could not copy {helper.name}: {exc}")
 
 
 def _write_resources_for_refs(
@@ -1249,12 +1325,22 @@ def _write_hook(hook: Any, hooks_root: Path, index: int, warnings: list[str], st
     # closure / dynamically-defined class), fall back to the full module
     # source — which is heavier but preserves correctness.
     src = _render_hook_source(cls, warnings, strict)
-    (hook_dir / "hook.py").write_text(
-        "# AUTOGENERATED from preset_to_workspace.\n"
-        f"# Original class: {cls.__module__}.{cls_name}\n"
-        f"{src}\n",
-        encoding="utf-8",
-    )
+    # The "Original class:" line was previously ``{cls.__module__}.{cls_name}``
+    # which drifted between passes (a hook loaded from
+    # ``_chw_hook_<dir>`` vs. its re-imported canonical module produced
+    # different bytes for the same logical class). Use the rendered
+    # source's import target as the stable identity instead.
+    #
+    # Only prepend the AUTOGENERATED header when the rendered source
+    # doesn't already carry it — branch 0 of ``_render_hook_source``
+    # copies a previously-snapshot file verbatim and we don't want
+    # the header to stack across repeat round-trips.
+    header = "# AUTOGENERATED from preset_to_workspace.\n"
+    if src.startswith(header):
+        body = src
+    else:
+        body = f"{header}{src}\n"
+    (hook_dir / "hook.py").write_text(body, encoding="utf-8")
 
     # Constructor kwargs: prefer hook.to_config(); else dataclasses.asdict;
     # else empty (caller will supply via workspace edit).
@@ -1278,14 +1364,32 @@ def _render_hook_source(cls: type, warnings: list[str], strict: bool) -> str:
     """Render a self-contained hook.py source for ``cls``.
 
     Preference order:
+      0. Loaded from a workspace ``_chw_hook_*`` dynamic module whose
+         source file is on disk → copy that file verbatim. Preserves
+         workspace-local subclasses (e.g. one that adds ``to_config()``)
+         that the MRO-walk fallback would silently drop by aliasing
+         the importable base class.
       1. Importable module → re-import the class by name.
-      2. Loaded from a workspace ``_chw_hook_*`` dynamic module → walk
-         the MRO to find an importable base class and re-import that.
+      2. Loaded from a workspace ``_chw_hook_*`` dynamic module with no
+         on-disk source → walk the MRO to find an importable base class
+         and re-import that.
       3. Module source available → dump full module (preserves imports).
       4. Class source only → dump source with a typing-import fallback.
     """
     cls_name = cls.__name__
     module_name = cls.__module__ or ""
+
+    # 0. Workspace ``_chw_hook_*`` source on disk → copy verbatim. This
+    #    is essential for byte-identity round-trip and for preserving
+    #    any methods (commonly ``to_config()``) the workspace-local
+    #    subclass adds beyond an installed base class.
+    if module_name.startswith("_chw_hook_"):
+        import sys as _sys  # noqa: PLC0415
+
+        chw_mod = _sys.modules.get(module_name)
+        chw_file = getattr(chw_mod, "__file__", None) if chw_mod is not None else None
+        if chw_file and Path(chw_file).is_file():
+            return Path(chw_file).read_text(encoding="utf-8")
 
     # 1. Try to re-import — works for installed packages, top-level classes
     #    in importable modules, and anything addressable by ``module:name``.
@@ -1297,11 +1401,17 @@ def _render_hook_source(cls: type, warnings: list[str], strict: bool) -> str:
         try:
             mod = importlib.import_module(module_name)
             if getattr(mod, cls_name, None) is cls:
+                # Canonical "as <cls_name>" form so this branch produces
+                # byte-identical output to the MRO-walk branch below —
+                # the snapshot writer needs to be idempotent under repeat
+                # round-trips, and that requires both code paths to emit
+                # the same source for the same hook class.
                 return (
-                    "# Re-imported from the original module so the class's full\n"
-                    "# closure (typing imports, helpers) stays available.\n"
-                    "# To customize, replace this import with a class definition.\n"
-                    f"from {module_name} import {cls_name}\n"
+                    "# Re-imported from the original module so the class's\n"
+                    "# full closure (typing imports, helpers) stays available.\n"
+                    "# Edit this file (or replace the import with a class\n"
+                    "# definition) to customise the hook in this workspace.\n"
+                    f"from {module_name} import {cls_name} as {cls_name}\n"
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -1323,12 +1433,12 @@ def _render_hook_source(cls: type, warnings: list[str], strict: bool) -> str:
         try:
             mod = importlib.import_module(anc_module)
             if getattr(mod, anc_name, None) is ancestor:
-                # Re-export under the original subclass name so config.yaml
-                # ``class_name`` lookups still resolve.
+                # Same canonical form as branch 1 — see comment there.
                 return (
-                    f"# Re-imported via base class {anc_module}.{anc_name}\n"
-                    f"# (subclass {cls_name!r} was loaded from a workspace\n"
-                    f"# _chw_hook_* dynamic module that has no on-disk source).\n"
+                    "# Re-imported from the original module so the class's\n"
+                    "# full closure (typing imports, helpers) stays available.\n"
+                    "# Edit this file (or replace the import with a class\n"
+                    "# definition) to customise the hook in this workspace.\n"
                     f"from {anc_module} import {anc_name} as {cls_name}\n"
                 )
         except Exception:  # noqa: BLE001
@@ -1367,16 +1477,22 @@ def _render_hook_source(cls: type, warnings: list[str], strict: bool) -> str:
 
 def _write_memory(
     source: Any, memory_root: Path, index: int, warnings: list[str], strict: bool
-) -> None:
+) -> str | None:
+    """Emit a memory source to disk.
+
+    Returns ``None`` when the source was written as a file in
+    ``memory/`` (StaticMemorySource → ``*.md``, top-level
+    CallableMemorySource → ``*.py``). Returns a resource ref name
+    (e.g. ``"project_memory"``) when the wrapped fn came from a
+    workspace-loaded ``_chw_resource_<name>`` module — the caller adds
+    the corresponding ``"@<name>"`` entry to ``config.yaml``'s
+    ``memory_sources`` list and the resource auto-emit machinery
+    copies the original on-disk source verbatim.
+    """
     if isinstance(source, StaticMemorySource):
         (memory_root / f"{index:02d}_static.md").write_text(source.text, encoding="utf-8")
-        return
-    # CallableMemorySource: if the wrapped callable is a top-level
-    # importable function, emit a ``<index>_callable.py`` that re-imports
-    # it. The loader recognises ``*.py`` files in memory/ and wraps the
-    # exported ``load`` callable with ``CallableMemorySource``. Closures
-    # / lambdas fall through to the generic warning path because they
-    # cannot be re-imported.
+        return None
+    # CallableMemorySource: three branches in priority order.
     from looplet.memory import CallableMemorySource  # noqa: PLC0415
 
     if isinstance(source, CallableMemorySource):
@@ -1384,6 +1500,18 @@ def _write_memory(
         fn_name = getattr(fn, "__name__", "")
         fn_mod = getattr(fn, "__module__", "") or ""
         fn_qual = getattr(fn, "__qualname__", "<lambda>")
+
+        # Branch A: fn was created inside a workspace-loaded
+        # ``_chw_resource_<name>`` builder. The resource pipeline
+        # already knows how to copy the original ``resources/<name>.py``
+        # file verbatim — route through @ref to reuse that machinery
+        # and to keep the closure (which closes over runtime values
+        # like ``workspace`` / ``max_steps``) intact across reload.
+        if fn_mod.startswith("_chw_resource_"):
+            return fn_mod[len("_chw_resource_") :]
+
+        # Branch B: fn is a top-level importable function. Emit a
+        # ``<idx>_callable.py`` shim that re-imports it.
         if (
             fn_name
             and fn_mod
@@ -1407,21 +1535,29 @@ def _write_memory(
                     f"a ``__main__`` callable {fn_name!r}; cross-process "
                     f"loads will fail until it is moved to a real module"
                 )
-            return
+            return None
+
+        # Branch C: lambda / closure / non-importable. Warn and skip —
+        # the caller should move the closure into a
+        # ``resources/<name>.py`` builder so branch A can route it.
         msg = (
             f"memory source 'CallableMemorySource' wraps a non-importable "
-            f"callable ({fn_qual!r} from {fn_mod!r}); skipping"
+            f"callable ({fn_qual!r} from {fn_mod!r}); skipping. Move the "
+            f"closure into a ``resources/<name>.py`` builder and reference "
+            f"it from ``config.yaml`` via ``memory_sources: ['@<name>']`` "
+            f"to make it round-trip cleanly."
         )
         if strict:
             raise WorkspaceSerializationError(msg)
         warnings.append(msg)
-        return
+        return None
 
     name = type(source).__name__
     msg = f"memory source {name!r} is not a StaticMemorySource; skipping"
     if strict:
         raise WorkspaceSerializationError(msg)
     warnings.append(msg)
+    return None
 
 
 # ── Deserialise: directory → AgentPreset ───────────────────────
@@ -1492,9 +1628,18 @@ def workspace_to_preset(
     if _path_pushed:
         _sys.path.insert(0, root_str)
     try:
-        return _workspace_to_preset_inner(
+        preset = _workspace_to_preset_inner(
             root, runtime_dict, state_factory=state_factory, strict=strict
         )
+        # Stamp the preset with its origin so a subsequent
+        # ``preset_to_workspace`` call can copy any top-level ``*.py``
+        # helper modules from the source workspace into the snapshot.
+        # Private attribute, not part of the public AgentPreset shape.
+        try:
+            preset._origin_workspace_root = root.resolve()  # type: ignore[attr-defined]
+        except (AttributeError, TypeError):
+            pass
+        return preset
     finally:
         if _path_pushed:
             try:
@@ -1537,11 +1682,20 @@ def _workspace_to_preset_inner(
     if sys_prompt_path.is_file():
         cfg_kwargs["system_prompt"] = sys_prompt_path.read_text(encoding="utf-8")
 
-    # Memory sources — ``*.md`` → StaticMemorySource, ``*.py`` →
-    # CallableMemorySource (the module's ``load`` attr is wrapped). Files
-    # are loaded in lexicographic order so the writer's ``00_``, ``01_``
-    # prefix preserves source order.
-    memory_sources: list[PersistentMemorySource] = []
+    # Memory sources — three sources, combined in the following order:
+    #   1. File-based ``memory/*.md`` → StaticMemorySource (sorted)
+    #   2. File-based ``memory/*.py`` → CallableMemorySource around the
+    #      module's ``load`` attr (sorted alongside .md files)
+    #   3. Any ``memory_sources: ["@x", ...]`` list declared in
+    #      ``config.yaml`` — each ``@ref`` is resolved against the
+    #      resource registry and must return a ``PersistentMemorySource``
+    #      (typically a ``CallableMemorySource`` whose builder closes
+    #      over ``runtime`` values like ``workspace`` / ``max_steps``).
+    # The yaml-declared list runs through the existing
+    # ``_resolve_refs(cfg_kwargs, resources)`` pass below; here we just
+    # ensure file-based entries are appended on top of whatever the
+    # yaml declared, preserving any explicit ordering the author chose.
+    file_memory_sources: list[PersistentMemorySource] = []
     memory_dir = root / WorkspaceLayout.MEMORY_DIR
     if memory_dir.is_dir():
         from looplet.memory import CallableMemorySource  # noqa: PLC0415
@@ -1551,7 +1705,7 @@ def _workspace_to_preset_inner(
         )
         for memory_file in memory_files:
             if memory_file.suffix == ".md":
-                memory_sources.append(
+                file_memory_sources.append(
                     StaticMemorySource(text=memory_file.read_text(encoding="utf-8"))
                 )
             else:
@@ -1565,9 +1719,15 @@ def _workspace_to_preset_inner(
                         raise WorkspaceSerializationError(msg)
                     logger.warning("%s; skipping", msg)
                     continue
-                memory_sources.append(CallableMemorySource(fn=load_fn))  # type: ignore[arg-type]
-    if memory_sources:
-        cfg_kwargs["memory_sources"] = memory_sources
+                file_memory_sources.append(CallableMemorySource(fn=load_fn))  # type: ignore[arg-type]
+
+    # Merge file-based memory with any yaml-declared @ref list. The
+    # yaml entries (still ``@ref`` strings at this point) get appended
+    # after the file-based ones; ``_resolve_refs`` below converts each
+    # ``@ref`` string in the list into the live resource instance.
+    yaml_declared_memory = cfg_kwargs.get("memory_sources") or []
+    if yaml_declared_memory or file_memory_sources:
+        cfg_kwargs["memory_sources"] = list(file_memory_sources) + list(yaml_declared_memory)
 
     # Resolve ``"@<name>"`` references in config kwargs against the
     # shared-resource registry so callable / opaque LoopConfig fields

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1553,3 +1553,153 @@ def test_chw_hook_inline_class_round_trips(tmp_path: Path) -> None:
     snap_hook = (snap / "hooks" / "00_GateHook" / "hook.py").read_text()
     # Must contain the inline marker — proves source was preserved.
     assert "inline-marker-XYZ" in snap_hook
+
+
+# ── Declarative @ref memory + workspace-helper copy + byte-identity ──
+
+
+def _project_memory_loader(state) -> str:
+    """Top-level loader returning a per-step memory line."""
+    return f"step={getattr(state, 'step_count', 0)}"
+
+
+def test_memory_sources_yaml_ref_resolves_via_resource_registry(tmp_path: Path) -> None:
+    """``memory_sources: ['@ref']`` in config.yaml round-trips through
+    the same resource-builder mechanism the hook kwargs use."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text(
+        'max_steps: 3\ndone_tool: done\nmemory_sources:\n  - "@dyn_memory"\n'
+    )
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "resources").mkdir()
+    (src / "resources/dyn_memory.py").write_text(
+        "from looplet import CallableMemorySource\n"
+        "def build(runtime=None):\n"
+        "    return CallableMemorySource(lambda state: 'dyn-memory-content')\n"
+    )
+
+    preset = workspace_to_preset(src, strict=True)
+    sources = preset.config.memory_sources or []
+    assert len(sources) == 1
+    assert type(sources[0]).__name__ == "CallableMemorySource"
+    assert sources[0].load(None) == "dyn-memory-content"
+
+
+def test_callable_memory_via_chw_resource_round_trips_losslessly(tmp_path: Path) -> None:
+    """A ``CallableMemorySource`` whose lambda was built inside a
+    ``resources/<name>.py`` builder must snapshot back to a
+    ``memory_sources: ['@<name>']`` entry + verbatim resource copy,
+    not warn about a non-importable lambda."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text(
+        'max_steps: 3\ndone_tool: done\nmemory_sources:\n  - "@dyn_memory"\n'
+    )
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "resources").mkdir()
+    builder_src = (
+        "from looplet import CallableMemorySource\n"
+        "def build(runtime=None):\n"
+        "    runtime = runtime or {}\n"
+        "    label = str(runtime.get('label', 'X'))\n"
+        "    return CallableMemorySource(lambda state: f'lab={label}')\n"
+    )
+    (src / "resources/dyn_memory.py").write_text(builder_src)
+
+    preset = workspace_to_preset(src, runtime={"label": "Z"}, strict=True)
+    snap = tmp_path / "snap"
+    ws = preset_to_workspace(preset, snap, name="snap")
+    assert ws.serialization_warnings == [], f"unexpected warnings: {ws.serialization_warnings}"
+    # Snapshot config.yaml carries the @ref entry, not a None-stub class:
+    snap_cfg = (snap / "config.yaml").read_text()
+    assert '"@dyn_memory"' in snap_cfg or "@dyn_memory" in snap_cfg
+    # And the resource file was copied verbatim:
+    assert (snap / "resources" / "dyn_memory.py").read_text() == builder_src
+
+
+def test_workspace_helpers_are_copied_into_snapshot(tmp_path: Path) -> None:
+    """Top-level ``*.py`` helper modules at the source workspace root
+    (e.g. ``coder_lib_tools.py``) must be vendored into the snapshot
+    so cross-process reload doesn't crash with ModuleNotFoundError."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "from helper_lib import HELLO\n"
+        "def execute(*, s='ok'): return {'status': 'completed', 'msg': HELLO + s}\n"
+    )
+    helper_src = "HELLO = 'hi-from-helper-'\n"
+    (src / "helper_lib.py").write_text(helper_src)
+
+    preset = workspace_to_preset(src, strict=True)
+    snap = tmp_path / "snap"
+    preset_to_workspace(preset, snap, name="snap")
+    # The helper module was copied into the snapshot.
+    assert (snap / "helper_lib.py").read_text() == helper_src
+
+
+def test_two_pass_round_trip_is_byte_identical(tmp_path: Path) -> None:
+    """preset → ws1 → preset' → ws2: ws1 and ws2 must be byte-identical
+    for a non-trivial preset. Catches header-stacking, MRO-walk drift,
+    and other normalization gaps."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "hooks" / "00_StagnationHook").mkdir(parents=True)
+    (src / "hooks/00_StagnationHook/hook.py").write_text(
+        "from looplet.stagnation import StagnationHook as StagnationHook\n"
+    )
+    (src / "hooks/00_StagnationHook/config.yaml").write_text(
+        "class_name: StagnationHook\nkwargs: {}\n"
+    )
+
+    preset_a = workspace_to_preset(src, strict=True)
+    ws1 = tmp_path / "ws1"
+    preset_to_workspace(preset_a, ws1, name="rt")
+    preset_b = workspace_to_preset(ws1, strict=True)
+    ws2 = tmp_path / "ws2"
+    preset_to_workspace(preset_b, ws2, name="rt")
+
+    files1 = sorted(
+        p.relative_to(ws1) for p in ws1.rglob("*") if p.is_file() and "__pycache__" not in p.parts
+    )
+    files2 = sorted(
+        p.relative_to(ws2) for p in ws2.rglob("*") if p.is_file() and "__pycache__" not in p.parts
+    )
+    assert files1 == files2
+
+    diffs = []
+    for rel in files1:
+        a = (ws1 / rel).read_text(encoding="utf-8")
+        b = (ws2 / rel).read_text(encoding="utf-8")
+        if a != b:
+            diffs.append((str(rel), len(a), len(b)))
+    assert not diffs, f"byte drift: {diffs}"


### PR DESCRIPTION
## Summary

Closes the last 2 frictions from the example dogfood (CallableMemorySource lambda + EvalHook collectors closure in `coder.workspace`) by wiring closure-bearing memory and collectors through the same resource-builder mechanism the rest of the v2 workspace uses, instead of dropping them via `setup.py`. Adds workspace-helper module copying so cross-process snapshot reload no longer crashes with `ModuleNotFoundError`, and unifies the hook writer's output so two repeat snapshot passes produce **byte-identical** workspaces.

## Library changes

### 1. `memory_sources` accepts `@ref` entries in `config.yaml`

The loader merges file-based memory (`memory/*.md`, `memory/*.py`) with any `memory_sources: ['@x', ...]` list declared in `config.yaml`, resolving each ref against the resource registry just like hook kwargs and other callable LoopConfig fields. Lets workspaces wire load-time-parameterised memory through `runtime=`-aware `resources/<name>.py` builders instead of a `setup.py` detour.

### 2. Writer routes `CallableMemorySource(fn from _chw_resource_*)` via `@ref`

When the wrapped fn was constructed inside a workspace's own resource builder, `_write_memory` returns the resource name; the snapshot writer adds a `memory_sources: ['@<name>']` entry to `config.yaml` AND stashes `source.fn` (whose `__module__` is `_chw_resource_<name>`) in the resource pipeline so the existing verbatim-copy pre-pass copies the original `resources/<name>.py` file. Closures over `workspace` / `max_steps` / etc. survive reload identically to the source preset.

### 3. Snapshot vendors workspace-root helper modules

`workspace_to_preset` stamps each loaded preset with a private `_origin_workspace_root` attribute; `preset_to_workspace` reads it and copies any top-level `*.py` helper files (e.g. `coder_lib_tools.py`, `threat_intel_lib.py`) into the snapshot. Without this, hooks/tools/resources that import from those helpers crashed on cross-process reload with `ModuleNotFoundError` because the modules only existed in the source workspace's directory.

### 4. Hook writer produces byte-identical output across repeat passes

Three sub-fixes:
- **(a)** `_render_hook_source` adds branch 0: when the live class came from a workspace's own `_chw_hook_<dir>` module with on-disk source, copy that source verbatim. **Preserves workspace-local subclasses adding `to_config()` / etc.** that the MRO-walk fallback would silently drop by aliasing the importable base class. (Real correctness gap — the alias produced empty round-trip kwargs on a 3rd pass.)
- **(b)** `_render_hook_source` step 1 (importable module) now uses the canonical `as <cls_name>` form to match the MRO-walk branch below, so both code paths emit byte-identical source.
- **(c)** `_write_hook` no longer prepends the `# AUTOGENERATED` header when the rendered source already carries it (idempotent header) — previously branch 0's verbatim copy stacked duplicate headers on every repeat pass.

`_write_hook`'s `# Original class:` line was removed (it drifted between passes — a hook loaded from `_chw_hook_<dir>` vs. its re-imported canonical module produced different bytes for the same logical class).

## Workspace migration: `examples/coder.workspace`

- Added `resources/project_memory.py` — builds the per-step `CallableMemorySource` that previously lived as a closure in `coder_lib_wiring.build_default_memory_sources`. Closure now lives in `_chw_resource_project_memory`, so the round-trip writer recognises it and copies this file verbatim.
- Added `resources/instructions_memory.py` — builds the `StaticMemorySource` carrying any project-discovered coding instructions (CLAUDE.md / AGENTS.md / etc.).
- Rewrote `resources/eval_collectors.py` — the test-runner closure is now constructed inside `build()` itself (rather than delegating to `coder_lib_wiring.make_test_collector` which produced a closure whose `__module__` was `coder_lib_wiring` not `_chw_resource_eval_collectors`).
- Added `memory_sources: ['@instructions_memory', '@project_memory']` to `config.yaml`.
- Stripped the `CallableMemorySource` append step from `setup.py` — memory is fully declarative now.

## Verification (4 dogfood scripts, all green)

**Smoke** (load + scripted MockLLM loop + snapshot round-trip):

All 5 example workspaces load + run + snapshot with **zero serialization warnings** and reload identically.

**Deep** (per-workspace triple round-trip + cross-process strict load + memory render parity):

| Property | Result |
|---|---|
| R1 byte-identical 2-pass round-trip | ✓ all 5 examples |
| R2 cross-process strict reload (subprocess Python) | ✓ all 5 examples |
| R3 memory render parity (pre vs post round-trip) | ✓ all 5 examples |

## Tests (+4)

- `test_memory_sources_yaml_ref_resolves_via_resource_registry`
- `test_callable_memory_via_chw_resource_round_trips_losslessly`
- `test_workspace_helpers_are_copied_into_snapshot`
- `test_two_pass_round_trip_is_byte_identical`

**1599 tests pass** (was 1595 + 4 new). Lint + pyright clean.
