### PR TITLE
fix(workspace): don't register unhashable instances in _resource_origin

### DIFF
--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -530,28 +530,40 @@ def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[s
 # Identity-keyed map from a resource-built instance's ``id()`` to its
 # ref name. Keyed by ``id`` because the instance may be unhashable (a
 # list, a dict) or its hash semantics may collide with another
-# instance. Entries are dropped on instance GC via ``weakref.finalize``
-# so this map can't leak memory.
+# instance. Entries are dropped on instance GC via ``weakref.finalize``;
+# instances that don't support weak references (built-in containers
+# like ``list`` / ``tuple`` / ``dict``) are NOT registered here at all
+# because their ``id()`` would be reused by a later same-typed object
+# whose source bears no relation to this resource. The
+# ``__module__``-based fallback in :func:`resource_ref_for` covers
+# those cases (closures created inside the resource module's
+# ``build()`` carry the synthetic ``_chw_resource_<name>`` module).
 _resource_origin: dict[int, str] = {}
 
 
 def _register_resource_origin(instance: Any, name: str) -> None:
     """Record that ``instance`` came from ``resources/<name>.py``.
 
-    Tries to attach a weakref finalizer; falls back to a best-effort
-    registration without finalizer for objects that don't support
-    weak references (e.g. tuples). The non-finalized entries are
-    cleaned up opportunistically the next time
-    :func:`_load_resources` runs for the same workspace.
+    Only registers instances that support :mod:`weakref`. Built-in
+    containers (``list``, ``tuple``, ``dict``, ``set``) and other
+    types that reject weak references would otherwise pin a stale
+    entry forever — and Python's ``id()`` can be reused once the
+    original object is garbage-collected, leading to false positives
+    in :func:`resource_ref_for`. Skip them here; their identity is
+    recovered via the ``__module__``-based fallback path.
     """
     import weakref  # noqa: PLC0415
 
     key = id(instance)
-    _resource_origin[key] = name
     try:
         weakref.finalize(instance, _resource_origin.pop, key, None)
     except TypeError:
-        pass  # built-in containers don't support weak refs; OK
+        # Object can't be weak-referenced (list / tuple / dict / set /
+        # bare int / etc.) — skip the identity registration entirely
+        # so a future object at the same ``id()`` can't pick up this
+        # name by accident.
+        return
+    _resource_origin[key] = name
 
 
 _REF_PREFIX = "@"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1944,3 +1944,57 @@ def test_tool_requires_unknown_resource_raises_in_strict_mode(tmp_path: Path) ->
 
     with pytest.raises(WorkspaceSerializationError, match="missing_resource"):
         workspace_to_preset(src, strict=True)
+
+
+# ── _resource_origin must not leak across tests ──
+
+
+def test_resource_origin_drops_unhashable_to_prevent_id_reuse_collision(
+    tmp_path: Path,
+) -> None:
+    """Regression test for a CI-only flake on master after PR #39:
+    when ``_load_resources`` registered an ``EvalHook.evaluators``
+    list (built by a workspace ``resources/eval_evaluators.py``) into
+    the identity-keyed ``_resource_origin``, the entry pinned forever
+    because ``weakref.finalize(list, ...)`` raises TypeError. Python's
+    ``id()`` is reused after GC, so a *different* test's brand-new
+    evaluators list could land at the same id and inherit the
+    previous workspace's ref name — making the writer try to copy a
+    no-longer-existent ``resources/<name>.py`` file.
+
+    Fix: instances that don't support weak references are NOT
+    registered in ``_resource_origin``; the ``__module__``-based
+    fallback in ``resource_ref_for`` handles them via the
+    synthetic ``_chw_resource_<name>`` module name on closures
+    defined inside the resource builder.
+    """
+    from looplet import workspace as _ws
+
+    src = tmp_path / "ws"
+    src.mkdir()
+    (src / "workspace.json").write_text('{"name": "w"}')
+    (src / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (src / "tools" / "done").mkdir(parents=True)
+    (src / "tools/done/tool.yaml").write_text(
+        "name: done\nparameters:\n  s: {type: string, description: s}\n"
+    )
+    (src / "tools/done/execute.py").write_text(
+        "def execute(*, s='ok'): return {'status': 'completed', 's': s}\n"
+    )
+    (src / "resources").mkdir()
+    (src / "resources/my_list.py").write_text(
+        "def build(runtime=None):\n"
+        "    # A bare list — built-in containers don't support weakref.\n"
+        "    return [lambda x: x]\n"
+    )
+
+    before = len(_ws._resource_origin)
+    workspace_to_preset(src)
+    after = len(_ws._resource_origin)
+    # The list returned by build() must NOT have been registered (would
+    # leak a stale id → name mapping across loads / tests).
+    assert after == before, (
+        "unhashable resource instance was registered in _resource_origin; "
+        "this would leak a stale id reservation that a later same-typed "
+        f"object could collide with (size went from {before} to {after})"
+    )


### PR DESCRIPTION
Master CI is failing on py3.13 with PR #41 due to a flaky test ordering interaction with the identity registry from PR #39. `_register_resource_origin` was registering built-in containers (list/tuple/dict) but their `weakref.finalize` raises TypeError, leaving entries pinned forever. Python's `id()` reuse after GC then made later tests inherit stale ref names → `FileNotFoundError` when the writer tried to copy a deleted tmpdir's resource file.

Fix: skip identity registration when the instance can't be weak-referenced; rely on the `__module__`-based fallback (which keys off the synthetic `_chw_resource_<name>` module that stays in `sys.modules`).

+1 regression test pinning the invariant. 1568 tests pass.