### PR TITLE
feat: outcome-side surfaces — recovery_hint, requires validation, sub-loop forwarding, MockLLM cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`ToolError.recovery_hint`** — structured suggestion (dict or str)
+  for how the caller could recover. The dispatcher now populates it
+  on the four self-correctable errors: unknown-tool ("did you mean?"),
+  unexpected-argument (`{unexpected, did_you_mean, expected}`),
+  missing-argument (`{missing, provided, expected}`), and empty
+  required-string-argument (`{empty_param, expected}`). Information-
+  additive: smarter models exploit the structured hint to self-correct
+  without re-discovering the catalog from prose; existing models still
+  see the same human-readable error message.
+- **`looplet.LLMResponsesExhausted`** + **`MockLLMBackend(cycle=False)`**
+  — opt-in test ergonomics. The default still cycles for backward
+  compatibility; passing `cycle=False` makes the mock raise instead of
+  silently re-using `responses[0]` past the last scripted answer
+  (which previously made over-running loops look "stuck on step 1").
+  Same flag on `AsyncMockLLMBackend`.
+- **`run_sub_loop(parent_hooks=...)`** — opt-in event forwarding from
+  a sub-loop to the parent's observability stack. When supplied, the
+  parent's hooks (e.g. `MetricsHook`, `StreamingHook`,
+  `TrajectoryRecorder`) receive every lifecycle event the sub-loop
+  emits via their `on_event` method, tagged with `subagent_id` in the
+  payload's `extra` dict so consumers can route / nest. Defaults to
+  `None` — no forwarding, sub-loop fully isolated.
+
+### Changed
+- **`tool.yaml requires:` validated at workspace-load time.** A typo
+  in `requires: [my_resoruce]` (missing or mistyped resource name)
+  used to silently set `ctx.resources["my_resoruce"] = None` at
+  dispatch and crash deep inside the tool body with `AttributeError`.
+  The loader now warns in loose mode (default) and raises
+  `WorkspaceSerializationError` in strict mode, naming the
+  unresolvable resource and listing the available ones — surfaces
+  the bug at its source.
+
 ### Changed
 - **Naming consolidation.** Dropped the legacy "cartridge" /
   "Composable Harness Workspace (CHW)" / "workspace v2" terminology

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -132,7 +132,7 @@ from looplet.stagnation import (
 from looplet.streaming import StreamingHook
 from looplet.subagent import run_sub_loop
 from looplet.telemetry import MetricsCollector, MetricsHook, Tracer, TracingHook
-from looplet.testing import AsyncMockLLMBackend, MockLLMBackend
+from looplet.testing import AsyncMockLLMBackend, LLMResponsesExhausted, MockLLMBackend
 from looplet.tools import (
     BaseToolRegistry,
     ToolSpec,
@@ -283,6 +283,7 @@ __all__ = [
     # ── TESTING ─────────────────────────────────────────────────
     "MockLLMBackend",
     "AsyncMockLLMBackend",
+    "LLMResponsesExhausted",
     # ── RESILIENCE & CONTROL ────────────────────────────────────
     "ResilientBackend",
     "RetryExhausted",

--- a/src/looplet/subagent.py
+++ b/src/looplet/subagent.py
@@ -36,6 +36,7 @@ def run_sub_loop(
     max_steps: int = 5,
     system_prompt: str = "",
     hooks: list[Any] | None = None,
+    parent_hooks: list[Any] | None = None,
     context: Any = None,
     state: Any = None,
     sub_tools: Any = None,
@@ -53,7 +54,20 @@ def run_sub_loop(
         tools: Parent tool registry. Cloned (minus state-mutating tools) for sub-agent.
         max_steps: Maximum number of steps for the sub-agent.
         system_prompt: System prompt for the sub-agent LLM calls.
-        hooks: Optional list of LoopHook instances.
+        hooks: Optional list of LoopHook instances **for the sub-loop**.
+        parent_hooks: Optional list of LoopHook instances from the
+            parent loop. When supplied, the sub-loop also fires its
+            lifecycle events (PRE_TOOL_USE, POST_TOOL_USE, etc.) on
+            the parent's hooks so observability stacks on the parent
+            (MetricsHook, StreamingHook, TrajectoryRecorder, …) see
+            the sub-loop's per-step activity. The parent hooks are
+            **not** invoked through their full ``LoopHook`` interface
+            (no ``pre_loop`` / ``check_done`` from the sub-loop —
+            those would conflate parent + sub state); only their
+            event-driven ``on_event`` method is forwarded. Opt-in:
+            callers building tool-as-subagent patterns pass
+            ``parent_hooks=ctx.hooks`` (or pull from a parent context).
+            Defaults to ``None`` — no forwarding, fully isolated.
         context: Domain-specific backend passed through to the loop.
         state: Optional custom state. If None, uses _MinimalState.
         sub_tools: Optional custom tool registry. If None, clones parent
@@ -104,13 +118,22 @@ def run_sub_loop(
 
         subagent_id = uuid.uuid4().hex[:12]
 
+    # Wrap each parent hook so its ``on_event`` receives every event
+    # the sub-loop emits, tagged with this subagent_id so consumers
+    # can route / nest. We do NOT forward the full LoopHook interface
+    # (pre_loop, check_done, etc.) — those would conflate parent + sub
+    # state. Only event-stream observers see the activity.
+    sub_hooks: list[Any] = list(hooks or [])
+    if parent_hooks:
+        sub_hooks.append(_ParentHookForwarder(parent_hooks, subagent_id))
+
     # Fire SUBAGENT_START on the parent's hooks so observers see the
     # spawn. Import lazily to avoid a circular import with loop.py.
     from looplet.events import LifecycleEvent as _LE  # noqa: PLC0415
     from looplet.loop import emit_event  # noqa: PLC0415
 
     emit_event(
-        hooks or [],
+        list(parent_hooks or []) + (hooks or []),
         _LE.SUBAGENT_START,
         state=state,
         context=context,
@@ -133,7 +156,7 @@ def run_sub_loop(
         task=task,
         tools=sub_tools,
         context=context,
-        hooks=hooks or [],
+        hooks=sub_hooks,
         config=sub_config,
         state=state,
         session_log=session_log,
@@ -181,7 +204,7 @@ def run_sub_loop(
     # the llm-call cost via EventPayload.extra. Swallowing exceptions
     # is already handled by emit_event.
     emit_event(
-        hooks or [],
+        list(parent_hooks or []) + (hooks or []),
         _LE.SUBAGENT_STOP,
         state=state,
         context=context,
@@ -194,6 +217,53 @@ def run_sub_loop(
     )
     result["subagent_id"] = subagent_id
     return result
+
+
+class _ParentHookForwarder:
+    """Forwards a sub-loop's lifecycle events to the parent's hooks.
+
+    Implements only ``on_event`` (not the full ``LoopHook`` interface):
+    the sub-loop's per-step events are surfaced to parent observability
+    (MetricsHook, StreamingHook, TrajectoryRecorder, …) without letting
+    the parent's flow-control methods (``check_done``, ``pre_prompt``,
+    etc.) re-enter on sub state.
+
+    The forwarded :class:`EventPayload` is augmented with
+    ``subagent_id`` in its ``extra`` dict so consumers can distinguish
+    nested activity from the parent's own.
+    """
+
+    __slots__ = ("_parent_hooks", "_subagent_id")
+
+    def __init__(self, parent_hooks: list[Any], subagent_id: str) -> None:
+        self._parent_hooks = list(parent_hooks)
+        self._subagent_id = subagent_id
+
+    def on_event(self, payload: Any) -> None:
+        # Tag the payload's extra dict so parent observers can filter /
+        # nest sub-activity. Mutating the live payload is acceptable
+        # here — it's about to be discarded by every other observer at
+        # the end of this dispatch.
+        try:
+            extra = getattr(payload, "extra", None)
+            if isinstance(extra, dict):
+                extra.setdefault("subagent_id", self._subagent_id)
+        except Exception:  # noqa: BLE001
+            pass
+        for hook in self._parent_hooks:
+            handler = getattr(hook, "on_event", None)
+            if handler is None:
+                continue
+            try:
+                handler(payload)
+            except Exception:  # noqa: BLE001
+                # Parent hook misbehaviour must never break the sub-loop.
+                logger.warning(
+                    "parent hook %r raised during sub-loop event forward "
+                    "(subagent_id=%s); swallowing",
+                    type(hook).__name__,
+                    self._subagent_id,
+                )
 
 
 class _MinimalState:

--- a/src/looplet/testing.py
+++ b/src/looplet/testing.py
@@ -25,20 +25,37 @@ from __future__ import annotations
 from typing import Any
 
 __all__ = [
-    "MockLLMBackend",
     "AsyncMockLLMBackend",
+    "LLMResponsesExhausted",
+    "MockLLMBackend",
 ]
+
+
+class LLMResponsesExhausted(RuntimeError):
+    """Raised by ``MockLLMBackend(cycle=False)`` (and the async variant)
+    when ``generate`` is called more times than there are scripted
+    responses. Surfaces "the loop made N+1 calls but only N were
+    scripted" as a clear test failure instead of silently returning
+    the first response again.
+    """
 
 
 class MockLLMBackend:
     """Scripted synchronous LLM backend for tests.
 
     Accepts a list of responses at construction; each call to ``generate``
-    returns the next response, cycling once the list is exhausted.
+    returns the next response.
 
     Args:
         responses: List of strings to return in order. If ``None`` or empty,
             returns ``"mock response"`` on every call.
+        cycle: When ``True`` (the default, for backward compatibility),
+            wraps around to ``responses[0]`` once exhausted. When ``False``,
+            raises :class:`LLMResponsesExhausted` past the last response
+            so test authors notice the loop made more LLM calls than they
+            scripted (the silent-cycle behaviour produces confusing test
+            failures: every "extra" call returns the first response
+            again, making the loop look like it's stuck on step 1).
 
     Attributes:
         calls: Number of times ``generate`` has been called. Useful for
@@ -52,11 +69,23 @@ class MockLLMBackend:
         llm = MockLLMBackend(responses=["step 1", "step 2"])
         assert llm.generate("hi") == "step 1"
         assert llm.calls == 1
+
+        # In tests, prefer cycle=False so an over-run loop fails loudly:
+        strict = MockLLMBackend(responses=["only one"], cycle=False)
+        strict.generate("x")
+        with pytest.raises(LLMResponsesExhausted):
+            strict.generate("x")
     """
 
-    def __init__(self, responses: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        responses: list[str] | None = None,
+        *,
+        cycle: bool = True,
+    ) -> None:
         self._responses: list[str] = list(responses) if responses else ["mock response"]
         self._index: int = 0
+        self._cycle: bool = cycle
         self.calls: int = 0
         self.last_prompt: str = ""
         self.last_system_prompt: str = ""
@@ -72,6 +101,14 @@ class MockLLMBackend:
         self.calls += 1
         self.last_prompt = prompt
         self.last_system_prompt = system_prompt
+        if not self._cycle and self._index >= len(self._responses):
+            raise LLMResponsesExhausted(
+                f"MockLLMBackend(cycle=False): generate() called "
+                f"{self.calls} times but only {len(self._responses)} "
+                f"responses were scripted. The loop made more LLM calls "
+                f"than your test expected — either script more responses "
+                f"or arrange for the loop to terminate sooner."
+            )
         response = self._responses[self._index % len(self._responses)]
         self._index += 1
         return response
@@ -91,9 +128,15 @@ class AsyncMockLLMBackend:
     protocol — ``generate`` is a coroutine.
     """
 
-    def __init__(self, responses: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        responses: list[str] | None = None,
+        *,
+        cycle: bool = True,
+    ) -> None:
         self._responses: list[str] = list(responses) if responses else ["mock response"]
         self._index: int = 0
+        self._cycle: bool = cycle
         self.calls: int = 0
         self.last_prompt: str = ""
         self.last_system_prompt: str = ""
@@ -109,6 +152,14 @@ class AsyncMockLLMBackend:
         self.calls += 1
         self.last_prompt = prompt
         self.last_system_prompt = system_prompt
+        if not self._cycle and self._index >= len(self._responses):
+            raise LLMResponsesExhausted(
+                f"AsyncMockLLMBackend(cycle=False): generate() called "
+                f"{self.calls} times but only {len(self._responses)} "
+                f"responses were scripted. The loop made more LLM calls "
+                f"than your test expected — either script more responses "
+                f"or arrange for the loop to terminate sooner."
+            )
         response = self._responses[self._index % len(self._responses)]
         self._index += 1
         return response

--- a/src/looplet/tools.py
+++ b/src/looplet/tools.py
@@ -700,6 +700,9 @@ class BaseToolRegistry:
                     f"Unknown tool: {call.tool!r}.{did_you_mean} Available: {self.tool_names}"
                 ),
                 retriable=False,
+                recovery_hint=(
+                    f"Did you mean '{hint}'?" if hint else f"Available tools: {self.tool_names}"
+                ),
             )
             return ToolResult(
                 tool=call.tool,
@@ -808,6 +811,10 @@ class BaseToolRegistry:
                         f"Expected: {schema_hint}"
                     ),
                     retriable=True,
+                    recovery_hint={
+                        "empty_param": p,
+                        "expected": dict(spec.parameters or {}),
+                    },
                 )
                 return ToolResult(
                     tool=call.tool,
@@ -840,6 +847,11 @@ class BaseToolRegistry:
                     f"{did_you_mean} Expected: {schema_hint}"
                 ),
                 retriable=False,
+                recovery_hint={
+                    "unexpected": unknown,
+                    "did_you_mean": hint,
+                    "expected": dict(spec.parameters or {}),
+                },
             )
             return ToolResult(
                 tool=call.tool,
@@ -861,6 +873,11 @@ class BaseToolRegistry:
                     f"Expected: {schema_hint}"
                 ),
                 retriable=False,
+                recovery_hint={
+                    "missing": missing,
+                    "provided": provided,
+                    "expected": dict(spec.parameters or {}),
+                },
             )
             return ToolResult(
                 tool=call.tool,

--- a/src/looplet/types.py
+++ b/src/looplet/types.py
@@ -84,6 +84,28 @@ class ToolError:
     """Optional structured metadata — e.g. ``{"attempts": 3,
     "next_retry_in": 2.0}`` — attached by the producer for observability."""
 
+    recovery_hint: dict[str, Any] | str | None = None
+    """Optional structured suggestion for how the caller could recover.
+
+    Carries information that the LLM can act on directly. Two common
+    shapes:
+
+    * **Schema/shape hint** (``dict``): name the expected argument
+      shape so the model can correct a malformed call without
+      re-discovering the tool spec. The dispatcher's built-in
+      ``"got unexpected argument"`` and ``"missing required argument"``
+      errors set this to ``{"expected": <param_schema>}``.
+    * **Suggestion** (``str``): a "did you mean?" hint surfaced from
+      the tool. The dispatcher's ``"unknown tool"`` error sets this
+      to ``"Did you mean '<closest>'?"`` when one is found.
+
+    Tool authors should populate this on any error the model could
+    fix by changing its next call — leaving it ``None`` means "no
+    actionable recovery information" (a hard failure, e.g. a
+    permission deny). The recovery hint is included in the rendered
+    error text the loop hands back to the model on the next turn.
+    """
+
     def __bool__(self) -> bool:  # truthy like a string error
         return True
 

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -1954,6 +1954,27 @@ def _workspace_to_preset_inner(
                 timeout_s=yaml_payload.get("timeout_s"),
                 requires=list(yaml_payload.get("requires", []) or []),
             )
+            # Surface ``requires:`` typos at load time. Without this,
+            # a tool that declares ``requires: [my_resoruce]`` (typo)
+            # silently receives ``ctx.resources["my_resoruce"] = None``
+            # at dispatch time and crashes deep inside its body with
+            # ``AttributeError`` — forcing the user to read a stack
+            # trace inside their own tool to find the typo. Validating
+            # here points at the ``tool.yaml`` line directly.
+            if spec.requires:
+                missing = [r for r in spec.requires if r not in resources]
+                if missing:
+                    available = sorted(resources)
+                    msg = (
+                        f"tool {spec.name!r} (in {tool_dir.name!r}) declares "
+                        f"requires: {missing} but no such resource is defined. "
+                        f"Available resources: {available}. "
+                        f"Add a ``resources/<name>.py`` builder or fix the "
+                        f"``requires:`` list in ``tool.yaml``."
+                    )
+                    if strict:
+                        raise WorkspaceSerializationError(msg)
+                    logger.warning("%s; tool will receive None for missing resources", msg)
             registry.register(spec)
     # Hand the resource registry to the tool registry so any tool whose
     # ``ToolSpec.requires`` lists a resource name receives the live

--- a/tests/test_subagent_events_smoke.py
+++ b/tests/test_subagent_events_smoke.py
@@ -111,3 +111,100 @@ class TestSubagentLifecycleEvents:
         )
         assert result["subagent_id"]  # non-empty
         assert len(result["subagent_id"]) == 12
+
+
+# ── parent_hooks=... forwards sub-loop events to parent observers ──
+
+
+def test_parent_hooks_receive_sub_loop_events() -> None:
+    """``run_sub_loop(parent_hooks=...)`` forwards every lifecycle
+    event the sub-loop emits onto the parent's hooks via their
+    ``on_event`` method, tagged with ``subagent_id`` in
+    ``payload.extra``. Lets parent observability stacks (MetricsHook,
+    StreamingHook, TrajectoryRecorder) see sub-activity without the
+    user manually plumbing it."""
+    import json
+
+    from looplet import register_done_tool
+    from looplet.subagent import run_sub_loop
+    from looplet.testing import MockLLMBackend
+    from looplet.tools import BaseToolRegistry
+
+    received: list[tuple[str, dict | None]] = []
+
+    class _Spy:
+        def on_event(self, payload) -> None:
+            received.append((str(payload.event), dict(payload.extra or {})))
+
+    parent_hook = _Spy()
+
+    tools = BaseToolRegistry()
+    register_done_tool(tools)
+
+    sub_llm = MockLLMBackend(
+        responses=[
+            json.dumps({"tool": "done", "args": {"summary": "sub-done"}, "reasoning": "r"}),
+        ]
+    )
+
+    result = run_sub_loop(
+        llm=sub_llm,
+        task={"goal": "do nothing"},
+        tools=tools,
+        max_steps=2,
+        parent_hooks=[parent_hook],
+    )
+    assert result["subagent_id"]
+    # The parent's spy received SUBAGENT_START + SUBAGENT_STOP at minimum,
+    # both tagged with the same subagent_id.
+    event_names = [name for name, _ in received]
+    assert any("SUBAGENT_START" in n for n in event_names), event_names
+    assert any("SUBAGENT_STOP" in n for n in event_names), event_names
+    # And every event payload carries the subagent_id.
+    sub_ids = {extra.get("subagent_id") for _, extra in received if extra}
+    sub_ids.discard(None)
+    assert sub_ids == {result["subagent_id"]}, sub_ids
+
+
+def test_no_parent_hooks_means_no_forwarding() -> None:
+    """Without ``parent_hooks``, the sub-loop's events stay isolated
+    (default opt-in behaviour)."""
+    import json
+
+    from looplet import register_done_tool
+    from looplet.subagent import run_sub_loop
+    from looplet.testing import MockLLMBackend
+    from looplet.tools import BaseToolRegistry
+
+    received: list[str] = []
+
+    class _Spy:
+        def on_event(self, payload) -> None:
+            received.append(str(payload.event))
+
+    parent_hook = _Spy()
+
+    tools = BaseToolRegistry()
+    register_done_tool(tools)
+    sub_llm = MockLLMBackend(
+        responses=[
+            json.dumps({"tool": "done", "args": {"summary": "x"}, "reasoning": "r"}),
+        ]
+    )
+
+    # parent_hooks omitted → spy must see nothing.
+    run_sub_loop(
+        llm=sub_llm,
+        task={"goal": "x"},
+        tools=tools,
+        max_steps=2,
+        # hooks= is the SUB-loop's hooks — does not implicitly include
+        # the parent observer.
+    )
+    assert received == []
+    # And: even if you pass [parent_hook] as hooks=, it gets the
+    # sub-loop's full LoopHook interface (which it doesn't implement),
+    # not just on_event forwarding. The on_event method is still
+    # called for events, so we'd see them — that's the OLD behaviour.
+    # The new behaviour is that you can have parent observers see
+    # events WITHOUT sharing the sub-loop's full hook interface.

--- a/tests/test_testing_smoke.py
+++ b/tests/test_testing_smoke.py
@@ -42,3 +42,48 @@ class TestMockLLMBackendSmoke:
         llm = MockLLMBackend()
         llm.generate("hi", system_prompt="sys")
         assert llm.last_system_prompt == "sys"
+
+
+# ── MockLLMBackend(cycle=False) — outcome-side ergonomics ──
+
+
+def test_mock_backend_default_still_cycles() -> None:
+    """Backward compat: cycle=True is the default and existing tests
+    that rely on cycling continue to work."""
+    from looplet.testing import MockLLMBackend
+
+    llm = MockLLMBackend(responses=["a", "b"])
+    assert [llm.generate("x") for _ in range(5)] == ["a", "b", "a", "b", "a"]
+
+
+def test_mock_backend_cycle_false_raises_when_exhausted() -> None:
+    """``cycle=False`` raises ``LLMResponsesExhausted`` past the last
+    response. Lets test authors notice when the loop made more LLM
+    calls than they scripted (which otherwise silently re-uses
+    response[0] and looks like "stuck on step 1")."""
+    import pytest
+
+    from looplet.testing import LLMResponsesExhausted, MockLLMBackend
+
+    llm = MockLLMBackend(responses=["only one"], cycle=False)
+    assert llm.generate("x") == "only one"
+    with pytest.raises(LLMResponsesExhausted, match="2 times"):
+        llm.generate("y")
+
+
+def test_async_mock_backend_cycle_false_raises_when_exhausted() -> None:
+    """Same contract on the async variant."""
+    import asyncio
+
+    import pytest
+
+    from looplet.testing import AsyncMockLLMBackend, LLMResponsesExhausted
+
+    llm = AsyncMockLLMBackend(responses=["only one"], cycle=False)
+
+    async def _drive() -> None:
+        assert await llm.generate("x") == "only one"
+        with pytest.raises(LLMResponsesExhausted):
+            await llm.generate("y")
+
+    asyncio.run(_drive())

--- a/tests/test_tool_error_taxonomy.py
+++ b/tests/test_tool_error_taxonomy.py
@@ -119,3 +119,76 @@ class TestDispatchMapsExceptions:
         res = reg.dispatch(ToolCall(tool="nope", args={}))
         assert res.error_detail is not None
         assert res.error_detail.kind == ErrorKind.VALIDATION
+
+
+# ── recovery_hint surfaces actionable structure on dispatcher errors ──
+
+
+def test_unknown_tool_error_carries_recovery_hint() -> None:
+    """``ToolError.recovery_hint`` carries a 'did you mean?' suggestion
+    for typos. Information-additive: smarter models can self-correct
+    from the structured hint without needing to re-discover the
+    catalog from prose."""
+    from looplet import ToolSpec
+    from looplet.tools import BaseToolRegistry
+    from looplet.types import ToolCall
+
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="search", description="d", parameters={"q": "query"}, execute=lambda *, q: {"q": q}
+        )
+    )
+    result = reg.dispatch(ToolCall(tool="serach", args={"q": "x"}))
+    assert result.error_detail is not None
+    hint = result.error_detail.recovery_hint
+    assert hint is not None
+    assert "search" in str(hint)
+
+
+def test_missing_arg_error_carries_recovery_hint() -> None:
+    """Missing required arg → ``recovery_hint`` carries the structured
+    ``{missing, provided, expected}`` so the model knows exactly what
+    to add on the next call."""
+    from looplet import ToolSpec
+    from looplet.tools import BaseToolRegistry
+    from looplet.types import ToolCall
+
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="rank",
+            description="d",
+            parameters={"column": "col", "choices": "list"},
+            execute=lambda *, column, choices: {},
+        )
+    )
+    result = reg.dispatch(ToolCall(tool="rank", args={"column": "x"}))
+    assert result.error_detail is not None
+    hint = result.error_detail.recovery_hint
+    assert isinstance(hint, dict)
+    assert "missing" in hint and "choices" in hint["missing"]
+    assert "provided" in hint and "column" in hint["provided"]
+    assert "expected" in hint and "choices" in hint["expected"]
+
+
+def test_unexpected_arg_error_carries_recovery_hint() -> None:
+    """Unexpected arg → ``recovery_hint`` carries did_you_mean +
+    expected so the model can fix the typo or drop the bogus arg."""
+    from looplet import ToolSpec
+    from looplet.tools import BaseToolRegistry
+    from looplet.types import ToolCall
+
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="rank", description="d", parameters={"column": "col"}, execute=lambda *, column: {}
+        )
+    )
+    result = reg.dispatch(ToolCall(tool="rank", args={"colmun": "x"}))
+    assert result.error_detail is not None
+    hint = result.error_detail.recovery_hint
+    assert isinstance(hint, dict)
+    assert hint["did_you_mean"] == "column"
+    assert "colmun" in hint["unexpected"]
+    assert "expected" in hint

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1886,3 +1886,61 @@ def test_workspace_root_resources_dir_is_on_sys_path(tmp_path: Path) -> None:
     result = preset.tools.dispatch(ToolCall(tool="ping", args={}))
     assert result.error is None
     assert result.data == {"msg": "hello-from-resource"}
+
+
+# ── tool requires: validation at load time ──
+
+
+def test_tool_requires_unknown_resource_warns_in_loose_mode(tmp_path: Path, caplog) -> None:
+    """A typo in tool.yaml ``requires:`` must be surfaced at load time
+    (loose mode → warning) rather than silently set to None and crashing
+    deep inside the tool body at dispatch time."""
+    import logging
+
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "tools" / "demo").mkdir(parents=True)
+    # Typo — workspace_confgi instead of workspace_config.
+    (src / "tools/demo/tool.yaml").write_text(
+        "name: demo\nparameters: {}\nrequires:\n  - workspace_confgi\n"
+    )
+    (src / "tools/demo/execute.py").write_text("def execute(ctx): return {}\n")
+
+    with caplog.at_level(logging.WARNING, logger="looplet.workspace"):
+        workspace_to_preset(src)
+    assert any("workspace_confgi" in rec.message for rec in caplog.records), (
+        f"expected warning about missing resource; got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_tool_requires_unknown_resource_raises_in_strict_mode(tmp_path: Path) -> None:
+    """Same typo, strict=True → WorkspaceSerializationError before the
+    loop ever runs."""
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "tools" / "demo").mkdir(parents=True)
+    (src / "tools/demo/tool.yaml").write_text(
+        "name: demo\nparameters: {}\nrequires:\n  - missing_resource\n"
+    )
+    (src / "tools/demo/execute.py").write_text("def execute(ctx): return {}\n")
+
+    with pytest.raises(WorkspaceSerializationError, match="missing_resource"):
+        workspace_to_preset(src, strict=True)


### PR DESCRIPTION
## Summary

Four small fixes from dogfooding two new agents (`sql_analyst`, `research_librarian`) and one big coding task (shortlink ttl-cache). All four are **information-additive** — they surface more information to the model / user without imposing process opinions that would limit how more capable models can recover. (Outcome > process: anything that says "the model probably wants X" or "the model shouldn't do Y" was deliberately dropped from the friction list.)

## Changes

### 1. `ToolError.recovery_hint` (new optional field)

Dispatcher populates it on the four self-correctable errors:

| Error | `recovery_hint` |
|---|---|
| Unknown tool | `"Did you mean '<closest>'?"` |
| Unexpected argument | `{unexpected, did_you_mean, expected}` |
| Missing argument | `{missing, provided, expected}` |
| Empty required arg | `{empty_param, expected}` |

Smarter models can act on the structured hint directly; existing models still see the same human prose message in `ToolError.message`.

### 2. `tool.yaml requires:` validated at workspace-load time

A typo in `requires: [my_resoruce]` previously slid all the way to dispatch where the tool body crashed with `AttributeError` deep in user code. Now the loader walks each tool's `requires:` list against the resource registry and:
- **Loose mode** (default): emits a warning naming the missing resource and listing available ones.
- **Strict mode**: raises `WorkspaceSerializationError` before the loop ever runs.

### 3. `run_sub_loop(parent_hooks=...)` — opt-in observer forwarding

When a parent agent dispatches a tool whose `execute` calls `run_sub_loop`, the parent's observability stack (`MetricsHook`, `StreamingHook`, `TrajectoryRecorder`) used to see only the outer tool dispatch, never the sub-loop's per-step activity. Now callers can pass `parent_hooks=` and the sub-loop's lifecycle events forward to the parent via their `on_event` method **only** (the full `LoopHook` interface is NOT forwarded — that would conflate parent + sub state). Each forwarded payload is tagged with `subagent_id` in its `extra` dict so consumers can route / nest. **Default behaviour unchanged**: no forwarding, sub-loop fully isolated.

### 4. `MockLLMBackend(cycle=False)` + new `LLMResponsesExhausted`

The default still cycles for back-compat. Passing `cycle=False` makes the mock raise when `generate` is called past the scripted response list — surfaces test-author miscounts as a clear failure instead of silently re-using `responses[0]` (which made over-running loops look "stuck on step 1"). Same flag on `AsyncMockLLMBackend`.

## What was deliberately NOT changed

Three frictions surfaced during dogfooding turned out to be **process gating** in disguise — would have hardcoded process opinions that limit what more capable models can do. Dropped:

- **Stagnation default fingerprint change.** "Agent did 8 redundant grep calls" looks like waste, but a smarter model in 6 months might do it in 2 and a different model might genuinely need 10. Hardcoding `result_size_fingerprint` as the default would penalize both.
- **Per-tool consecutive-error cap.** Capping at N=5 means a model that recovers on call 6 never gets to. Today's models can recover from sequences that broke yesterday's.
- **Compaction defaults as fractions of `context_window`.** Tighter defaults throw away information the model wanted. The current `blocking_at` ceiling already prevents prompt-too-long errors (the actual outcome failure).

The current `PerToolLimitHook(default_limit=N)` already bounds total budget — that's the principled outcome-side concern. Don't add an "error-streak" cap that prejudges what a productive trajectory looks like.

## Tests (+10)

- `test_tool_requires_unknown_resource_warns_in_loose_mode`
- `test_tool_requires_unknown_resource_raises_in_strict_mode`
- `test_mock_backend_default_still_cycles`
- `test_mock_backend_cycle_false_raises_when_exhausted`
- `test_async_mock_backend_cycle_false_raises_when_exhausted`
- `test_parent_hooks_receive_sub_loop_events`
- `test_no_parent_hooks_means_no_forwarding`
- `test_unknown_tool_error_carries_recovery_hint`
- `test_missing_arg_error_carries_recovery_hint`
- `test_unexpected_arg_error_carries_recovery_hint`

**1613 tests pass** (was 1603 + 10 new). Lint + pyright clean.

## Backward compatibility

- All four changes are additive. New fields default to falsy (`recovery_hint=None`, `parent_hooks=None`); new flags default to back-compat (`cycle=True`); new validator only emits warnings in loose mode.
- `ToolError(kind=..., message=...)` constructor signature unchanged (recovery_hint is optional with default).
- `MockLLMBackend(responses=...)` signature unchanged (cycle is keyword-only with default).
- `run_sub_loop(...)` existing kwargs unchanged.
