### PR TITLE
fix(workspace): preserve original `@ref` names + push resources/ onto sys.path

### DIFF
--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -160,6 +160,7 @@ from looplet.workspace import (
     WorkspaceLayout,
     WorkspaceSerializationError,
     preset_to_workspace,
+    resource_ref_for,
     workspace_to_preset,
 )
 
@@ -256,6 +257,7 @@ __all__ = [
     "WorkspaceLayout",
     "WorkspaceSerializationError",
     "preset_to_workspace",
+    "resource_ref_for",
     "workspace_to_preset",
     "StreamingHook",
     "Tracer",

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -835,14 +835,21 @@ class EvalHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``evaluators`` (and ``collectors``
-        when present) as ``@ref`` strings so the workspace writer
-        auto-generates ``resources/<name>.py`` builders. Lambda
-        evaluators land in placeholder builders the user must replace;
-        top-level callables ride straight through.
+        when present) as ``@ref`` strings.
+
+        Original resource ref names are preserved when the evaluator /
+        collector lists were produced by a workspace resource builder
+        (e.g. ``resources/sql_evaluators.py`` round-trips as
+        ``{"evaluators": "@sql_evaluators"}``). Otherwise the writer
+        emits the generic ``"@evaluators"`` / ``"@collectors"`` names.
         """
-        cfg: dict[str, Any] = {"evaluators": "@evaluators"}
+        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+
+        ev_ref = resource_ref_for(self.evaluators)
+        cfg: dict[str, Any] = {"evaluators": ev_ref or "@evaluators"}
         if self.collectors:
-            cfg["collectors"] = "@collectors"
+            co_ref = resource_ref_for(self.collectors)
+            cfg["collectors"] = co_ref or "@collectors"
         if self.verbose:
             cfg["verbose"] = True
         return cfg

--- a/src/looplet/permissions.py
+++ b/src/looplet/permissions.py
@@ -263,11 +263,19 @@ class PermissionHook:
 
     def to_config(self) -> dict:
         """Workspace round-trip: emit ``engine`` as an ``@ref`` so the
-        workspace writer auto-generates ``resources/engine.py``. The
-        rule list does not survive auto-emit — users edit the generated
-        builder to declare their rules in code.
+        workspace writer auto-generates ``resources/<name>.py``.
+
+        When ``self.engine`` was produced by a workspace resource
+        builder (its class lives in ``_chw_resource_<name>``), the
+        original ref name is preserved — e.g. a workspace declaring
+        ``resources/sql_permissions.py`` round-trips as
+        ``{"engine": "@sql_permissions"}``. Otherwise the writer
+        emits the generic ``"@engine"`` name.
         """
-        return {"engine": "@engine"}
+        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+
+        ref = resource_ref_for(self.engine)
+        return {"engine": ref or "@engine"}
 
     def on_event(self, payload: Any) -> Any:
         """Fire on ``PRE_TOOL_USE`` and convert engine outcomes to decisions."""

--- a/src/looplet/streaming.py
+++ b/src/looplet/streaming.py
@@ -305,13 +305,20 @@ class StreamingHook:
         self._step_llm_calls: int = 0
 
     def to_config(self) -> dict:
-        """Workspace round-trip: emit ``emitter`` as an ``@ref`` so the
-        workspace writer auto-generates ``resources/emitter.py``.
-        Closure-based emitters (e.g. ``CallbackEmitter(list.append)``)
-        will fall through to a None-stub the user must replace; classes
-        with a clean ``__init__`` round-trip automatically.
+        """Workspace round-trip: emit ``emitter`` as an ``@ref``.
+
+        When ``self._emitter`` was produced by a workspace resource
+        builder, the original ref name is preserved (e.g.
+        ``resources/event_collector.py`` round-trips as
+        ``{"emitter": "@event_collector"}``). Otherwise the writer
+        emits the generic ``"@emitter"`` name. Closure-based emitters
+        whose origin can't be traced fall through to a None-stub the
+        user must replace.
         """
-        return {"emitter": "@emitter"}
+        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+
+        ref = resource_ref_for(self._emitter)
+        return {"emitter": ref or "@emitter"}
 
     @property
     def emitter(self) -> EventEmitter:

--- a/src/looplet/telemetry.py
+++ b/src/looplet/telemetry.py
@@ -350,11 +350,16 @@ class MetricsHook:
         self._classify = classify  # optional Callable[[Step, Any], str]
 
     def to_config(self) -> dict:
-        """Workspace round-trip: emit ``collector`` as an ``@ref`` so the
-        workspace writer auto-generates ``resources/collector.py`` and
-        the loader rebuilds a fresh ``MetricsCollector`` per load.
+        """Workspace round-trip: emit ``collector`` as an ``@ref``.
+
+        When ``self._collector`` was produced by a workspace resource
+        builder, the original ref name is preserved. Otherwise the
+        writer emits the generic ``"@collector"`` name.
         """
-        return {"collector": "@collector"}
+        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+
+        ref = resource_ref_for(self._collector)
+        return {"collector": ref or "@collector"}
 
     @property
     def collector(self) -> MetricsCollector:

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -490,6 +490,14 @@ def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[s
     host-supplied ``runtime`` dict (e.g. ``runtime['workspace']`` for
     the coder workspace). Resources are shared by every ``"@<name>"``
     reference in hook / tool kwargs.
+
+    Each built instance is also registered in
+    :data:`_resource_origin` (keyed by ``id``, with a finalizer that
+    drops the entry when the instance is garbage-collected) so that
+    :func:`resource_ref_for` can recover the original ref name on
+    workspace round-trip — even when the instance's class lives in a
+    third-party module (e.g. ``looplet.permissions.PermissionEngine``)
+    rather than the workspace's own resource module.
     """
     import inspect as _inspect  # noqa: PLC0415
 
@@ -515,11 +523,98 @@ def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[s
             )
         except (TypeError, ValueError):
             accepts_runtime = False
-        resources[name] = builder(runtime=runtime_dict) if accepts_runtime else builder()
+        instance = builder(runtime=runtime_dict) if accepts_runtime else builder()
+        resources[name] = instance
+        _register_resource_origin(instance, name)
     return resources
 
 
+# Identity-keyed map from a resource-built instance's ``id()`` to its
+# ref name. Keyed by ``id`` because the instance may be unhashable (a
+# list, a dict) or its hash semantics may collide with another
+# instance. Entries are dropped on instance GC via ``weakref.finalize``
+# so this map can't leak memory.
+_resource_origin: dict[int, str] = {}
+
+
+def _register_resource_origin(instance: Any, name: str) -> None:
+    """Record that ``instance`` came from ``resources/<name>.py``.
+
+    Tries to attach a weakref finalizer; falls back to a best-effort
+    registration without finalizer for objects that don't support
+    weak references (e.g. tuples). The non-finalized entries are
+    cleaned up opportunistically the next time
+    :func:`_load_resources` runs for the same workspace.
+    """
+    import weakref  # noqa: PLC0415
+
+    key = id(instance)
+    _resource_origin[key] = name
+    try:
+        weakref.finalize(instance, _resource_origin.pop, key, None)
+    except TypeError:
+        pass  # built-in containers don't support weak refs; OK
+
+
 _REF_PREFIX = "@"
+
+
+def resource_ref_for(value: Any) -> str | None:
+    """Return ``"@<name>"`` when ``value`` was produced by a workspace
+    ``resources/<name>.py`` builder; ``None`` otherwise.
+
+    Two detection paths:
+
+    1. **Identity registry.** :func:`_load_resources` stamps every
+       built instance into ``_resource_origin`` keyed by ``id``. This
+       handles the common case where the builder returns a stock
+       third-party object (e.g. ``PermissionEngine``,
+       ``MetricsCollector``) whose own ``__module__`` is *not* in
+       the workspace.
+    2. **Module name fallback.** When the value (or its first list
+       element) was *defined* inside the workspace's resource module
+       (e.g. a closure built by ``def build(): def fn(...): ...``),
+       its ``__module__`` starts with ``_chw_resource_``.
+
+    Used by hook ``to_config()`` implementations to round-trip the
+    *original* resource ref name (e.g. ``"@sql_permissions"``) instead
+    of a hardcoded fallback (e.g. ``"@engine"``).
+
+    Returns ``None`` for in-process objects so callers can fall back
+    to a default ref name.
+    """
+    # Path 1: identity registry — handles instances of stock classes
+    # like ``looplet.permissions.PermissionEngine`` whose own
+    # ``__module__`` is the framework, not the workspace.
+    by_id = _resource_origin.get(id(value))
+    if by_id is not None:
+        return f"{_REF_PREFIX}{by_id}"
+    # Also probe list/tuple elements for identity matches — common
+    # for ``EvalHook(evaluators=[...])`` whose list is rebuilt each
+    # call by the resource builder.
+    if isinstance(value, (list, tuple)) and value:
+        elem_id = _resource_origin.get(id(value[0]))
+        if elem_id is not None:
+            return f"{_REF_PREFIX}{elem_id}"
+
+    # Path 2: module-name fallback — handles closures defined inside
+    # the resource module (CallableMemorySource(fn=lambda ...)) and
+    # custom classes declared in the resource file.
+    candidate_modules: list[str] = []
+    cls_mod = getattr(type(value), "__module__", "") or ""
+    if cls_mod:
+        candidate_modules.append(cls_mod)
+    direct_mod = getattr(value, "__module__", "") or ""
+    if direct_mod and direct_mod != cls_mod:
+        candidate_modules.append(direct_mod)
+    if isinstance(value, (list, tuple)) and value:
+        item_mod = getattr(value[0], "__module__", "") or getattr(type(value[0]), "__module__", "")
+        if item_mod and item_mod not in candidate_modules:
+            candidate_modules.append(item_mod)
+    for mod in candidate_modules:
+        if mod.startswith("_chw_resource_"):
+            return f"{_REF_PREFIX}{mod[len('_chw_resource_') :]}"
+    return None
 
 
 def _resolve_refs(value: Any, resources: dict[str, Any]) -> Any:
@@ -975,15 +1070,37 @@ def _write_resources_for_refs(
 
     def _origin_chw_resource_file(value: Any) -> Path | None:
         """If ``value`` (or every callable element of a list/tuple)
-        traces back to a single ``_chw_resource_<name>`` module, return
-        the on-disk source file. The original ``resources/<name>.py``
-        is the canonical builder — copying it round-trips builds
-        that compute lists / closures / nested objects without losing
-        the original ``def build()`` signature.
+        traces back to a single workspace resource module, return the
+        on-disk source file. Two detection paths:
+
+        1. **Identity registry** (set up by :func:`_load_resources`):
+           covers stock-class instances like ``PermissionEngine``
+           whose own ``__module__`` is the framework, not the
+           workspace.
+        2. **Module name fallback**: covers closures defined inside
+           the resource module (``def build(): def fn(...): ...``)
+           and custom classes declared in the resource file.
+
+        The original ``resources/<name>.py`` is the canonical builder
+        — copying it round-trips builds that compute lists / closures
+        / nested objects without losing the original ``def build()``
+        signature.
         """
+        # Path 1: identity registry → look up by id(), then read the
+        # registered name's source file from sys.modules.
         candidates: list[Any] = list(value) if isinstance(value, (list, tuple)) else [value]
         if not candidates:
             return None
+        registered_name = _resource_origin.get(id(value))
+        if registered_name is None and isinstance(value, (list, tuple)):
+            registered_name = _resource_origin.get(id(candidates[0]))
+        if registered_name is not None:
+            chw_mod = _sys.modules.get(f"_chw_resource_{registered_name}")
+            chw_file = getattr(chw_mod, "__file__", None) if chw_mod is not None else None
+            if chw_file and Path(chw_file).is_file():
+                return Path(chw_file)
+
+        # Path 2: every candidate's __module__ is the same _chw_resource_*
         chw_modules: set[str] = set()
         for item in candidates:
             mod = getattr(item, "__module__", "") or type(item).__module__ or ""
@@ -1658,15 +1775,22 @@ def workspace_to_preset(
     # ``<workspace>/<wsname>_lib.py`` or similar; pick a name unique to
     # this workspace so two workspaces loaded back-to-back don't share
     # a cached ``lib`` module). The loader pushes the workspace root
-    # onto ``sys.path`` for the duration of this load so
-    # ``from <wsname>_lib import X`` resolves without forcing every
-    # workspace to ship a setup.py shim.
+    # AND its ``resources/`` subdirectory onto ``sys.path`` for the
+    # duration of this load so:
+    #   * ``from <wsname>_lib import X`` resolves to the workspace root
+    #   * ``from <resource_name> import helper`` resolves to a
+    #     ``resources/<resource_name>.py`` module (lets tools call back
+    #     into resource modules without forcing a setup.py shim).
     import sys as _sys  # noqa: PLC0415
 
     root_str = str(root)
-    _path_pushed = root_str not in _sys.path
-    if _path_pushed:
-        _sys.path.insert(0, root_str)
+    resources_dir_str = str(root / WorkspaceLayout.RESOURCES_DIR)
+    pushed_paths: list[str] = []
+    for p in (root_str, resources_dir_str):
+        if (root / WorkspaceLayout.RESOURCES_DIR).is_dir() or p == root_str:
+            if p not in _sys.path:
+                _sys.path.insert(0, p)
+                pushed_paths.append(p)
     try:
         preset = _workspace_to_preset_inner(
             root, runtime_dict, state_factory=state_factory, strict=strict
@@ -1680,9 +1804,9 @@ def workspace_to_preset(
         _stamp_preset_origin(preset, root)
         return preset
     finally:
-        if _path_pushed:
+        for p in pushed_paths:
             try:
-                _sys.path.remove(root_str)
+                _sys.path.remove(p)
             except ValueError:
                 pass
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1790,3 +1790,99 @@ def test_tool_without_ctx_logs_warning_when_requires_set(tmp_path: Path, caplog)
         result = reg.dispatch(ToolCall(tool="demo", args={"x": 1}))
     assert result.error is None
     assert any("ctx" in rec.message for rec in caplog.records)
+
+
+# ── resource_ref_for + identity-keyed origin tracking ──
+
+
+def test_resource_ref_for_preserves_original_ref_name(tmp_path: Path) -> None:
+    """When a hook holds an instance built by ``resources/<name>.py``,
+    ``to_config()`` round-trips with the *original* ``"@<name>"`` ref
+    even when the instance's class lives in a third-party module.
+    Catches the friction where ``PermissionHook.to_config()`` always
+    returned ``"@engine"`` instead of ``"@sql_permissions"``."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "resources").mkdir()
+    (src / "resources/sql_permissions.py").write_text(
+        "from looplet import PermissionDecision, PermissionEngine, PermissionRule\n"
+        "def build(runtime=None):\n"
+        "    return PermissionEngine(rules=[\n"
+        "        PermissionRule(tool='*', decision=PermissionDecision.ALLOW),\n"
+        "    ])\n"
+    )
+    (src / "hooks" / "00_PermissionHook").mkdir(parents=True)
+    (src / "hooks/00_PermissionHook/hook.py").write_text(
+        "from looplet.permissions import PermissionHook as PermissionHook\n"
+    )
+    (src / "hooks/00_PermissionHook/config.yaml").write_text(
+        'class_name: PermissionHook\nkwargs:\n  engine: "@sql_permissions"\n'
+    )
+
+    preset = workspace_to_preset(src, strict=True)
+    snap1 = tmp_path / "snap1"
+    preset_to_workspace(preset, snap1, name="snap")
+
+    # Snapshot config.yaml carries the ORIGINAL ref name, not "@engine":
+    snap_yaml = (snap1 / "hooks" / "00_PermissionHook" / "config.yaml").read_text()
+    assert "@sql_permissions" in snap_yaml, f"got: {snap_yaml}"
+
+    # Snapshot resources/sql_permissions.py is the verbatim source,
+    # not an auto-generated stub:
+    snap_resource = (snap1 / "resources" / "sql_permissions.py").read_text()
+    original = (src / "resources" / "sql_permissions.py").read_text()
+    assert snap_resource == original
+
+    # Two-pass byte-identical round-trip — the rules survive intact.
+    preset2 = workspace_to_preset(snap1, strict=True)
+    snap2 = tmp_path / "snap2"
+    preset_to_workspace(preset2, snap2, name="snap")
+    assert (snap1 / "resources" / "sql_permissions.py").read_text() == (
+        snap2 / "resources" / "sql_permissions.py"
+    ).read_text()
+
+
+def test_workspace_root_resources_dir_is_on_sys_path(tmp_path: Path) -> None:
+    """Tools and other workspace modules must be able to ``from
+    <resource_name> import helper`` — the loader pushes both the
+    workspace root AND its ``resources/`` subdir onto ``sys.path``
+    for the duration of the load."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "tools" / "ping").mkdir(parents=True)
+    (src / "tools/ping/tool.yaml").write_text("name: ping\nparameters: {}\n")
+    # Imports from a resources/-defined helper module — this would
+    # fail with ModuleNotFoundError if resources/ wasn't on sys.path.
+    (src / "tools/ping/execute.py").write_text(
+        "from helper_resource import greet\ndef execute(): return {'msg': greet()}\n"
+    )
+    (src / "resources").mkdir()
+    (src / "resources/helper_resource.py").write_text(
+        "def greet():\n    return 'hello-from-resource'\n"
+        "def build(runtime=None):\n    return greet\n"
+    )
+
+    preset = workspace_to_preset(src, strict=True)
+    from looplet.types import ToolCall
+
+    result = preset.tools.dispatch(ToolCall(tool="ping", args={}))
+    assert result.error is None
+    assert result.data == {"msg": "hello-from-resource"}


### PR DESCRIPTION
## Summary

Two principled fixes from dogfooding two new agent workspaces:

- **SQL data analyst** with arg-matched permission rules (DENY destructive SQL via `arg_matcher` callable), `ctx.llm` for column-purpose inference, structured output, and EvalHook with top-level evaluators.
- **Research librarian** with multiple memory sources (`StaticMemorySource` + closure-bearing `CallableMemorySource`), aggressive compaction, and citation-graph traversal tools.

Both agents broke the snapshot round-trip in different ways. Both fixes ship here.

## Fix 1: Hook `to_config()` lost the user's resource ref name

`PermissionHook.to_config()` always returned `{'engine': '@engine'}` even when the engine was built by `resources/sql_permissions.py` and the source workspace declared `engine: "@sql_permissions"`. On round-trip the writer auto-emitted a generic `engine.py` (with **no rules!**) instead of copying the original `sql_permissions.py` verbatim. Same pattern broke `MetricsHook`, `StreamingHook`, `EvalHook`.

**Root cause**: `type(engine).__module__` is `looplet.permissions`, not `_chw_resource_*`, so the writer's existing module-name detection couldn't trace the engine back to its origin file.

**Fix**: introduce `looplet.resource_ref_for(value)` — a public helper with two detection paths:

1. **Identity registry**: `_load_resources()` now stamps every built instance into a module-level `_resource_origin` dict keyed by `id(instance)` with a `weakref.finalize` for memory cleanup. `resource_ref_for()` consults this first.
2. **Module name fallback** (existing): for closures defined inside the resource module.

The four built-in hooks now use `resource_ref_for(...) or '@<default>'` so the ref name round-trips losslessly when the instance came from a workspace resource, and falls back to the generic name otherwise.

## Fix 2: `from <resource_name> import helper` from a tool failed

The loader pushed `<workspace>/` onto `sys.path` (so `from <wsname>_lib import X` worked) but not `<workspace>/resources/`. Tools that needed to call back into a resource module (e.g. an analysis-memory recorder shared with a `CallableMemorySource`) hit `ModuleNotFoundError`.

**Fix**: also push `<workspace>/resources/` onto `sys.path` for the duration of the load. Both paths are removed on exit.

## Tests (+2)

- `test_resource_ref_for_preserves_original_ref_name`: pins both halves of fix 1 — the user's ref name appears in the snapshot `config.yaml` AND the original resource file is copied verbatim.
- `test_workspace_root_resources_dir_is_on_sys_path`: pins fix 2 — a tool that imports from a resources/-defined helper succeeds on dispatch.

## Verification

- **1621 tests pass** (was 1619 + 2 new). Lint + pyright clean.
- **Smoke dogfood** (5 shipped examples): **0 frictions**.
- **Stress dogfood** (2 new agents — `sql_analyst.workspace`, `research_librarian.workspace`):

| Property | Result |
|---|---|
| R1 byte-identical 2-pass round-trip | ✓ both |
| R2 cross-process strict load (subprocess Python) | ✓ both |
| R3 provenance trajectory recording | ✓ both |
| R4 checkpoint round-trip | ✓ both |

## API additions

- `looplet.resource_ref_for(value: Any) -> str | None` — public; returns `"@<name>"` when `value` was produced by a workspace resource builder, `None` otherwise. Hooks should use it inside `to_config()` to preserve the user's chosen ref name.
