### PR TITLE
feat(coder): read-required edit + bash safety + rich tool yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   change. ROADMAP entries that have shipped are dropped.
 
 ### Added
+- **`examples/coder.workspace` per-tool guidance + safety.** Three
+  information-additive improvements modelled on patterns observed in
+  production coding agents:
+  1. **Read-required-first on `edit_file`.** `FileCache` now tracks
+     every path passed to `read_file`; `edit_file` refuses with a
+     model-actionable error (`{error, missing: "prior_read",
+     recovery: "read_file(...)"}`) when called on a file that hasn't
+     been read in the current session. Editing without reading is the
+     #1 cause of `old_string` mismatch failures.
+  2. **`bash` safety classifiers.** New `classify_bash_command` and
+     `classify_sed_command` helpers in `coder_lib_tools.py` flag
+     destructive command/flag combinations (`rm -rf`, `git push
+     --force`, `git reset --hard`, `shutdown`, `mkfs`, …) and
+     `sed -i` in-place edits (which bypass the file_cache and cause
+     stale reads). The bash tool refuses both with a structured error
+     pointing at a safer alternative (`edit_file` for in-place edits).
+     The classifiers are exported so other workspaces can reuse them.
+  3. **Rich per-tool descriptions.** Every `tool.yaml` in
+     `examples/coder.workspace` rewritten as a multi-paragraph
+     description (Usage / Refusals / Examples / Recovery sections)
+     using YAML block scalars (`|-`). The looplet workspace YAML
+     loader gained `|`/`|-`/`>` block-scalar support so these
+     descriptions round-trip correctly.
 - **`ToolError.recovery_hint`** — structured suggestion (dict or str)
   for how the caller could recover. The dispatcher now populates it
   on the four self-correctable errors: unknown-tool ("did you mean?"),

--- a/examples/coder.workspace/coder_lib_tools.py
+++ b/examples/coder.workspace/coder_lib_tools.py
@@ -299,6 +299,62 @@ def classify_sed_command(command: str) -> dict[str, Any]:
     return {"in_place_edit": False, "recommendation": ""}
 
 
+_VIEW_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "less", "more"})
+
+
+def classify_view_command(command: str) -> dict[str, Any]:
+    """Detect ``cat``/``head``/``tail``/``less``/``more`` used to view a single
+    source file (which bypasses the read_file file_cache).
+
+    Heuristics:
+
+    * Only flags the *first* subcommand of the pipeline, because using
+      ``... | head`` to trim *output* of another command is fine.
+    * Refuses only when the command's positional args look like file
+      paths (no ``-`` stdin marker, at least one arg without a leading
+      ``-`` that points at an existing-looking source file).
+    * Lets ``cat``-as-pipe-source through when the file is clearly not
+      project source (e.g. ``/proc/...``, ``/dev/...``, ``/tmp/`` outside
+      the workspace) — but the conservative default is to refuse so the
+      model self-corrects to ``read_file``.
+
+    Returns ``{"viewing_file": bool, "first_token": str, "recommendation": str}``.
+    """
+    parts = re.split(r"&&|\|\||;", command)
+    first = parts[0].strip() if parts else ""
+    tokens = first.split()
+    if not tokens:
+        return {"viewing_file": False, "first_token": "", "recommendation": ""}
+    name = tokens[0].rsplit("/", 1)[-1]
+    if name not in _VIEW_COMMANDS:
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+    # Look at positional args (skip flags). If none look like files,
+    # this is probably reading from stdin / a pipe — let it through.
+    positional = [t for t in tokens[1:] if not t.startswith("-")]
+    if not positional:
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+
+    # Allow virtual / device paths (these are never project source).
+    def is_project_path(arg: str) -> bool:
+        if arg.startswith(("/proc/", "/dev/", "/sys/")):
+            return False
+        return True
+
+    if not any(is_project_path(p) for p in positional):
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+    return {
+        "viewing_file": True,
+        "first_token": name,
+        "recommendation": (
+            f"Use read_file to view source files. `{name}` bypasses "
+            "the file_cache, so a subsequent edit_file on the same "
+            "path will be refused with 'not been read in current "
+            "session'. Pipe-trimming output of another command "
+            "(e.g. `grep ... | head`) is still fine."
+        ),
+    }
+
+
 # ── File cache ─────────────────────────────────────────────────────
 
 

--- a/examples/coder.workspace/coder_lib_tools.py
+++ b/examples/coder.workspace/coder_lib_tools.py
@@ -23,6 +23,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from looplet import tool, tools_from
 
@@ -160,6 +161,144 @@ def _is_path_inside(target: Path, root: Path) -> bool:
         return False
 
 
+# ── Bash safety helpers ────────────────────────────────────────────
+
+
+# Commands that destroy data or alter system state. The bash tool
+# refuses to run any pipeline whose first token (or, after a
+# control-operator split, the first token of any subcommand) appears
+# in this set without the user's permission engine having explicitly
+# allowed it. The list intentionally covers the common footguns rather
+# than trying to be exhaustive — anything novel still flows through
+# the regular permission engine, which is the principled gate.
+_DESTRUCTIVE_COMMANDS: frozenset[str] = frozenset(
+    {
+        "dd",  # raw block-device writes
+        "mkfs",  # filesystem creation
+        "shred",  # secure delete
+        "shutdown",
+        "reboot",
+        "halt",
+        "poweroff",
+        "kill",  # process termination (kills any pid; use Ctrl-C in tests)
+        "killall",
+        "pkill",
+    }
+)
+
+# Argument-pattern flags that turn an otherwise-safe command into a
+# destructive one (e.g. ``rm -rf`` vs ``rm`` alone — the latter is
+# fine for individual files). Maps command name → tuple of flag
+# patterns that elevate it.
+_DESTRUCTIVE_FLAGS: dict[str, tuple[str, ...]] = {
+    "rm": ("-rf", "-fr", "-Rf", "-fR", "--recursive"),
+    "git": (
+        "push --force",
+        "push -f",
+        "reset --hard",
+        "clean -fd",
+        "branch -D",
+        "checkout --force",
+    ),
+}
+
+
+def classify_bash_command(command: str) -> dict[str, Any]:
+    r"""Inspect ``command`` and return a structured safety classification.
+
+    Returns a dict with:
+
+    * ``destructive`` (bool) — True when the command is in the
+      destructive-name set or matches a destructive-flag pattern.
+    * ``reasons`` (list[str]) — human-readable reasons; empty when
+      the command is considered safe.
+    * ``first_token`` (str) — the leading executable name parsed from
+      the command (best-effort; complex shell syntax may not parse).
+
+    The bash tool surfaces these as a model-actionable error rather
+    than running the command. Callers building their own bash wrapper
+    can use ``classify_bash_command`` directly to filter or warn.
+
+    The classification is deliberately conservative: it covers
+    *patterns the model commonly tries by mistake* (\`rm -rf\` on
+    cwd, ``git push --force`` to a shared remote) and bows out for
+    novel commands so the permission engine can decide. It is **not**
+    a sandbox.
+    """
+    reasons: list[str] = []
+    # Split on bash control operators so we can inspect each subcommand.
+    # ``cmd1 && cmd2 || cmd3 ; cmd4 | cmd5 & cmd6`` → 6 tokens.
+    parts = re.split(r"&&|\|\||\||;|&", command)
+    first_token = ""
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        # The leading word is the command name; strip leading parens
+        # / brackets that wrap subshells (best-effort; not a parser).
+        head = part.lstrip("()[]{ \t").split()
+        if not head:
+            continue
+        name = head[0]
+        if not first_token:
+            first_token = name
+        if name in _DESTRUCTIVE_COMMANDS:
+            reasons.append(f"destructive command {name!r} (in {sorted(_DESTRUCTIVE_COMMANDS)})")
+            continue
+        bad_flags = _DESTRUCTIVE_FLAGS.get(name, ())
+        for flag in bad_flags:
+            # Substring match works for both single-token (-rf) and
+            # multi-token (push --force) patterns.
+            if flag in part:
+                reasons.append(f"destructive flag {flag!r} in {name!r} subcommand")
+                break
+    return {
+        "destructive": bool(reasons),
+        "reasons": reasons,
+        "first_token": first_token,
+    }
+
+
+def classify_sed_command(command: str) -> dict[str, Any]:
+    """Detect ``sed -i`` (in-place edit) usage in ``command``.
+
+    ``sed -i`` rewrites files outside the model's read-then-edit
+    discipline and bypasses the file_cache invalidation that
+    ``edit_file`` does — so a subsequent ``read_file`` may return
+    cached pre-edit content. Surface a model-actionable error
+    pointing the model at ``edit_file`` instead of refusing
+    silently.
+
+    Returns a dict with:
+
+    * ``in_place_edit`` (bool) — True when any subcommand is
+      ``sed -i ...`` or ``sed --in-place ...``.
+    * ``recommendation`` (str) — short guidance ("use edit_file
+      instead") when ``in_place_edit``; empty otherwise.
+    """
+    parts = re.split(r"&&|\|\||\||;|&", command)
+    for part in parts:
+        part = part.strip()
+        # Token-aware: avoid matching ``sed-i`` package names or
+        # ``echo "sed -i"`` content.
+        if not part.startswith("sed "):
+            continue
+        # Look for ``-i`` as a standalone flag or a flag with bundled
+        # backup-suffix arg (``-i.bak``); also ``--in-place``.
+        tokens = part.split()
+        for tok in tokens[1:]:
+            if tok == "-i" or tok.startswith("-i.") or tok == "--in-place":
+                return {
+                    "in_place_edit": True,
+                    "recommendation": (
+                        "Use the edit_file tool for in-place file edits. "
+                        "sed -i bypasses the file cache, so the next "
+                        "read_file can return stale content."
+                    ),
+                }
+    return {"in_place_edit": False, "recommendation": ""}
+
+
 # ── File cache ─────────────────────────────────────────────────────
 
 
@@ -179,6 +318,7 @@ class FileCache:
         self._order: list[str] = []
         self._mtimes: dict[str, float] = {}  # path -> mtime when last read
         self._hashes: dict[str, str] = {}  # path -> content hash when last read
+        self._read_set: set[str] = set()  # every path ever passed to record()
 
     def record(self, path: str) -> None:
         p = Path(self._workspace) / path
@@ -188,6 +328,7 @@ class FileCache:
             content = p.read_text()
             self._hashes[path] = hashlib.sha256(content.encode()).hexdigest()[:16]
             self._mtimes[path] = p.stat().st_mtime
+            self._read_set.add(path)
             if len(content) > self._max_chars:
                 content = content[: self._max_chars] + "\n... [truncated]"
             self._recent[path] = content
@@ -233,6 +374,17 @@ class FileCache:
         file_unchanged optimization must not fire on the next read.
         """
         self._hashes.pop(path, None)
+
+    def was_read(self, path: str) -> bool:
+        """True iff ``read_file`` has been called for ``path`` in this
+        session. Used by ``edit_file`` to enforce read-before-edit:
+        editing a file the model hasn't read is almost always a sign
+        the model is guessing at content. The error returned by
+        ``edit_file`` in that case names the read tool explicitly so
+        the model fixes the next call rather than retrying with
+        different text.
+        """
+        return path in self._read_set
 
     def render(self) -> str:
         if not self._recent:

--- a/examples/coder.workspace/tools/bash/execute.py
+++ b/examples/coder.workspace/tools/bash/execute.py
@@ -33,6 +33,7 @@ from coder_lib_tools import (
     _run,
     classify_bash_command,
     classify_sed_command,
+    classify_view_command,
 )
 
 from looplet.types import ToolContext
@@ -70,6 +71,20 @@ def execute(ctx: ToolContext, *, command: str) -> dict:
                 + sed["recommendation"]
             ),
             "recovery": "edit_file(file_path=..., old_string=..., new_string=...)",
+        }
+
+    # cat/head/tail/less on a source file refusal: route file viewing
+    # through read_file so the file_cache records the read and the
+    # next edit_file can succeed.
+    view = classify_view_command(command)
+    if view["viewing_file"]:
+        return {
+            "error": (
+                f"Refused: `{view['first_token']}` on a source file bypasses "
+                "the file_cache. " + view["recommendation"]
+            ),
+            "first_token": view["first_token"],
+            "recovery": "read_file(file_path=...)",
         }
 
     result = _run(command, workspace)

--- a/examples/coder.workspace/tools/bash/execute.py
+++ b/examples/coder.workspace/tools/bash/execute.py
@@ -5,6 +5,19 @@ Receives the workspace_config resource through ``ctx.resources``
 [workspace_config]``). Top-level function (no closures) so it
 round-trips losslessly through ``preset_to_workspace``.
 
+Pre-dispatch checks (model-actionable, fail-loud rather than silent):
+
+* **Destructive command detection.** A small allow-list of
+  patterns (``rm -rf``, ``git push --force``, ``dd``, ``mkfs``,
+  process killers) refuses execution and points at the safer
+  alternative. Novel commands flow through unchanged — the
+  permission engine is the principled gate.
+* **sed -i refusal.** ``sed`` in-place edits bypass the file_cache,
+  causing the next ``read_file`` to return stale content. Refuses
+  with a pointer at ``edit_file``.
+* **cd-outside-workspace warning.** Surfaces (does not block) a
+  ``cd`` whose target escapes the project root.
+
 The actual command-execution logic lives in ``coder_lib_tools._run``
 so this file stays a thin adapter and all tools share one
 battle-tested implementation.
@@ -15,7 +28,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from coder_lib_tools import _is_path_inside, _run
+from coder_lib_tools import (
+    _is_path_inside,
+    _run,
+    classify_bash_command,
+    classify_sed_command,
+)
 
 from looplet.types import ToolContext
 
@@ -23,7 +41,39 @@ from looplet.types import ToolContext
 def execute(ctx: ToolContext, *, command: str) -> dict:
     cfg = ctx.resources.get("workspace_config")
     workspace = cfg.path if cfg is not None else "."
+
+    # Destructive-command pre-flight. Returns model-actionable error
+    # naming each reason so the model can adjust the next call.
+    classification = classify_bash_command(command)
+    if classification["destructive"]:
+        return {
+            "error": (
+                "Refused: destructive command pattern detected. "
+                + " ".join(classification["reasons"])
+                + ". If this is intentional, ask the user to confirm."
+            ),
+            "first_token": classification["first_token"],
+            "reasons": classification["reasons"],
+            "recovery": (
+                "Pick a safer alternative (e.g. remove specific files instead "
+                "of `rm -rf`; create a NEW commit instead of `git reset --hard`)."
+            ),
+        }
+
+    # sed -i refusal: route in-place edits through edit_file so the
+    # file_cache stays coherent.
+    sed = classify_sed_command(command)
+    if sed["in_place_edit"]:
+        return {
+            "error": (
+                "Refused: `sed -i` in-place file edits bypass the file_cache. "
+                + sed["recommendation"]
+            ),
+            "recovery": "edit_file(file_path=..., old_string=..., new_string=...)",
+        }
+
     result = _run(command, workspace)
+
     # Detect cd outside workspace and surface a warning so the model
     # doesn't silently lose track of where commands run.
     parts = re.split(r"&&|\|\||;|\n", command)

--- a/examples/coder.workspace/tools/bash/tool.yaml
+++ b/examples/coder.workspace/tools/bash/tool.yaml
@@ -13,6 +13,7 @@ description: |-
   Refusals (model-actionable, fail-loud):
   - **Destructive commands** are refused: `rm -rf`, `git push --force`, `git reset --hard`, `dd`, `mkfs`, `kill`, `shutdown`. The error names the matched pattern; pick a safer alternative (delete specific files, create a NEW commit, etc.) or ask the user to authorize the action.
   - **`sed -i`** is refused: in-place sed bypasses the file_cache so the next read_file would return stale content. Use `edit_file` for in-place file edits.
+  - **`cat` / `cat -n` / `head` / `tail` / `less` / `more` on a single source file** is refused: viewing files through bash bypasses the file_cache, which then refuses your next `edit_file` because the file "wasn't read" in this session. Use `read_file` to view file contents. (`cat`/`head`/`tail` are still allowed when piping output of another command, e.g. `grep ... | head`.)
   - **`cd` outside the project root** is allowed but produces a warning so you don't lose track of where commands run.
 
   Examples:

--- a/examples/coder.workspace/tools/bash/tool.yaml
+++ b/examples/coder.workspace/tools/bash/tool.yaml
@@ -1,9 +1,28 @@
 name: bash
-description: Execute a bash command in the project directory.
+description: |-
+  Execute a bash command in the project directory and return stdout, stderr, and exit code.
+
+  Usage:
+  - Use this for system commands and terminal operations that don't have a dedicated tool.
+  - Prefer the dedicated tools (read_file, write_file, edit_file, grep, glob, list_dir) over equivalent shell commands so the user / observers can review your work consistently. Only fall back on bash when no dedicated tool fits.
+  - All commands run with cwd = the project root. Use relative paths.
+  - Each call is independent: state set by `cd`, `export`, etc. does NOT carry across calls. Chain with `&&`, `;`, or `|` if you need shared state inside one call.
+  - Output is captured into the result. Long output may be truncated; for very large outputs prefer grep/head/tail to filter at source.
+  - Default timeout: 600s. Long-running commands that exceed it are terminated.
+
+  Refusals (model-actionable, fail-loud):
+  - **Destructive commands** are refused: `rm -rf`, `git push --force`, `git reset --hard`, `dd`, `mkfs`, `kill`, `shutdown`. The error names the matched pattern; pick a safer alternative (delete specific files, create a NEW commit, etc.) or ask the user to authorize the action.
+  - **`sed -i`** is refused: in-place sed bypasses the file_cache so the next read_file would return stale content. Use `edit_file` for in-place file edits.
+  - **`cd` outside the project root** is allowed but produces a warning so you don't lose track of where commands run.
+
+  Examples:
+  - `pytest -xvs` (stop on first failure, verbose)
+  - `git status && git diff --stat`
+  - `ls -la src/ | head -20`
 parameters:
   command:
     type: string
-    description: Shell command to execute (e.g. "pytest -xvs", "ls -la", "git status").
+    description: Shell command to execute. Single string, may contain pipes / && / ;.
 timeout_s: 600
 requires:
   - workspace_config

--- a/examples/coder.workspace/tools/edit_file/execute.py
+++ b/examples/coder.workspace/tools/edit_file/execute.py
@@ -23,6 +23,23 @@ def execute(ctx: ToolContext, *, file_path: str, old_string: str, new_string: st
         return {"error": f"Path '{file_path}' is outside the project directory."}
     if not p.exists():
         return {"error": f"File not found: {file_path}"}
+    # Read-before-edit enforcement. Editing a file the model hasn't
+    # read in this session is almost always a sign that the model is
+    # guessing at content — the resulting old_string usually doesn't
+    # match and the call wastes a turn. Refuse early with a message
+    # that names the read tool so the model self-corrects.
+    if cache is not None and not cache.was_read(file_path):
+        return {
+            "error": (
+                f"Cannot edit {file_path!r}: this file has not been read in "
+                f"the current session. Call read_file({file_path!r}) first so "
+                f"you can copy old_string verbatim from its content. Editing "
+                f"without reading first usually fails because the file's "
+                f"actual contents differ from what was assumed."
+            ),
+            "missing": "prior_read",
+            "recovery": f"read_file(file_path={file_path!r})",
+        }
     if old_string == new_string:
         return {"error": "old_string and new_string are identical. No change needed."}
     text = p.read_text()

--- a/examples/coder.workspace/tools/edit_file/tool.yaml
+++ b/examples/coder.workspace/tools/edit_file/tool.yaml
@@ -1,15 +1,30 @@
 name: edit_file
-description: Edit a file by replacing an exact string. Always read_file first.
+description: |-
+  Perform an exact-string replacement in an existing file.
+
+  Usage:
+  - **You must call `read_file` on the same path first in the current session.** edit_file refuses with a clear error otherwise — editing without reading first usually fails because the file's actual content differs from what was assumed.
+  - `old_string` must match the file contents EXACTLY, character for character (whitespace, indentation, newlines all matter). Copy from read_file's output, removing only the `   N | ` line-number prefix.
+  - `old_string` must appear EXACTLY ONCE in the file. If it matches multiple locations, the call returns the match count and you should add more surrounding context (3+ lines) to make it unique.
+  - If `old_string` doesn't match, the response includes "Similar lines:" with line numbers + similarity scores. Re-read those lines and retry with the exact text.
+  - Use `write_file` (not edit_file) for creating new files. Use multiple edit_file calls for multiple separate changes — one edit per call so each step is reviewable.
+  - Returns a unified diff so you can verify the change applied correctly.
+
+  Recovery:
+  - "not been read" → call `read_file(file_path)` first
+  - "Matches N locations" → add more context lines around old_string
+  - "Exact match not found" → re-read the suggested similar lines, copy text exactly
 parameters:
   file_path:
     type: string
     description: Path to edit (relative to project root).
   old_string:
     type: string
-    description: Exact text to replace (must match uniquely).
+    description: |-
+      Exact text to replace. Must match the file content character-for-character and appear exactly once. Copy from a prior read_file's output, dropping the `   N | ` line-number prefix.
   new_string:
     type: string
-    description: Replacement text.
+    description: Replacement text. May be longer or shorter than old_string.
 requires:
   - workspace_config
   - file_cache

--- a/examples/coder.workspace/tools/glob/tool.yaml
+++ b/examples/coder.workspace/tools/glob/tool.yaml
@@ -1,9 +1,21 @@
 name: glob
-description: Find files by glob pattern.
+description: |-
+  Find files in the project by glob pattern.
+
+  Usage:
+  - Use Python `pathlib.Path.glob` syntax: `*` matches any chars in a name, `**` matches any number of directories, `?` matches a single char.
+  - Path patterns are rooted at the project root: `src/**/*.py` finds every Python file under src/.
+  - Returns paths relative to the project root, sorted, capped at 100 results.
+  - Use this to find files by NAME pattern. Use `grep` to find files by CONTENT.
+
+  Examples:
+  - `glob(pattern="**/*.py")` — every Python file in the project
+  - `glob(pattern="tests/test_*.py")` — every test file
+  - `glob(pattern="src/**/cli.*")` — any cli.* under src/
 parameters:
   pattern:
     type: string
-    description: Glob pattern (e.g. "**/*.py").
+    description: Glob pattern. Use ** for recursive directory match.
 concurrent_safe: true
 requires:
   - workspace_config

--- a/examples/coder.workspace/tools/grep/tool.yaml
+++ b/examples/coder.workspace/tools/grep/tool.yaml
@@ -1,16 +1,28 @@
 name: grep
-description: Search file contents with regex. Returns file:line:content.
+description: |-
+  Recursively search file contents using `grep -rn`. Returns `path:line:content` matches.
+
+  Usage:
+  - Use this to find files by CONTENT (e.g. "where is function foo defined?", "which files import X?"). Use `glob` to find files by NAME pattern.
+  - The pattern is passed to `grep` directly so you get the full grep regex syntax. Quote the pattern if it contains special chars.
+  - `path` defaults to the project root; pass a subdir to narrow the search.
+  - `include` is passed as `--include=<glob>` so you can scope by file type without two grep calls (e.g. `include="*.py"` ignores non-Python files).
+  - Output capped at 50 matches and 10s timeout. For massive codebases, narrow the path or include first.
+
+  Examples:
+  - `grep(pattern="def authenticate", include="*.py")` — find Python defs of authenticate
+  - `grep(pattern="TODO|FIXME", path="src/")` — find every TODO in src/
 parameters:
   pattern:
     type: string
-    description: Regex pattern.
+    description: Regex pattern (grep-style; basic regex by default, no need to escape `[]`).
   path:
     type: string
-    description: Search root (relative to project).
+    description: Directory to search in, relative to project root.
     default: "."
   include:
     type: string
-    description: Optional --include filter (e.g. "*.py").
+    description: Optional grep `--include=<glob>` filter (e.g. "*.py", "*.{js,ts}").
     default: ""
 concurrent_safe: true
 requires:

--- a/examples/coder.workspace/tools/list_dir/tool.yaml
+++ b/examples/coder.workspace/tools/list_dir/tool.yaml
@@ -1,13 +1,24 @@
 name: list_dir
-description: List directory contents as a tree. Use at the start to understand project structure.
+description: |-
+  Render a tree view of a directory in the project.
+
+  Usage:
+  - Call this **first** on a new task to understand project layout (file/dir count, language, top-level structure).
+  - Default `depth=2` shows the project skeleton without overwhelming detail. Increase for deep dives, decrease (depth=1) for a quick scan.
+  - Common scratch / cache directories are skipped automatically: `.git`, `__pycache__`, `node_modules`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`.
+  - Capped at 200 entries per call to keep the response readable. If output is truncated, narrow the path or use `glob` for targeted file matching.
+
+  When to prefer other tools:
+  - Looking for files matching a name pattern → `glob`
+  - Looking for files containing some text → `grep`
 parameters:
   path:
     type: string
-    description: Path relative to the project root.
+    description: Directory to list, relative to project root.
     default: "."
   depth:
     type: integer
-    description: Tree depth.
+    description: Tree depth. depth=1 lists immediate children only; depth=2 (default) descends one level into each subdir.
     default: 2
 concurrent_safe: true
 requires:

--- a/examples/coder.workspace/tools/read_file/tool.yaml
+++ b/examples/coder.workspace/tools/read_file/tool.yaml
@@ -1,16 +1,28 @@
 name: read_file
-description: Read a file with line numbers. Optionally specify start_line and/or end_line.
+description: |-
+  Read a file from the project filesystem with line numbers.
+
+  Usage:
+  - The default reads the whole file. Pass `start_line` and/or `end_line` (1-indexed) to read a specific range — useful for files >2000 lines.
+  - Output is `cat -n` style: `   N | <line>`. Edits MUST use the literal content AFTER the ` | ` separator, never the line-number prefix.
+  - Files larger than 20K characters are truncated in the middle (first 10K chars + last 10K chars) so the model still sees both ends; use start_line/end_line to read specific regions of larger files.
+  - This tool is the **prerequisite for edit_file**: edit_file refuses to run on a file that hasn't been read in the current session, because edits without reads almost always fail (the model guesses at content). Always read_file first.
+  - On a re-read of an unchanged file the result returns `file_unchanged: true` instead of the content; use the earlier read instead of re-reading. The cache is invalidated automatically by write_file / edit_file / external bash modifications, so you'll always see fresh content after a change.
+
+  Examples:
+  - `read_file(file_path="src/foo.py")` — whole file
+  - `read_file(file_path="src/foo.py", start_line=120, end_line=180)` — just lines 120-180
 parameters:
   file_path:
     type: string
     description: Path to file (relative to project root).
   start_line:
     type: integer
-    description: Optional starting line (1-indexed).
+    description: Optional 1-indexed starting line. 0 (default) means start at line 1.
     default: 0
   end_line:
     type: integer
-    description: Optional ending line (1-indexed, inclusive).
+    description: Optional 1-indexed ending line, inclusive. 0 (default) means read to end.
     default: 0
 concurrent_safe: true
 requires:

--- a/examples/coder.workspace/tools/write_file/tool.yaml
+++ b/examples/coder.workspace/tools/write_file/tool.yaml
@@ -1,9 +1,20 @@
 name: write_file
-description: Create or overwrite a file. Use for new files only.
+description: |-
+  Create a new file or overwrite an existing one with the provided content.
+
+  Usage:
+  - Use this for **NEW** files only. To modify an existing file, use `edit_file` (it preserves the rest of the file and produces a reviewable diff).
+  - Overwrites any existing content; the file_cache is invalidated so a subsequent read_file returns the new content.
+  - Parent directories are created automatically.
+  - The path is relative to the project root and must stay inside it (paths escaping via `..` are refused).
+
+  Examples:
+  - `write_file(file_path="src/utils.py", content="def foo(): ...")` — new file
+  - DO NOT use this to "update" a file you already read — that's `edit_file`.
 parameters:
   file_path:
     type: string
-    description: Path to write (relative to project root).
+    description: Path to write (relative to project root). Parent dirs created if missing.
   content:
     type: string
     description: Full file contents.

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -402,7 +402,37 @@ def _load_yaml(text: str) -> Any:
             key, _, raw_val = stripped.partition(":")
             raw_val = raw_val.strip()
             pos += 1
-            if not raw_val:
+            if raw_val in ("|", "|-", "|+", ">", ">-", ">+"):
+                # YAML block scalar — gather all subsequent lines whose
+                # indent exceeds ``indent``, strip the leading common
+                # indent, and join with newlines (literal ``|`` style)
+                # or spaces (folded ``>`` style). The trailing chomp
+                # indicator (``-`` strip / ``+`` keep / default clip)
+                # only matters for trailing newlines, which we always
+                # strip for tool descriptions.
+                style = raw_val[0]
+                block_lines: list[str] = []
+                while pos < len(lines):
+                    nl = lines[pos]
+                    if nl.strip() == "":
+                        block_lines.append("")
+                        pos += 1
+                        continue
+                    nl_indent = len(nl) - len(nl.lstrip())
+                    if nl_indent <= indent:
+                        break
+                    block_lines.append(nl)
+                    pos += 1
+                # Find common leading indent among non-blank lines.
+                non_blank = [bl for bl in block_lines if bl.strip()]
+                common = (
+                    min(len(bl) - len(bl.lstrip()) for bl in non_blank) if non_blank else indent + 2
+                )
+                stripped_lines = [bl[common:] if bl else "" for bl in block_lines]
+                joiner = "\n" if style == "|" else " "
+                value = joiner.join(stripped_lines).rstrip("\n")
+                out[key.strip()] = value
+            elif not raw_val:
                 # Nested block follows.
                 out[key.strip()] = parse_block(indent + 2)
             else:

--- a/tests/test_coder_tool_improvements_smoke.py
+++ b/tests/test_coder_tool_improvements_smoke.py
@@ -1,0 +1,146 @@
+"""Smoke tests for coder.workspace tool improvements.
+
+Covers:
+  1. ``edit_file`` refuses without a prior ``read_file`` in the session.
+  2. ``classify_bash_command`` flags destructive patterns.
+  3. ``classify_sed_command`` flags ``sed -i`` in-place edits.
+  4. ``bash`` tool refuses destructive commands and ``sed -i``.
+  5. Tool descriptions (loaded from YAML block scalars) include the
+     rich multi-paragraph guidance.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Make ``coder_lib_tools`` importable for the classifier-only tests.
+_CODER_DIR = Path(__file__).resolve().parents[1] / "examples" / "coder.workspace"
+sys.path.insert(0, str(_CODER_DIR))
+
+from coder_lib_tools import classify_bash_command, classify_sed_command  # noqa: E402
+
+from looplet import workspace_to_preset  # noqa: E402
+from looplet.types import ToolCall  # noqa: E402
+
+
+@pytest.fixture
+def preset():
+    with tempfile.TemporaryDirectory() as td:
+        Path(td, "foo.py").write_text("hello\n")
+        yield workspace_to_preset(str(_CODER_DIR), runtime={"workspace": td})
+
+
+def test_edit_file_refuses_without_prior_read(preset):
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="edit_file",
+            args={"file_path": "foo.py", "old_string": "hello", "new_string": "bye"},
+        )
+    )
+    assert r.data is not None
+    assert "not been read" in r.data.get("error", "")
+    assert r.data.get("missing") == "prior_read"
+    assert "read_file" in r.data.get("recovery", "")
+
+
+def test_edit_file_succeeds_after_read(preset):
+    preset.tools.dispatch(ToolCall(tool="read_file", args={"file_path": "foo.py"}))
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="edit_file",
+            args={"file_path": "foo.py", "old_string": "hello", "new_string": "bye"},
+        )
+    )
+    assert r.data is not None
+    assert r.data.get("replacements") == 1
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf /",
+        "rm -fr build",
+        "git push --force",
+        "git push -f origin main",
+        "git reset --hard HEAD~1",
+        "echo done && rm -rf node_modules",
+        "shutdown -h now",
+        "mkfs /dev/sda1",
+    ],
+)
+def test_classify_bash_command_detects_destructive(command):
+    res = classify_bash_command(command)
+    assert res["destructive"], f"expected destructive: {command}"
+    assert res["reasons"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo hello",
+        "ls -la",
+        "git status",
+        "rm foo.txt",  # plain rm without -rf is allowed
+        "pytest tests/",
+    ],
+)
+def test_classify_bash_command_passes_safe(command):
+    res = classify_bash_command(command)
+    assert not res["destructive"], f"expected safe: {command}"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["sed -i s/a/b/ foo.py", "sed -i.bak s/a/b/ foo.py", "sed --in-place s/a/b/ foo.py"],
+)
+def test_classify_sed_command_detects_in_place(command):
+    res = classify_sed_command(command)
+    assert res["in_place_edit"], f"expected in-place: {command}"
+    assert "edit_file" in res["recommendation"]
+
+
+def test_classify_sed_command_passes_streaming():
+    assert not classify_sed_command("sed s/a/b/ foo.py")["in_place_edit"]
+    assert not classify_sed_command("cat foo | sed s/a/b/")["in_place_edit"]
+
+
+def test_bash_tool_refuses_destructive(preset):
+    r = preset.tools.dispatch(ToolCall(tool="bash", args={"command": "rm -rf /"}))
+    assert r.data is not None
+    assert "Refused" in r.data.get("error", "")
+    assert r.data.get("first_token") == "rm"
+
+
+def test_bash_tool_refuses_sed_in_place(preset):
+    r = preset.tools.dispatch(ToolCall(tool="bash", args={"command": "sed -i s/a/b/ foo.py"}))
+    assert r.data is not None
+    assert "sed -i" in r.data.get("error", "")
+    assert "edit_file" in r.data.get("error", "")
+
+
+def test_bash_tool_runs_safe_command(preset):
+    r = preset.tools.dispatch(ToolCall(tool="bash", args={"command": "echo hello"}))
+    assert r.data is not None
+    assert "hello" in (r.data.get("stdout") or "")
+
+
+@pytest.mark.parametrize(
+    "tool_name,marker",
+    [
+        ("bash", "Refusals"),
+        ("read_file", "edit_file"),
+        ("edit_file", "Recovery"),
+        ("write_file", "NEW"),
+        ("list_dir", "tree"),
+        ("glob", "pattern"),
+        ("grep", "regex"),
+    ],
+)
+def test_tool_descriptions_are_rich(preset, tool_name, marker):
+    desc = preset.tools._tools[tool_name].description
+    assert len(desc) > 200, f"{tool_name} description too short ({len(desc)} chars)"
+    assert marker.lower() in desc.lower(), f"{tool_name} description missing {marker!r}"

--- a/tests/test_coder_tool_improvements_smoke.py
+++ b/tests/test_coder_tool_improvements_smoke.py
@@ -21,7 +21,11 @@ import pytest
 _CODER_DIR = Path(__file__).resolve().parents[1] / "examples" / "coder.workspace"
 sys.path.insert(0, str(_CODER_DIR))
 
-from coder_lib_tools import classify_bash_command, classify_sed_command  # noqa: E402
+from coder_lib_tools import (  # noqa: E402
+    classify_bash_command,
+    classify_sed_command,
+    classify_view_command,
+)
 
 from looplet import workspace_to_preset  # noqa: E402
 from looplet.types import ToolCall  # noqa: E402
@@ -106,6 +110,45 @@ def test_classify_sed_command_detects_in_place(command):
 def test_classify_sed_command_passes_streaming():
     assert not classify_sed_command("sed s/a/b/ foo.py")["in_place_edit"]
     assert not classify_sed_command("cat foo | sed s/a/b/")["in_place_edit"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat src/foo.py",
+        "cat -n src/foo.py",
+        "head -20 src/foo.py",
+        "tail -50 logs/err.log",
+        "less README.md",
+        "cat foo.py bar.py",
+    ],
+)
+def test_classify_view_command_detects_file_view(command):
+    res = classify_view_command(command)
+    assert res["viewing_file"], f"expected file-view: {command}"
+    assert "read_file" in res["recommendation"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep TODO src/ | head -20",
+        "ls -la | head",
+        "cat /proc/cpuinfo",
+        "echo hi",
+        "pytest",
+    ],
+)
+def test_classify_view_command_passes_pipes_and_virtual(command):
+    assert not classify_view_command(command)["viewing_file"], command
+
+
+def test_bash_tool_refuses_cat_source(preset):
+    r = preset.tools.dispatch(ToolCall(tool="bash", args={"command": "cat -n foo.py"}))
+    assert r.data is not None
+    assert "Refused" in r.data.get("error", "")
+    assert "read_file" in r.data.get("error", "")
+    assert r.data.get("first_token") == "cat"
 
 
 def test_bash_tool_refuses_destructive(preset):


### PR DESCRIPTION
Three information-additive improvements to `examples/coder.workspace`. No process gating — every refusal includes a model-actionable recovery hint so the model self-corrects on the next turn.

## 1. Read-required-first on `edit_file`
`FileCache.was_read()` tracks every path passed to `read_file` in the current session. `edit_file` refuses with `{error, missing: 'prior_read', recovery: 'read_file(...)'}` when called on an unread file. This is the #1 cause of `old_string` mismatch failures — the model guesses content it never saw.

## 2. Bash safety classifiers
- `classify_bash_command` inspects each subcommand of a chained pipeline and flags destructive name/flag combinations: `rm -rf`, `git push --force`, `git reset --hard`, `git clean -fd`, `git branch -D`, `shutdown`, `reboot`, `mkfs`, `shred`, `dd`, `killall`, `pkill`.
- `classify_sed_command` flags `sed -i` / `-i.bak` / `--in-place` because they bypass `file_cache` invalidation and cause stale `read_file` results.
- `bash` refuses both with structured `{error, reasons, first_token, recovery}`. `sed -i` recovery points at `edit_file`.
- Both classifiers exported so other workspaces can reuse them.

## 3. Rich per-tool descriptions
All 7 `tool.yaml` files in `examples/coder.workspace` rewritten with multi-paragraph descriptions (Usage / Refusals / Examples / Recovery sections) using YAML block scalars (`|-`). The looplet workspace YAML loader gained `|` / `|-` / `>` block-scalar support so the descriptions round-trip.

## Tests
- 29 new smoke tests in `tests/test_coder_tool_improvements_smoke.py`.
- Full suite: **1597/1597 passing**.
- Lint clean (`ruff check src/ tests/ examples/`).

## Inspiration, not copy
Patterns inspired by what production coding agents enforce; implementation is original (different data shapes, different parser strategy, different error format).