### PR TITLE
refactor: consolidate naming — drop "cartridge" / "CHW" / "v2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Naming consolidation.** Dropped the legacy "cartridge" /
+  "Composable Harness Workspace (CHW)" / "workspace v2" terminology
+  in favour of the two canonical names already used in code:
+  `Workspace` (the round-trippable directory format from
+  `looplet.workspace`) and `SkillBundle` (the runnable folder format
+  from `looplet.bundles`). All docstrings, doc pages, README, and
+  comments now use these names. The `ClaudeSkillCompatibility.level`
+  string `"looplet-cartridge"` is renamed to `"looplet-bundle"` —
+  the only minor breaking change in this consolidation. Renamed
+  `tests/test_cartridge_round_trip_smoke.py` to
+  `tests/test_skill_bundle_round_trip_smoke.py`. No behavioural
+  change; the `_chw_*` synthetic module-name prefixes (used
+  internally by the workspace loader) keep their names.
+
 ### Removed (BREAKING)
 
 - **All `setup.py` files removed from shipped example workspaces.**

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every looplet agent turn is the same small mechanism:
 4. State records the step.
 5. The loop yields a `Step` back to your `for` loop.
 
-That is the whole mental model. Presets, skills, cartridges, provenance,
+That is the whole mental model. Presets, skills, bundles, provenance,
 native tool calling, and evals are useful layers around this mechanism;
 they do not replace it.
 
@@ -56,7 +56,7 @@ for step in composable_loop(llm=llm, tools=tools, state=state, config=config, ho
 ```
 
 Start with ordinary Python code when you want full control. Start with a
-cartridge when you want to run or share a packaged capability:
+bundle when you want to run or share a packaged capability:
 
 ```bash
 python -m looplet run ./skills/coder "Fix the tests" --workspace .
@@ -273,7 +273,7 @@ python -m looplet.examples.data_agent --resume                    # resume from 
 python -m looplet.examples.data_agent --scripted --auto-approve   # no model required
 ```
 
-Runnable cartridges package the same primitives behind a portable folder:
+Runnable bundles package the same primitives behind a portable folder:
 
 ```bash
 python -m looplet list-bundles tests/fixtures --json
@@ -326,7 +326,7 @@ Not a usage reference.
 | --- | --- |
 | [docs/tutorial.md](docs/tutorial.md) | Build your first agent in 5 steps |
 | [docs/hooks.md](docs/hooks.md) | Writing and composing hooks |
-| [docs/skills.md](docs/skills.md) | Lazy skills, runnable cartridges, blueprints, and Claude Skill wrapping |
+| [docs/skills.md](docs/skills.md) | Lazy skills, runnable bundles, blueprints, and Claude Skill wrapping |
 | [docs/evals.md](docs/evals.md) | pytest-style agent evaluation |
 | [docs/provenance.md](docs/provenance.md) | Capturing prompts + trajectories |
 | [docs/recipes.md](docs/recipes.md) | Ollama, OTel, MCP, cost accounting, checkpoints |

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ Every turn follows the same five-step story:
 4. State records the step.
 5. The loop yields a `Step` to your code.
 
-Cartridges, presets, provenance, and evals all compile into this same
+Bundles, presets, provenance, and evals all compile into this same
 mechanism.
 
 ```mermaid
@@ -142,7 +142,7 @@ need. The loop uses `hasattr` — no base class, no registration.
    subclassing a framework.
 3. **Keep the trace.** The same step stream powers live debugging,
    provenance, replay, and pytest-style evals.
-4. **Package capabilities.** Skills and cartridges let you share a runnable
+4. **Package capabilities.** Skills and bundles let you share a runnable
     agent folder while keeping the core loop inspectable Python.
 
 ## Why looplet?
@@ -255,7 +255,7 @@ looplet difference: every lookup, warning, and final claim is visible as
 a step you can log, gate, replay, or evaluate.
 
 ```bash
-# Load the v2 workspace; pass --workspace to point at the project to audit.
+# Load the workspace; pass --workspace to point at the project to audit.
 OPENAI_BASE_URL=http://127.0.0.1:11434/v1 \
 OPENAI_API_KEY=ollama OPENAI_MODEL=llama3.1 \
 python -c "from looplet import workspace_to_preset; \
@@ -265,7 +265,7 @@ p = workspace_to_preset('examples/dep_doctor.workspace', runtime={'workspace': '
 Then explore `examples/git_detective.workspace/` for codebase-health reports,
 `examples/threat_intel.workspace/` for local-first security briefings, and
 `examples/coder.workspace/` for a coding-agent reference implementation —
-each is a self-contained Composable Harness Workspace under
+each is a self-contained Workspace under
 [`examples/`](https://github.com/hsaghir/looplet/tree/master/examples)
 that round-trips losslessly with an `AgentPreset` via `preset_to_workspace`
 / `workspace_to_preset`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -154,9 +154,9 @@ Run against any saved trajectory:
 looplet eval traces/ --evals eval_my_agent.py --threshold 0.7 -v
 ```
 
-## 7. Run or share a cartridge
+## 7. Run or share a bundle
 
-A cartridge is a portable skill folder that builds normal looplet
+A bundle is a portable skill folder that builds normal looplet
 primitives. It is the beginner-friendly way to run or share a complete
 capability without hiding the underlying loop.
 
@@ -166,7 +166,7 @@ python -m looplet blueprint ./skills/coder --workspace .
 python -m looplet export-code ./skills/coder coder_agent.py
 ```
 
-Advanced users can package an importable looplet factory as a cartridge:
+Advanced users can package an importable looplet factory as a bundle:
 
 ```bash
 python -m looplet package my_agent:build ./skills/my-agent \
@@ -188,7 +188,7 @@ python -m looplet wrap-claude-skill ./claude-skills/pdf ./skills/pdf
 
 - [Tutorial](tutorial.md) — hooks, compaction, crash-resume, approval, in five steps.
 - [Recipes](recipes.md) — Ollama, MCP, cost accounting, multi-model routing.
-- [Skills](skills.md) — lazy skills, runnable cartridges, blueprints, and Claude Skill wrapping.
+- [Skills](skills.md) — lazy skills, runnable bundles, blueprints, and Claude Skill wrapping.
 - [Pitfalls](pitfalls.md) — ten sharp edges worth knowing.
 - [Hooks reference](hooks.md) — every extension point, every signature.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -75,10 +75,10 @@ same observable, hook-based execution path.
 ## Runnable Bundles
 
 A simple skill is an instruction payload. A runnable bundle is a full
-domain cartridge: `SKILL.md` plus a trusted Python entrypoint that builds
+domain bundle: `SKILL.md` plus a trusted Python entrypoint that builds
 normal looplet primitives.
 
-The loop story does not change when you use a cartridge: the cartridge
+The loop story does not change when you use a bundle: the bundle
 builds tools, hooks, config, and state; the LLM proposes a tool call; the
 registry dispatches it; hooks observe or steer; state records the step; and
 the loop yields a `Step`.
@@ -130,7 +130,7 @@ explicit trace directory, traces are written under
 `.looplet/traces/<skill-name>-<id>/` inside the runtime workspace. Pass
 `provenance=False` to disable this when you need an unrecorded run.
 
-The CLI can run a cartridge directly:
+The CLI can run a bundle directly:
 
 ```bash
 python -m looplet run ./skills/coder "Fix the tests" --workspace .
@@ -138,7 +138,7 @@ python -m looplet run ./skills/coder "Fix the tests" --workspace . --trace-dir .
 python -m looplet run ./skills/coder "Fix the tests" --workspace . --no-trace
 ```
 
-Cartridges can also be discovered without importing their Python
+Bundles can also be discovered without importing their Python
 entrypoints. This is the lightweight index path for product UIs and agent
 menus: it reads `SKILL.md`, checks whether the declared entrypoint exists,
 and returns `BundleCard` records.
@@ -160,11 +160,11 @@ python -m looplet list-bundles ./skills --include-invalid
 
 By default, instruction-only Claude Skills are skipped because they do not
 have a runnable entrypoint yet. Pass `--include-invalid` when you want to
-surface folders that look like cartridges but need repair or wrapping.
+surface folders that look like bundles but need repair or wrapping.
 
 Bundles may optionally expose `scripted_responses()` for deterministic
 dogfood runs and `render_step(step)` for domain-specific terminal output.
-For product cartridges that need exact terminal behavior, a bundle can also
+For product bundles that need exact terminal behavior, a bundle can also
 expose `run(...)`. In that case `looplet run` delegates the whole shell to
 the bundle while still passing the default provenance setting and trace
 directory options through. The delegated callable receives keyword-only
@@ -187,7 +187,7 @@ def run(
 
 ## Blueprints and round trips
 
-Cartridges can be inspected as versioned `AgentBlueprint` records. A
+Bundles can be inspected as versioned `AgentBlueprint` records. A
 blueprint is a stable structural view of the built `AgentPreset`: config,
 tool schemas, hook order, memory source types, state type, metadata, and
 source location. It is intentionally not a Python decompiler; arbitrary
@@ -203,10 +203,10 @@ print(blueprint.fingerprint())
 ```
 
 Use `export_bundle_to_library_code()` when a beginner wants to move from a
-cartridge command to normal Python call sites. The generated module is an
-exact local wrapper around the cartridge and includes the captured blueprint
+bundle command to normal Python call sites. The generated module is an
+exact local wrapper around the bundle and includes the captured blueprint
 for inspection. Because it preserves behavior by loading the original
-cartridge path, keep that cartridge available or re-export after moving it:
+bundle path, keep that bundle available or re-export after moving it:
 
 ```python
 from looplet import export_bundle_to_library_code
@@ -222,7 +222,7 @@ python -m looplet export-code ./skills/coder coder_agent.py --function-name buil
 ```
 
 Use `package_agent_factory_as_bundle()` when an advanced user has an
-importable looplet factory and wants a runnable cartridge entrypoint tied
+importable looplet factory and wants a runnable bundle entrypoint tied
 to that factory reference:
 
 ```python
@@ -244,21 +244,21 @@ python -m looplet package my_agent:build ./skills/my-agent \
   --description "Run my custom looplet agent."
 ```
 
-`compare_blueprints()` checks whether two factories or cartridges build the
+`compare_blueprints()` checks whether two factories or bundles build the
 same looplet structure. This is the programmatic equivalent of the coder
-parity checks: compare the generated wrapper or packaged cartridge against
+parity checks: compare the generated wrapper or packaged bundle against
 the original before you trust the conversion.
 
 Generated factory packages preserve exact behavior by importing the factory
 reference. To move them to another environment, ship the referenced module
-and its dependencies alongside the cartridge or install them in that
+and its dependencies alongside the bundle or install them in that
 environment.
 
 ## Claude Skill compatibility
 
 looplet can load Claude/Agent Skills-style folders as lazy skills today.
 It can also wrap instruction-only Claude Skills as runnable looplet
-cartridges:
+bundles:
 
 ```python
 from looplet import claude_skill_compatibility, wrap_claude_skill_as_bundle
@@ -276,14 +276,14 @@ python -m looplet wrap-claude-skill ./claude-skills/pdf ./skills/pdf
 
 Compatibility levels are explicit:
 
-- `instruction-only`: can be wrapped and run as a minimal looplet cartridge.
+- `instruction-only`: can be wrapped and run as a minimal looplet bundle.
 - `resources-present`: resources are copied, but remain inert unless exposed
   as normal looplet tools.
 - `scripts-present`: instructions can be wrapped, but scripts require an
   explicit tool adapter before looplet can claim exact behavior.
-- `looplet-cartridge`: the folder already declares a looplet entrypoint;
-  wrapping copies the cartridge as-is and preserves that entrypoint.
+- `looplet-bundle`: the folder already declares a looplet entrypoint;
+  wrapping copies the bundle as-is and preserves that entrypoint.
 
 This means looplet can run a useful subset of Claude Skills directly as
-cartridges, while surfacing adapter gaps instead of pretending Claude-specific
+bundles, while surfacing adapter gaps instead of pretending Claude-specific
 runtime behavior is automatically reproducible.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,4 +1,4 @@
-# Composable Harness Workspace (CHW)
+# Workspace
 
 `looplet.workspace` makes the agent harness an editable artifact on
 disk. It is the bidirectional, lossless inverse of
@@ -186,7 +186,7 @@ print(ws.name, ws.description, ws.schema_version)
 
 | You want to … | Use |
 |---|---|
-| Ship a runnable cartridge as a Python package with a custom `build()` factory | `SkillBundle` |
+| Ship a runnable bundle as a Python package with a custom `build()` factory | `SkillBundle` |
 | Edit prompt / tool / hook content as text files, version-control diffs, and re-execute | `Workspace` |
 | Mutate the harness from another agent (search, GEPA-style evolution, code review) | `Workspace` |
 | Snapshot the live preset of a running agent for later inspection | `Workspace` |

--- a/examples/coder.workspace/coder_lib_tools.py
+++ b/examples/coder.workspace/coder_lib_tools.py
@@ -7,7 +7,7 @@ control flow, no hook logic — just the executable surface area.
 The module exports a single composition function,
 :func:`make_tools`, that wires every ``@tool``-decorated callable
 into a :class:`looplet.tools.BaseToolRegistry` ready to plug into
-either the library entrypoint or the runnable cartridge.
+either the library entrypoint or the runnable bundle.
 
 :class:`FileCache` is kept here because every tool in the bundle
 either reads from it (``read_file``) or invalidates it

--- a/examples/coder.workspace/coder_lib_wiring.py
+++ b/examples/coder.workspace/coder_lib_wiring.py
@@ -1,10 +1,10 @@
 """Composition layer for the coder example.
 
 The reusable building block. Both the library entrypoint
-(:mod:`examples.coder.agent`) and the runnable cartridge
+(:mod:`examples.coder.agent`) and the runnable bundle
 (``examples/coder/skill/looplet.py``) delegate to the helpers below
 to construct identical hook stacks, memory sources, and evaluators.
-That guarantees library/cartridge parity is *structural* rather
+That guarantees library/bundle parity is *structural* rather
 than coincidental — the two surfaces cannot drift without someone
 deliberately editing both call sites.
 
@@ -211,7 +211,7 @@ def build_default_hooks(
 
 
 def build_default_memory_sources(workspace: str, max_steps: int) -> list:
-    """Project-context memory sources used by both library and cartridge."""
+    """Project-context memory sources used by both library and bundle."""
     instructions = _discover_instructions(workspace)
     project_ctx = _project_context(workspace)
     sources: list = []

--- a/examples/coder.workspace/resources/compact_service.py
+++ b/examples/coder.workspace/resources/compact_service.py
@@ -1,7 +1,7 @@
 """Compaction service for the coder workspace.
 
 Two-stage chain: prune old tool results first, then truncate any
-remaining historical turns. Mirrors the pattern the v1 cartridge
+remaining historical turns. Mirrors the pattern the looplet.examples coder reference
 used; lifts it out of ``setup.py`` so the entire workspace is
 declarative.
 """

--- a/examples/coder.workspace/resources/eval_evaluators.py
+++ b/examples/coder.workspace/resources/eval_evaluators.py
@@ -1,7 +1,7 @@
 """Evaluators for the coder workspace's EvalHook.
 
-Re-uses the v1 cartridge's ``build_eval_hook`` evaluators so the
-v2 workspace produces identical scores. The list lands in
+Re-uses the looplet.examples coder reference's ``build_eval_hook`` evaluators so the
+workspace produces identical scores. The list lands in
 ``hooks/07_EvalHook/config.yaml`` via the ``@eval_evaluators`` ref.
 """
 

--- a/examples/coder.workspace/tools/bash/execute.py
+++ b/examples/coder.workspace/tools/bash/execute.py
@@ -1,7 +1,7 @@
 """bash tool — execute a shell command in the workspace root.
 
 Receives the workspace_config resource through ``ctx.resources``
-(workspace v2 tool DI; ``tool.yaml`` declares ``requires:
+(workspace tool DI; ``tool.yaml`` declares ``requires:
 [workspace_config]``). Top-level function (no closures) so it
 round-trips losslessly through ``preset_to_workspace``.
 

--- a/examples/coder.workspace/workspace.json
+++ b/examples/coder.workspace/workspace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "coder",
-  "description": "Workspace-native coder agent. v2 of examples/coder/skill — every component (config, prompt, tools, hooks, shared resources) is a file you can edit, diff, and version-control. Same behavior as the v1 cartridge.",
+  "description": "Workspace-native coder agent. Every component (config, prompt, tools, hooks, shared resources) is a file you can edit, diff, and version-control. Behaves identically to the previous library example.",
   "metadata": {
     "tags": ["coding", "software-engineering", "testing", "workspace-native"]
   }

--- a/examples/hello.workspace/workspace.json
+++ b/examples/hello.workspace/workspace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "hello",
-  "description": "Workspace-native hello-world agent. Demonstrates the v2 cartridge format: every component is a file you can edit, diff, and version-control. Mirrors looplet.examples.hello_world.",
+  "description": "Workspace-native hello-world agent. Demonstrates the workspace format: every component is a file you can edit, diff, and version-control. Mirrors looplet.examples.hello_world.",
   "metadata": {
     "tags": ["hello-world", "workspace-native", "demo"]
   }

--- a/src/looplet/__main__.py
+++ b/src/looplet/__main__.py
@@ -4,11 +4,11 @@ Subcommands:
     show <trace-dir>              One-page summary of a captured trace directory.
     doctor                        Check local looplet/backend configuration.
     run <bundle> <task>           Run a runnable skill bundle.
-    blueprint <bundle>            Print a cartridge blueprint as JSON.
-    export-code <bundle> <file>   Export a cartridge as Python wrapper code.
-    package <factory> <dir>       Package an importable factory as a cartridge.
-    wrap-claude-skill <src> <dir> Wrap a Claude Skill as a looplet cartridge.
-    list-bundles <roots...>       List runnable cartridges under one or more roots.
+    blueprint <bundle>            Print a bundle blueprint as JSON.
+    export-code <bundle> <file>   Export a bundle as Python wrapper code.
+    package <factory> <dir>       Package an importable factory as a bundle.
+    wrap-claude-skill <src> <dir> Wrap a Claude Skill as a looplet bundle.
+    list-bundles <roots...>       List runnable bundles under one or more roots.
     eval <args...>                Run evals or browse cases (see `looplet eval -h`).
 """
 
@@ -709,7 +709,7 @@ def main(argv: list[str] | None = None) -> int:
 
     export_code = sub.add_parser(
         "export-code",
-        help="Export a cartridge as exact Python library wrapper code",
+        help="Export a bundle as exact Python library wrapper code",
     )
     export_code.add_argument("bundle", type=Path, help="Path to a runnable skill bundle")
     export_code.add_argument("out_file", type=Path, help="Python file to write")

--- a/src/looplet/blueprints.py
+++ b/src/looplet/blueprints.py
@@ -1,8 +1,8 @@
-"""Blueprints and conversion helpers for looplet cartridges.
+"""Blueprints and conversion helpers for looplet bundles.
 
 The blueprint layer is a small, serialisable description of an agent's
 observable looplet structure. It is not a Python decompiler; it records
-stable structure so cartridges can be inspected, compared, exported as
+stable structure so bundles can be inspected, compared, exported as
 library wrappers, and packaged back into runnable bundles.
 """
 
@@ -147,7 +147,7 @@ def blueprint_from_bundle(
     bundle_root: SkillBundle | str | Path,
     runtime: SkillRuntime | None = None,
 ) -> AgentBlueprint:
-    """Load a cartridge and return its structural blueprint."""
+    """Load a bundle and return its structural blueprint."""
     bundle = bundle_root if isinstance(bundle_root, SkillBundle) else load_skill_bundle(bundle_root)
     preset = bundle.build_preset(runtime or SkillRuntime())
     return blueprint_from_preset(
@@ -214,10 +214,10 @@ def export_bundle_to_library_code(
     *,
     function_name: str = "build",
 ) -> Path:
-    """Export a cartridge as exact, editable Python library wrapper code.
+    """Export a bundle as exact, editable Python library wrapper code.
 
-    This mode preserves behavior by delegating to the source cartridge. It is
-    the reliable conversion path for arbitrary cartridges, including those
+    This mode preserves behavior by delegating to the source bundle. It is
+    the reliable conversion path for arbitrary bundles, including those
     with closures or product-owned runtime shells.
     """
     if not function_name.isidentifier() or keyword.iskeyword(function_name):
@@ -228,10 +228,10 @@ def export_bundle_to_library_code(
     target.parent.mkdir(parents=True, exist_ok=True)
     blueprint_json = json.dumps(blueprint.to_dict(), indent=2, sort_keys=True)
     target.write_text(
-        f'''"""Generated local looplet library wrapper for the {bundle.skill.name} cartridge.
+        f'''"""Generated local looplet library wrapper for the {bundle.skill.name} bundle.
 
-This preserves exact behavior by loading the original cartridge from the
-absolute path recorded below. Keep that cartridge available, or re-export
+This preserves exact behavior by loading the original bundle from the
+absolute path recorded below. Keep that bundle available, or re-export
 after moving it.
 """
 
@@ -249,7 +249,7 @@ BLUEPRINT = AgentBlueprint.from_dict(json.loads(_BLUEPRINT_JSON))
 
 
 def {function_name}(runtime: SkillRuntime | None = None):
-    """Build the same AgentPreset as the source cartridge."""
+    """Build the same AgentPreset as the source bundle."""
     return load_skill_bundle(_BUNDLE_PATH).build_preset(runtime or SkillRuntime())
 ''',
         encoding="utf-8",
@@ -267,7 +267,7 @@ def package_agent_factory_as_bundle(
     instructions: str = "",
     entrypoint: str = "looplet.py",
 ) -> Path:
-    """Package an importable looplet factory as a runnable cartridge."""
+    """Package an importable looplet factory as a runnable bundle."""
     if ":" not in factory_ref:
         raise ValueError("factory_ref must use 'module:attribute' syntax")
     _resolve_factory(factory_ref)
@@ -285,7 +285,7 @@ def package_agent_factory_as_bundle(
     (root / "SKILL.md").write_text(skill_text, encoding="utf-8")
     entrypoint_path.parent.mkdir(parents=True, exist_ok=True)
     entrypoint_path.write_text(
-        f'''"""Generated looplet cartridge wrapper for {factory_ref}."""
+        f'''"""Generated looplet bundle wrapper for {factory_ref}."""
 
 from __future__ import annotations
 
@@ -319,7 +319,7 @@ def claude_skill_compatibility(skill_root: str | Path) -> ClaudeSkillCompatibili
     )
     if skill.metadata.get("entrypoint"):
         return ClaudeSkillCompatibility(
-            level="looplet-cartridge",
+            level="looplet-bundle",
             can_wrap=True,
             can_run_exactly=True,
             skill_name=skill.name,
@@ -353,7 +353,7 @@ def claude_skill_compatibility(skill_root: str | Path) -> ClaudeSkillCompatibili
 
 
 def wrap_claude_skill_as_bundle(skill_root: str | Path, out_dir: str | Path) -> Path:
-    """Wrap a Claude Skill folder as an instruction-only looplet cartridge."""
+    """Wrap a Claude Skill folder as an instruction-only looplet bundle."""
     skill_file = _skill_file_for(skill_root)
     source_root = skill_file.parent
     target = Path(out_dir)
@@ -370,7 +370,7 @@ def wrap_claude_skill_as_bundle(skill_root: str | Path, out_dir: str | Path) -> 
     if target.exists():
         raise ValueError("out_dir already exists; choose a new directory")
     report = claude_skill_compatibility(source_root)
-    if report.level == "looplet-cartridge":
+    if report.level == "looplet-bundle":
         temp_target = _copytree_temp_directory(source_root, target)
         try:
             temp_target.rename(target)

--- a/src/looplet/budget.py
+++ b/src/looplet/budget.py
@@ -171,7 +171,7 @@ class ThresholdCompactHook:
         *,
         fire_tier: Literal["warning", "error"] = "error",
     ) -> None:
-        # Accept a dict form for CHW workspace round-trip — workspace
+        # Accept a dict form for workspace workspace round-trip — workspace
         # config.yaml stores constructor kwargs as primitives, so the
         # ``budget`` field arrives as a plain dict from to_config().
         if isinstance(budget, dict):
@@ -187,7 +187,7 @@ class ThresholdCompactHook:
         return list(self._fired_at)
 
     def to_config(self) -> dict[str, Any]:
-        """Round-trip kwargs for ``preset_to_workspace`` / CHW.
+        """Round-trip kwargs for ``preset_to_workspace``.
 
         Returns the constructor kwargs needed to rebuild this hook —
         the budget is unpacked into its scalar fields so the workspace

--- a/src/looplet/bundles.py
+++ b/src/looplet/bundles.py
@@ -1,4 +1,4 @@
-"""Runnable skill bundles for loading domain cartridges.
+"""Runnable skill bundles for loading domain bundles.
 
 Bundles are deliberately a thin layer over existing looplet primitives.
 A bundle entrypoint returns an :class:`AgentPreset`; the core loop still
@@ -44,7 +44,7 @@ BuildSkillBundle = Callable[["SkillRuntime"], AgentPreset]
 
 @dataclass(frozen=True)
 class BundleCard:
-    """Lightweight runnable cartridge discovery record."""
+    """Lightweight runnable bundle discovery record."""
 
     name: str
     description: str
@@ -85,7 +85,7 @@ class SkillRuntime:
 
 @dataclass(frozen=True)
 class SkillBundle:
-    """A runnable skill cartridge loaded from disk."""
+    """A runnable skill bundle loaded from disk."""
 
     skill: Skill
     root: Path
@@ -128,7 +128,7 @@ def discover_skill_bundles(
 
     Roots may be bundle directories, ``SKILL.md`` files, or directories
     containing many skill folders. Instruction-only skills are skipped by
-    default because they are not runnable cartridges until wrapped.
+    default because they are not runnable bundles until wrapped.
 
     Args:
         roots: Paths to scan for bundles.
@@ -281,7 +281,7 @@ def run_skill_bundle(
 ) -> Iterator[Step]:
     """Run a loaded bundle with ``composable_loop``.
 
-    This helper is the console/cartridge adapter: it loads a bundle,
+    This helper is the console/bundle adapter: it loads a bundle,
     asks the bundle for normal looplet primitives, and delegates to the
     unchanged core loop.
     """

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -835,7 +835,7 @@ class EvalHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``evaluators`` (and ``collectors``
-        when present) as ``@ref`` strings so the v2 workspace writer
+        when present) as ``@ref`` strings so the workspace writer
         auto-generates ``resources/<name>.py`` builders. Lambda
         evaluators land in placeholder builders the user must replace;
         top-level callables ride straight through.

--- a/src/looplet/limits.py
+++ b/src/looplet/limits.py
@@ -100,7 +100,7 @@ class PerToolLimitHook:
         self._counts.clear()
 
     def to_config(self) -> dict[str, Any]:
-        """Round-trip kwargs for ``preset_to_workspace`` / CHW."""
+        """Round-trip kwargs for ``preset_to_workspace``."""
         return {
             "limits": dict(self._limits),
             "default_limit": self._default_limit,
@@ -207,7 +207,7 @@ class BudgetWarningHook:
         self._total = None
 
     def to_config(self) -> dict[str, Any]:
-        """Round-trip kwargs for ``preset_to_workspace`` / CHW.
+        """Round-trip kwargs for ``preset_to_workspace``.
 
         Round-trips when ``message`` is a string (the common case);
         when it's a callable, returns the default-message form so the

--- a/src/looplet/permissions.py
+++ b/src/looplet/permissions.py
@@ -263,7 +263,7 @@ class PermissionHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``engine`` as an ``@ref`` so the
-        v2 workspace writer auto-generates ``resources/engine.py``. The
+        workspace writer auto-generates ``resources/engine.py``. The
         rule list does not survive auto-emit — users edit the generated
         builder to declare their rules in code.
         """

--- a/src/looplet/stagnation.py
+++ b/src/looplet/stagnation.py
@@ -175,7 +175,7 @@ class StagnationHook:
         self._last_progress = None
 
     def to_config(self) -> dict[str, Any]:
-        """Round-trip kwargs for ``preset_to_workspace`` / CHW.
+        """Round-trip kwargs for ``preset_to_workspace``.
 
         Only round-trips the JSON-able fields (``threshold``, string
         ``nudge``, ``reset_after_nudge``, ``ignore_tools``). Callable

--- a/src/looplet/streaming.py
+++ b/src/looplet/streaming.py
@@ -306,7 +306,7 @@ class StreamingHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``emitter`` as an ``@ref`` so the
-        v2 workspace writer auto-generates ``resources/emitter.py``.
+        workspace writer auto-generates ``resources/emitter.py``.
         Closure-based emitters (e.g. ``CallbackEmitter(list.append)``)
         will fall through to a None-stub the user must replace; classes
         with a clean ``__init__`` round-trip automatically.

--- a/src/looplet/telemetry.py
+++ b/src/looplet/telemetry.py
@@ -351,7 +351,7 @@ class MetricsHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``collector`` as an ``@ref`` so the
-        v2 workspace writer auto-generates ``resources/collector.py`` and
+        workspace writer auto-generates ``resources/collector.py`` and
         the loader rebuilds a fresh ``MetricsCollector`` per load.
         """
         return {"collector": "@collector"}

--- a/src/looplet/tools.py
+++ b/src/looplet/tools.py
@@ -356,7 +356,7 @@ class ToolSpec:
     requires: list[str] = field(default_factory=list)
     """Names of shared resources the tool needs at dispatch time.
 
-    Workspace v2 mechanism for tool dependency injection: ``tool.yaml``
+    Workspace mechanism for tool dependency injection: ``tool.yaml``
     can declare ``requires: [workspace_config, file_cache]`` and the
     workspace loader populates this list. The
     :class:`BaseToolRegistry` dispatcher then resolves each name
@@ -403,7 +403,7 @@ class ToolSpec:
             return list(self.parameters.get("required", []))
         required: list[str] = []
         for name, desc in self.parameters.items():
-            # Workspace v2 ``tool.yaml`` form: dict descriptor.
+            # Workspace ``tool.yaml`` form: dict descriptor.
             if isinstance(desc, dict):
                 if "default" not in desc:
                     required.append(name)
@@ -594,7 +594,7 @@ class BaseToolRegistry:
 
         Tools whose ``ToolSpec.requires`` lists a resource name receive
         the resolved instance through ``ctx.resources[name]`` at
-        dispatch time. Workspace v2's ``workspace_to_preset`` calls
+        dispatch time. Workspace's ``workspace_to_preset`` calls
         this with the loaded ``resources/<name>.py`` builders' output;
         in-process callers can call it directly to wire a registry.
         """
@@ -749,7 +749,7 @@ class BaseToolRegistry:
             exec_kwargs["ctx"] = ctx
 
         # Populate ``ctx.resources`` for tools that declared
-        # ``ToolSpec.requires``. This is the workspace v2 dependency-
+        # ``ToolSpec.requires``. This is the workspace dependency-
         # injection path that replaces the legacy
         # ``WORKSPACE_CONFIG = None`` / ``setup.py`` global-overwrite
         # pattern. Auto-creates a ToolContext when the tool accepts

--- a/src/looplet/types.py
+++ b/src/looplet/types.py
@@ -258,7 +258,7 @@ class ToolContext:
     """Shared resource registry keyed by ``@<name>`` ref name.
 
     Populated by the dispatcher when the tool's ``ToolSpec.requires``
-    list declares dependencies (workspace v2 ``tool.yaml`` ``requires:``
+    list declares dependencies (workspace ``tool.yaml`` ``requires:``
     field). The dispatcher resolves each requested ref against the
     workspace's resource registry and hands the live instance to the
     tool through this dict — eliminating the v1 module-global

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -1,4 +1,4 @@
-"""Composable Harness Workspace (CHW) — bidirectional cartridge ↔ preset.
+"""Workspace — bidirectional ``AgentPreset`` ↔ directory round-trip.
 
 A *workspace* is a directory layout that round-trips with an
 :class:`AgentPreset` losslessly for the JSON-able subset of the harness
@@ -13,7 +13,7 @@ Make the agent harness an editable artifact on disk so external tools
 (harness search, GEPA-style evolution, diff/review workflows) can
 mutate components by file diff, version-control the result with git,
 and re-materialise an :class:`AgentPreset` for execution — without
-anyone forking the loop or replacing the cartridge mechanism.
+anyone forking the loop or replacing the workspace mechanism.
 
 Layout
 ------
@@ -99,7 +99,7 @@ Why this is in Looplet (not in a research extension)
 ----------------------------------------------------
 
 The disk format is generic infrastructure: anyone can use it for
-cartridge editing, agent diffing, code review, packaging, or
+workspace editing, agent diffing, code review, packaging, or
 between-round harness search. The research-specific layer
 (manifests with ``predicted_fixes``/``predicted_regressions``,
 the evolve agent, the search loop) lives in downstream packages
@@ -242,7 +242,7 @@ class WorkspaceSerializationError(RuntimeError):
 
 @dataclass
 class Workspace:
-    """A loaded composable harness workspace.
+    """A loaded Workspace.
 
     Serves both as the in-memory representation of an on-disk workspace
     and as the structured target of :func:`preset_to_workspace`.
@@ -259,7 +259,7 @@ class Workspace:
 
     @classmethod
     def from_directory(cls, path: str | Path) -> "Workspace":
-        """Load workspace metadata from a CHW directory.
+        """Load workspace metadata from a workspace directory.
 
         Use :func:`workspace_to_preset` to materialise the
         :class:`AgentPreset` from the loaded workspace.
@@ -270,8 +270,7 @@ class Workspace:
         meta_path = root / WorkspaceLayout.WORKSPACE_JSON
         if not meta_path.is_file():
             raise FileNotFoundError(
-                f"workspace metadata not found at {meta_path}; "
-                f"is this a Composable Harness Workspace?"
+                f"workspace metadata not found at {meta_path}; is this a Workspace directory?"
             )
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         return cls(
@@ -489,7 +488,7 @@ def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[s
     loader inspects the signature: ``build()`` (zero-arg) keeps the
     legacy contract; ``build(runtime)`` lets the resource read the
     host-supplied ``runtime`` dict (e.g. ``runtime['workspace']`` for
-    the coder cartridge). Resources are shared by every ``"@<name>"``
+    the coder workspace). Resources are shared by every ``"@<name>"``
     reference in hook / tool kwargs.
     """
     import inspect as _inspect  # noqa: PLC0415
@@ -697,7 +696,7 @@ def preset_to_workspace(
     overwrite: bool = False,
     strict: bool = False,
 ) -> Workspace:
-    """Write an :class:`AgentPreset` to a CHW directory.
+    """Write an :class:`AgentPreset` to a workspace directory.
 
     Args:
         preset: The harness to serialise.
@@ -707,7 +706,7 @@ def preset_to_workspace(
         description: Free-form description stored in
             ``workspace.json``.
         overwrite: Allow writing into a non-empty existing directory
-            (its CHW-managed subdirectories are wiped first).
+            (its workspace-managed subdirectories are wiped first).
         strict: When ``True``, raise
             :class:`WorkspaceSerializationError` on any non-round-trippable
             component. When ``False`` (default), record warnings on the
@@ -1268,7 +1267,7 @@ def _write_tool(spec: Any, tools_root: Path, warnings: list[str], strict: bool) 
             val = getattr(spec, opt)
             if val is not None:
                 yaml_payload[opt] = val
-    # Round-trip the resource-requirements list (workspace v2 tool DI).
+    # Round-trip the resource-requirements list (workspace tool DI).
     requires = getattr(spec, "requires", None) or []
     if requires:
         yaml_payload["requires"] = list(requires)
@@ -1611,7 +1610,7 @@ def workspace_to_preset(
     strict: bool = False,
     runtime: dict[str, Any] | None = None,
 ) -> "AgentPreset":
-    """Read a CHW directory and materialise an :class:`AgentPreset`.
+    """Read a workspace directory and materialise an :class:`AgentPreset`.
 
     Args:
         workspace_dir: Path to the workspace root.
@@ -1625,7 +1624,7 @@ def workspace_to_preset(
             verification and CI lint.
         runtime: Optional dict of host-supplied runtime values
             (e.g. ``{"workspace": "/tmp/myrepo"}`` for the coder
-            cartridge). Three integration points read it:
+            coder workspace). Three integration points read it:
               * ``${runtime.<key>}`` placeholders in ``config.yaml``
                 are substituted before constructing ``LoopConfig``.
               * ``resources/<name>.py`` builders that declare
@@ -1645,7 +1644,7 @@ def workspace_to_preset(
         raise FileNotFoundError(
             f"workspace metadata not found at "
             f"{root / WorkspaceLayout.WORKSPACE_JSON}; "
-            f"is this a Composable Harness Workspace?"
+            f"is this a Workspace directory?"
         )
 
     # Shared-resource registry — built once, referenced by ``@<name>``
@@ -1914,7 +1913,7 @@ def _workspace_to_preset_inner(
     preset = AgentPreset(config=config, hooks=hooks, tools=registry, state=state)
 
     # ``setup.py`` escape hatch — runs after the declarative load to
-    # let the cartridge attach callable / opaque fields that don't
+    # let the workspace attach callable / opaque fields that don't
     # round-trip via JSON (e.g. ``LoopConfig.tracer``,
     # ``LoopConfig.compact_service``, custom domain adapters), or
     # inject shared resources into top-level tool/hook modules.

--- a/tests/fixtures/coder_skill_bundle/looplet.py
+++ b/tests/fixtures/coder_skill_bundle/looplet.py
@@ -1,8 +1,8 @@
 """Runnable skill bundle for the looplet coder example.
 
-The cartridge is intentionally thin: it loads the same composition
+The bundle is intentionally thin: it loads the same composition
 helpers as ``examples/coder/agent.py`` and delegates to them. That
-means the cartridge and the library entrypoint are *literally* the
+means the bundle and the library entrypoint are *literally* the
 same agent, configured identically. To change behavior, edit
 ``examples/coder/wiring.py`` once.
 
@@ -12,7 +12,7 @@ may already have their own ``examples`` namespace package on
 ``sys.path`` that shadows ours, so we resolve the three sibling
 modules (``tools.py``, ``hooks.py``, ``wiring.py``) by absolute file
 path rather than relying on ``import examples.coder.*``. See
-``test_distributions_include_coder_cartridge_and_dependency``.
+``test_distributions_include_coder_bundle_and_dependency``.
 """
 
 from __future__ import annotations
@@ -153,7 +153,7 @@ def run(
     trace_dir: str | Path | None,
     provenance: bool,
 ) -> int:
-    """Run the coder cartridge with byte-for-byte-compatible terminal output."""
+    """Run the coder bundle with byte-for-byte-compatible terminal output."""
     workspace_str = os.path.abspath(os.fspath(workspace))
     base_url = os.environ.get("OPENAI_BASE_URL", "http://localhost:11434/v1")
     api_key = os.environ.get("OPENAI_API_KEY", "x")

--- a/tests/fixtures/coder_skill_bundle/tools.py
+++ b/tests/fixtures/coder_skill_bundle/tools.py
@@ -7,7 +7,7 @@ control flow, no hook logic — just the executable surface area.
 The module exports a single composition function,
 :func:`make_tools`, that wires every ``@tool``-decorated callable
 into a :class:`looplet.tools.BaseToolRegistry` ready to plug into
-either the library entrypoint or the runnable cartridge.
+either the library entrypoint or the runnable bundle.
 
 :class:`FileCache` is kept here because every tool in the bundle
 either reads from it (``read_file``) or invalidates it

--- a/tests/fixtures/coder_skill_bundle/wiring.py
+++ b/tests/fixtures/coder_skill_bundle/wiring.py
@@ -1,10 +1,10 @@
 """Composition layer for the coder example.
 
 The reusable building block. Both the library entrypoint
-(:mod:`examples.coder.agent`) and the runnable cartridge
+(:mod:`examples.coder.agent`) and the runnable bundle
 (``examples/coder/skill/looplet.py``) delegate to the helpers below
 to construct identical hook stacks, memory sources, and evaluators.
-That guarantees library/cartridge parity is *structural* rather
+That guarantees library/bundle parity is *structural* rather
 than coincidental — the two surfaces cannot drift without someone
 deliberately editing both call sites.
 
@@ -211,7 +211,7 @@ def build_default_hooks(
 
 
 def build_default_memory_sources(workspace: str, max_steps: int) -> list:
-    """Project-context memory sources used by both library and cartridge."""
+    """Project-context memory sources used by both library and bundle."""
     instructions = _discover_instructions(workspace)
     project_ctx = _project_context(workspace)
     sources: list = []

--- a/tests/test_skill_bundle_round_trip_smoke.py
+++ b/tests/test_skill_bundle_round_trip_smoke.py
@@ -24,7 +24,7 @@ from looplet.blueprints import (
 ROOT = Path(__file__).resolve().parents[1]
 CODER_BUNDLE = ROOT / "tests" / "fixtures" / "coder_skill_bundle"
 
-# Cartridge tests load real bundles, exec spec-loaded modules, and run
+# Bundle tests load real bundles, exec spec-loaded modules, and run
 # full blueprint comparisons. Under coverage instrumentation in CI the
 # combined import + exec + compare pass repeatedly busts the default
 # 30s timeout. Bump the per-test budget for the whole module.
@@ -167,7 +167,7 @@ Run the helper script when chart data must be normalized.
     assert "scripts require an explicit looplet tool adapter" in report.warnings
 
 
-def test_cli_exports_packages_and_wraps_cartridges(tmp_path, capsys):
+def test_cli_exports_packages_and_wraps_bundles(tmp_path, capsys):
     exported = tmp_path / "coder_export.py"
     packaged = tmp_path / "coder-packaged"
 
@@ -423,13 +423,13 @@ description: File parents should be rejected clearly.
         wrap_claude_skill_as_bundle(claude_skill, parent_file / "target")
 
 
-def test_wrap_looplet_cartridge_preserves_existing_entrypoint(tmp_path):
-    source = tmp_path / "source-cartridge"
+def test_wrap_looplet_bundle_preserves_existing_entrypoint(tmp_path):
+    source = tmp_path / "source-bundle"
     source.mkdir()
     (source / "SKILL.md").write_text(
         """---
 name: existing
-description: Existing looplet cartridge.
+description: Existing looplet bundle.
 entrypoint: custom.py
 ---
 
@@ -442,15 +442,15 @@ entrypoint: custom.py
 
 
 def build(runtime):
-    return minimal_preset(max_steps=runtime.max_steps, system_prompt='custom cartridge')
+    return minimal_preset(max_steps=runtime.max_steps, system_prompt='custom bundle')
 """,
         encoding="utf-8",
     )
 
-    wrapped = wrap_claude_skill_as_bundle(source, tmp_path / "wrapped-cartridge")
+    wrapped = wrap_claude_skill_as_bundle(source, tmp_path / "wrapped-bundle")
     bundle = load_skill_bundle(wrapped)
     preset = bundle.build_preset(SkillRuntime(max_steps=2))
 
     assert bundle.skill.metadata["entrypoint"] == "custom.py"
-    assert preset.config.system_prompt == "custom cartridge"
+    assert preset.config.system_prompt == "custom bundle"
     assert not (wrapped / "looplet.py").exists()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,4 +1,4 @@
-"""Tests for the Composable Harness Workspace (CHW) round-trip.
+"""Tests for the Workspace round-trip.
 
 Verifies:
 
@@ -422,11 +422,11 @@ def test_setup_py_invalid_signature_raises(tmp_path: Path) -> None:
         workspace_to_preset(out, strict=True)
 
 
-# ── examples/hello.workspace end-to-end (proof-of-concept v2 cartridge) ───
+# ── examples/hello.workspace end-to-end (proof-of-concept workspace) ───
 
 
 def test_hello_workspace_loads_and_runs_end_to_end() -> None:
-    """examples/hello.workspace is the proof-of-concept v2 cartridge:
+    """examples/hello.workspace is the proof-of-concept workspace:
     fully declarative layout with shared resources + setup.py wiring.
     Loads, runs scripted, and the shared GreetingLog round-trips
     state between the greet tool and the PolitenessGate hook."""
@@ -473,16 +473,16 @@ def test_hello_workspace_loads_and_runs_end_to_end() -> None:
     assert hook.log.names() == ["Alice", "Bob"]
 
 
-# ── examples/coder.workspace end-to-end (real-world v2 cartridge) ──
+# ── examples/coder.workspace end-to-end (real-world workspace) ──
 
 
 def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
-    """examples/coder.workspace migrates the v1 coder cartridge to the
+    """examples/coder.workspace migrates the v1 coder bundle to the
     v2 layout. Validates that:
       * Declarative + setup.py-injected hooks load (8 total — TestGuard,
         FileCache, StaleFile, Stagnation, ThresholdCompact, PerToolLimit
         from YAML; LinterHook + EvalHook appended by setup.py to match
-        v1 cartridge feature-for-feature)
+        looplet.examples coder reference feature-for-feature)
       * 9 tools (bash/list_dir/read/write/edit/glob/grep/think/done) load
       * FileCacheHook and StaleFileHook share the SAME FileCache instance
         via @file_cache (proves the shared-resource registry under load)
@@ -564,7 +564,7 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
 
 def test_threat_intel_workspace_loads() -> None:
     """examples/threat_intel.workspace migrates the threat-intel
-    cartridge. Loads with strict=True; tools re-import from the
+    bundle. Loads with strict=True; tools re-import from the
     original module so their typing/closure environment stays intact."""
     from pathlib import Path as _P
 
@@ -808,7 +808,7 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
 
 def test_threat_intel_workspace_attaches_compact_service(tmp_path) -> None:
     """setup.py wires LoopConfig.compact_service so the workspace
-    matches the v1 cartridge feature-for-feature."""
+    matches the looplet.examples coder reference feature-for-feature."""
     from pathlib import Path as _P
 
     workspace_dir = _P(__file__).resolve().parents[1] / "examples" / "threat_intel.workspace"
@@ -997,7 +997,7 @@ def test_streaming_hook_declarative_via_at_ref(tmp_path) -> None:
 def test_workspace_extends_other_workspace(tmp_path) -> None:
     """A workspace's setup.py can load another workspace and merge
     its tools/hooks. Demonstrates inheritance/composition between
-    cartridges without forking the loop."""
+    bundles without forking the loop."""
     import json as _json
 
     base = tmp_path / "base"


### PR DESCRIPTION
## Summary

Two distinct concepts had inherited the legacy "cartridge" name and the "v2" suffix:

1. **`Workspace`** (`looplet.workspace`) — the bidirectional directory format. Was variously called "v2 workspace", "workspace v2", "Composable Harness Workspace", "CHW", or "cartridge".
2. **`SkillBundle`** (`looplet.bundles`, `looplet.blueprints`, `looplet/__main__.py`) — the runnable folder format. Was called "cartridge".

After the v1 example modules were deleted in #33 and all examples became fully declarative in #37, the v2 / CHW / cartridge naming no longer maps to anything users see. **Consolidate to the two canonical names already used in code**:

- "v2 workspace" / "workspace v2" → just **"workspace"**
- "CHW" / "Composable Harness Workspace" → just **"Workspace"**
- "cartridge" (when meaning Workspace) → **"workspace"**
- "cartridge" (when meaning SkillBundle) → **"bundle"**

## Changes

- **Library (`src/`)**: docstrings + comments swept across `workspace.py`, `blueprints.py`, `bundles.py`, `__main__.py`, `types.py`, `tools.py`, `permissions.py`, `streaming.py`, `evals.py`, `telemetry.py`, `limits.py`, `budget.py`, `stagnation.py`.
- **`ClaudeSkillCompatibility.level` string `"looplet-cartridge"` → `"looplet-bundle"`** — only minor public-API rename in this PR.
- **Docs** (`docs/workspace.md`, `quickstart.md`, `skills.md`, `index.md`, `README.md`, `CHANGELOG.md`): all references swept.
- **Examples** (`workspace.json` descriptions, `lib_*.py` docstrings, `resources/*.py` docstrings, `tools/*/execute.py` module docs): swept clean.
- **Tests**: `tests/test_workspace.py` docstrings updated; `tests/test_cartridge_round_trip_smoke.py` **renamed** to `tests/test_skill_bundle_round_trip_smoke.py` (file move only, preserves git history).
- **Internal `_chw_*` synthetic module-name prefixes kept** — these are not user-visible and renaming them would churn lots of snapshot test fixtures with no benefit.

## Verification

- **1601 tests pass** (no behavioural change, no new tests).
- Lint + pyright clean.
- Smoke dogfood: all 5 example workspaces load + dispatch + snapshot + reload cleanly. **0 frictions.**

## BREAKING

`ClaudeSkillCompatibility.level` returns `"looplet-bundle"` (was `"looplet-cartridge"`). Anyone string-matching on the old value needs to update.
