### PR TITLE
feat(workspace): extends: composition + agent_factory.workspace

### DIFF
--- a/examples/agent_factory.workspace/config.yaml
+++ b/examples/agent_factory.workspace/config.yaml
@@ -1,0 +1,2 @@
+extends: ../coder.workspace
+max_steps: 80

--- a/examples/agent_factory.workspace/prompts/system.md
+++ b/examples/agent_factory.workspace/prompts/system.md
@@ -1,0 +1,81 @@
+You are an **agent factory**. Your job: given a one-paragraph English brief, generate a complete, working **looplet workspace** under the path the user specifies (default `./agent.workspace/`).
+
+## What is a looplet workspace?
+
+A looplet workspace is a directory of files that defines an agent **as data** — the loader (`workspace_to_preset(path)`) reads them and materialises a runnable agent. The required layout is:
+
+```
+my_agent.workspace/
+├── workspace.json          # {"name": "...", "schema_version": 1}
+├── config.yaml             # max_steps, max_tokens, etc. (LoopConfig fields)
+├── prompts/system.md       # the agent's system prompt (REQUIRED for it to be useful)
+├── tools/<name>/
+│   ├── tool.yaml           # name, description, parameters, requires
+│   └── execute.py          # def execute(ctx, *, ...) -> dict
+├── hooks/<name>/           # OPTIONAL — only if the agent needs cross-cutting policy
+│   ├── hook.py             # class FooHook with on_event(self, event, payload)
+│   └── config.yaml         # class_name + kwargs
+└── resources/<name>.py     # OPTIONAL — shared state objects (file caches, configs)
+```
+
+Every agent **must** have a `done` tool — it's the completion sentinel.
+
+## Workflow
+
+1. **Plan first** (use `think`). Decide:
+   - What does the agent *do* end-to-end? Write a one-sentence mission.
+   - What tools does it need? Aim for the smallest set (3-6 tools).
+   - Does it need any hook? (most agents don't — only add if you have a real reason)
+   - Does it need any resource? (rarely — only for shared state)
+
+2. **Write the system prompt first** (`prompts/system.md`). It should cover: role, available tools, expected workflow, when to call `done`. Keep it under 500 words.
+
+3. **Write tools one at a time.** Each tool is `tools/<name>/tool.yaml` + `tools/<name>/execute.py`.
+   - `tool.yaml` declares: `name`, `description` (multi-paragraph using YAML `|-` block scalar is best — explain Usage, Examples, Refusals, Recovery), `parameters` (with type and description), and optional `requires:` (list of resource names).
+   - `execute.py` defines `def execute(ctx: ToolContext, *, <params>) -> dict`. The `ctx` is positional-only; the rest are keyword-only. Return a dict (this is what the model sees).
+   - For tools that call the LLM: use `ctx.llm.generate(prompt=..., system_prompt=...)`.
+
+4. **Write `config.yaml`** with sensible defaults:
+   ```yaml
+   max_steps: 20
+   max_tokens: 2000
+   temperature: 0.7
+   done_tool: done
+   ```
+
+5. **Write `workspace.json`** — one line: `{"name": "<agent-name>", "schema_version": 1}`.
+
+6. **Validate** with `validate_workspace(workspace_path)`. This runs `workspace_to_preset()` and reports any structural errors. Fix and re-validate until it loads cleanly.
+
+7. **Test** — write a short `tests/test_<agent>.py` that:
+   - Loads the workspace via `workspace_to_preset(...)` and checks the tool list.
+   - Asserts `preset.config.system_prompt` is non-empty.
+   - (Optional) Runs the agent end-to-end with `MockLLMBackend` for a deterministic smoke test.
+   - Run via `bash`: `pytest tests/test_<agent>.py -v`.
+
+8. **`done`** with a one-line summary of what was built.
+
+## Style rules
+
+- Tool descriptions: multi-paragraph, with Usage / Examples sections. The model that uses your agent will read these — invest in them.
+- One concept per tool. If a tool's description has more than two "or" clauses, split it.
+- Type-hint every parameter. Default values where it makes sense.
+- No unnecessary error handling — fail fast. The loop and the dispatcher already catch and surface tool errors.
+- Workspace files are co-located: a `lib.py` next to `tools/` is fine for shared helpers.
+
+## Composition: `extends:`
+
+If the brief asks for an agent that *extends* an existing workspace (e.g. "a security-focused coder"), use `extends:` in `config.yaml`:
+
+```yaml
+extends: ../coder.workspace
+```
+
+The child workspace inherits all tools, hooks, and resources from the parent — only override or add what differs. This is the right choice when the parent is `coder.workspace` and the child is "coder + special skill X."
+
+## Common pitfalls
+
+- **Tool name must match the directory name** in the response visible to the model — set `name:` in `tool.yaml` to the dir name.
+- **`done` is not optional.** Every agent must have a `done` tool. Copy it from `examples/coder.workspace/tools/done/`.
+- **`prompts/system.md` is required.** Without it, the agent has no idea what it is.
+- **Don't over-engineer.** A useful agent has 3-6 tools. Resist the urge to add a tool for every concept.

--- a/examples/agent_factory.workspace/tools/validate_workspace/execute.py
+++ b/examples/agent_factory.workspace/tools/validate_workspace/execute.py
@@ -1,0 +1,95 @@
+"""validate_workspace tool — structural validator for generated workspaces.
+
+Calls ``looplet.workspace_to_preset()`` against the path and reports
+either the loaded tool/hook/config inventory (success) or a structured
+error that names the failure mode and the likely file (failure). The
+factory model uses this tool as a tight feedback loop: it writes files,
+validates, fixes, and re-validates without burning steps on shell
+gymnastics.
+"""
+
+from __future__ import annotations
+
+from coder_lib_tools import _resolve_safe_path
+
+from looplet.types import ToolContext
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    workspace_path: str,
+    strict: bool = True,
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    abs_path = _resolve_safe_path(workspace, workspace_path)
+    if abs_path is None:
+        return {
+            "error": f"Path {workspace_path!r} is outside the project directory.",
+        }
+    if not abs_path.is_dir():
+        return {
+            "error": f"{workspace_path!r} is not a directory.",
+            "recovery": "Pass the workspace root (the directory containing workspace.json).",
+        }
+
+    # Defer the looplet import to call-time so the tool stays
+    # importable in environments where looplet isn't on the path
+    # (e.g. test harnesses that mock the dispatcher).
+    from looplet import workspace_to_preset  # noqa: PLC0415
+    from looplet.workspace import WorkspaceSerializationError  # noqa: PLC0415
+
+    try:
+        preset = workspace_to_preset(str(abs_path), strict=strict)
+    except FileNotFoundError as exc:
+        return {
+            "error": f"FileNotFoundError: {exc}",
+            "missing": "workspace.json",
+            "recovery": (
+                f"Create {workspace_path}/workspace.json with content "
+                '`{"name": "<agent-name>", "schema_version": 1}`.'
+            ),
+        }
+    except WorkspaceSerializationError as exc:
+        return {
+            "error": f"WorkspaceSerializationError: {exc}",
+            "kind": "serialization",
+            "recovery": (
+                "The message names the offending file. Read it, fix the "
+                "shape (yaml indent / required keys), and re-validate."
+            ),
+        }
+    except ImportError as exc:
+        return {
+            "error": f"ImportError while loading: {exc}",
+            "kind": "import",
+            "recovery": ("A tool/hook execute.py has a bad import. Read it and fix."),
+        }
+    except Exception as exc:
+        return {
+            "error": f"{type(exc).__name__}: {exc}",
+            "kind": "other",
+        }
+
+    tools = sorted(preset.tools._tools.keys())
+    hooks = [type(h).__name__ for h in preset.hooks]
+    sys_prompt_chars = len(preset.config.system_prompt or "")
+    return {
+        "valid": True,
+        "workspace_path": workspace_path,
+        "tools": tools,
+        "n_tools": len(tools),
+        "hooks": hooks,
+        "n_hooks": len(hooks),
+        "max_steps": preset.config.max_steps,
+        "system_prompt_chars": sys_prompt_chars,
+        "warnings": [
+            warning
+            for warning in (
+                "system_prompt is empty — add prompts/system.md" if sys_prompt_chars == 0 else None,
+                "no `done` tool — every agent must have one" if "done" not in tools else None,
+            )
+            if warning is not None
+        ],
+    }

--- a/examples/agent_factory.workspace/tools/validate_workspace/tool.yaml
+++ b/examples/agent_factory.workspace/tools/validate_workspace/tool.yaml
@@ -1,0 +1,28 @@
+name: validate_workspace
+description: |-
+  Structurally validate a looplet workspace by attempting to load it via `workspace_to_preset()`.
+
+  Usage:
+  - Call this after writing every file in a generated workspace to confirm it loads cleanly. Cheap (no LLM, no I/O outside the workspace).
+  - On success, returns the tool names, hook names, and key config values. Use this to confirm the agent has the tools it should.
+  - On failure, returns a structured error: type + message + (best-effort) which file is the culprit. Fix the file and re-validate.
+
+  When to call:
+  - After writing `workspace.json`, `config.yaml`, and at least one tool — get an early signal.
+  - After every batch of file changes — cheap insurance against silent regressions.
+  - Before declaring `done` — final gate.
+
+  Recovery:
+  - "FileNotFoundError" → check the workspace_path and that workspace.json exists.
+  - "WorkspaceSerializationError" → the message names the offending file; read it, fix, retry.
+  - "ImportError" inside an execute.py → the tool body has a bad import; read_file and fix.
+parameters:
+  workspace_path:
+    type: string
+    description: Path to the workspace directory (relative to project root).
+  strict:
+    type: boolean
+    description: When true, any tool/hook that fails to load raises (vs. logs a warning).
+    default: true
+requires:
+  - workspace_config

--- a/examples/agent_factory.workspace/workspace.json
+++ b/examples/agent_factory.workspace/workspace.json
@@ -1,0 +1,1 @@
+{"name": "agent-factory", "schema_version": 1}

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -1798,6 +1798,23 @@ def workspace_to_preset(
             f"is this a Workspace directory?"
         )
 
+    # ``extends:`` resolution. If config.yaml declares
+    # ``extends: <path>``, we merge the parent workspace under the
+    # current one — for every file under tools/, hooks/, resources/,
+    # prompts/, memory/, and any top-level *.py the child doesn't
+    # provide, we transparently inherit from the parent. Implemented by
+    # materializing a merged directory in a tempdir and loading from
+    # there. Multi-level extends is supported: the parent's own
+    # ``extends:`` is resolved recursively before the merge.
+    extended_root = _resolve_extends(root)
+    if extended_root is not root:
+        # Re-validate metadata in the merged dir.
+        if not (extended_root / WorkspaceLayout.WORKSPACE_JSON).is_file():
+            raise WorkspaceSerializationError(
+                f"merged workspace at {extended_root} missing workspace.json"
+            )
+        root = extended_root
+
     # Shared-resource registry — built once, referenced by ``@<name>``
     # strings throughout hook / tool kwargs. Lets two hooks share the
     # same live object (e.g. a FileCache) on reload, instead of
@@ -1843,6 +1860,72 @@ def workspace_to_preset(
                 _sys.path.remove(p)
             except ValueError:
                 pass
+
+
+def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
+    """Resolve ``extends:`` in a workspace's config.yaml.
+
+    If ``config.yaml`` declares ``extends: <path>`` (relative to ``root``
+    or absolute), the parent workspace is recursively resolved and a
+    *merged* workspace directory is materialized under a tempdir:
+
+    * Parent files are copied first (recursively).
+    * Child files overlay on top — any same-relative-path file in the
+      child wins.
+
+    Returns the path to the merged workspace, or ``root`` itself when
+    there is no ``extends:`` to resolve. Multi-level inheritance works
+    (parent can itself ``extends:`` a grandparent).
+
+    Cycle detection: ``_seen`` carries the resolved paths visited so
+    far; revisiting raises :class:`WorkspaceSerializationError`.
+
+    The merged workspace dir is created via :func:`tempfile.mkdtemp`
+    with a stable prefix; it is NOT cleaned up automatically because
+    the loaded preset's modules may continue importing from it. The OS
+    handles cleanup on process exit (``/tmp`` is volatile).
+    """
+    cfg_path = root / WorkspaceLayout.CONFIG_YAML
+    if not cfg_path.is_file():
+        return root
+    cfg_text = cfg_path.read_text(encoding="utf-8")
+    cfg = _load_yaml(cfg_text) or {}
+    extends_val = cfg.get("extends")
+    if not extends_val:
+        return root
+
+    seen = set(_seen) if _seen is not None else set()
+    root_resolved = root.resolve()
+    if root_resolved in seen:
+        raise WorkspaceSerializationError(f"circular ``extends:`` detected at {root}")
+    seen.add(root_resolved)
+
+    parent_path = Path(extends_val)
+    if not parent_path.is_absolute():
+        parent_path = (root / parent_path).resolve()
+    if not parent_path.is_dir():
+        raise WorkspaceSerializationError(
+            f"extends: {extends_val!r} → {parent_path} does not exist or is not a directory"
+        )
+
+    # Resolve parent's own extends first (recursive).
+    parent_root = _resolve_extends(parent_path, _seen=seen)
+
+    import shutil as _shutil  # noqa: PLC0415
+    import tempfile as _tempfile  # noqa: PLC0415
+
+    merged = Path(_tempfile.mkdtemp(prefix=f"looplet_extends_{root.name}_"))
+    # Copy parent first, then overlay child.
+    _shutil.copytree(parent_root, merged, dirs_exist_ok=True, symlinks=False)
+    _shutil.copytree(root, merged, dirs_exist_ok=True, symlinks=False)
+    # Strip the ``extends:`` line from the merged config.yaml so the
+    # inner loader doesn't re-resolve it.
+    merged_cfg = merged / WorkspaceLayout.CONFIG_YAML
+    if merged_cfg.is_file():
+        lines = merged_cfg.read_text(encoding="utf-8").splitlines()
+        kept = [ln for ln in lines if not ln.strip().startswith("extends:")]
+        merged_cfg.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+    return merged
 
 
 def _workspace_to_preset_inner(

--- a/tests/test_workspace_extends_smoke.py
+++ b/tests/test_workspace_extends_smoke.py
@@ -1,0 +1,214 @@
+"""Smoke tests for workspace ``extends:`` composition + agent_factory.
+
+Covers:
+  1. ``extends:`` inherits parent's tools + lets child override max_steps
+  2. ``extends:`` is recursive (grandparent → parent → child)
+  3. Cycle detection raises a clean error
+  4. agent_factory.workspace loads + extends coder.workspace correctly
+  5. validate_workspace tool returns structured success / errors
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from looplet import workspace_to_preset
+from looplet.types import ToolCall
+from looplet.workspace import WorkspaceSerializationError
+
+PARENT_FILES = {
+    "workspace.json": '{"name":"parent","schema_version":1}\n',
+    "config.yaml": "max_steps: 10\n",
+    "tools/greet/tool.yaml": (
+        "name: greet\ndescription: say hello\nparameters:\n  who:\n    type: string\n"
+    ),
+    "tools/greet/execute.py": ("def execute(*, who):\n    return {'msg': f'hi {who}'}\n"),
+    "tools/done/tool.yaml": (
+        "name: done\ndescription: finish\nparameters:\n  summary:\n    type: string\n"
+    ),
+    "tools/done/execute.py": ("def execute(*, summary):\n    return {'summary': summary}\n"),
+}
+
+
+def _make_workspace(root: Path, name: str, files: dict[str, str]) -> Path:
+    ws = root / name
+    ws.mkdir()
+    for rel, content in files.items():
+        path = ws / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return ws
+
+
+def test_extends_inherits_parent_tools(tmp_path: Path) -> None:
+    parent = _make_workspace(tmp_path, "parent.workspace", PARENT_FILES)
+    child = _make_workspace(
+        tmp_path,
+        "child.workspace",
+        {
+            "workspace.json": '{"name":"child","schema_version":1}\n',
+            "config.yaml": f"extends: {parent}\nmax_steps: 25\n",
+            "tools/shout/tool.yaml": (
+                "name: shout\ndescription: yell\nparameters:\n  msg:\n    type: string\n"
+            ),
+            "tools/shout/execute.py": ("def execute(*, msg):\n    return {'yell': msg.upper()}\n"),
+        },
+    )
+    p = workspace_to_preset(child)
+    assert sorted(p.tools._tools.keys()) == ["done", "greet", "shout"]
+    # Child's max_steps wins.
+    assert p.config.max_steps == 25
+
+
+def test_extends_child_can_override_parent_tool(tmp_path: Path) -> None:
+    parent = _make_workspace(tmp_path, "parent.workspace", PARENT_FILES)
+    child = _make_workspace(
+        tmp_path,
+        "child.workspace",
+        {
+            "workspace.json": '{"name":"child","schema_version":1}\n',
+            "config.yaml": f"extends: {parent}\n",
+            # Override greet with a different implementation.
+            "tools/greet/tool.yaml": (
+                "name: greet\ndescription: say HELLO\nparameters:\n  who:\n    type: string\n"
+            ),
+            "tools/greet/execute.py": (
+                "def execute(*, who):\n    return {'msg': f'HELLO {who}'}\n"
+            ),
+        },
+    )
+    p = workspace_to_preset(child)
+    r = p.tools.dispatch(ToolCall(tool="greet", args={"who": "world"}))
+    # Child override should win.
+    assert r.data.get("msg") == "HELLO world"
+
+
+def test_extends_cycle_detection(tmp_path: Path) -> None:
+    a = _make_workspace(
+        tmp_path,
+        "a.workspace",
+        {
+            "workspace.json": '{"name":"a","schema_version":1}\n',
+            "config.yaml": "extends: ../b.workspace\n",
+        },
+    )
+    _make_workspace(
+        tmp_path,
+        "b.workspace",
+        {
+            "workspace.json": '{"name":"b","schema_version":1}\n',
+            "config.yaml": "extends: ../a.workspace\n",
+        },
+    )
+    with pytest.raises(WorkspaceSerializationError, match="circular"):
+        workspace_to_preset(a)
+
+
+def test_extends_recursive_three_levels(tmp_path: Path) -> None:
+    grand = _make_workspace(tmp_path, "grand.workspace", PARENT_FILES)
+    mid = _make_workspace(
+        tmp_path,
+        "mid.workspace",
+        {
+            "workspace.json": '{"name":"mid","schema_version":1}\n',
+            "config.yaml": f"extends: {grand}\n",
+            "tools/middle/tool.yaml": ("name: middle\ndescription: middle layer\nparameters: {}\n"),
+            "tools/middle/execute.py": ("def execute():\n    return {'level': 'mid'}\n"),
+        },
+    )
+    child = _make_workspace(
+        tmp_path,
+        "child.workspace",
+        {
+            "workspace.json": '{"name":"child","schema_version":1}\n',
+            "config.yaml": f"extends: {mid}\n",
+            "tools/child_only/tool.yaml": (
+                "name: child_only\ndescription: child layer\nparameters: {}\n"
+            ),
+            "tools/child_only/execute.py": ("def execute():\n    return {'level': 'child'}\n"),
+        },
+    )
+    p = workspace_to_preset(child)
+    # Tools from all three levels.
+    assert set(p.tools._tools.keys()) == {"done", "greet", "middle", "child_only"}
+
+
+def test_extends_missing_parent_raises(tmp_path: Path) -> None:
+    child = _make_workspace(
+        tmp_path,
+        "child.workspace",
+        {
+            "workspace.json": '{"name":"child","schema_version":1}\n',
+            "config.yaml": "extends: ./nonexistent.workspace\n",
+        },
+    )
+    with pytest.raises(WorkspaceSerializationError, match="does not exist"):
+        workspace_to_preset(child)
+
+
+def test_agent_factory_workspace_loads() -> None:
+    """examples/agent_factory.workspace must extend coder.workspace
+    successfully and add a validate_workspace tool."""
+    repo_root = Path(__file__).resolve().parents[1]
+    ws = repo_root / "examples" / "agent_factory.workspace"
+    p = workspace_to_preset(str(ws), runtime={"workspace": "."})
+    tool_names = sorted(p.tools._tools.keys())
+    # Inherits all coder tools + adds validate_workspace.
+    assert "validate_workspace" in tool_names
+    assert "edit_file" in tool_names  # inherited from coder
+    assert "multi_edit" in tool_names  # inherited from coder
+    assert "done" in tool_names
+    # Has its own system prompt (overrides coder's).
+    assert p.config.system_prompt and len(p.config.system_prompt) > 1000
+    assert "agent factory" in p.config.system_prompt.lower()
+    # Child's max_steps wins.
+    assert p.config.max_steps == 80
+
+
+def test_validate_workspace_tool_success(tmp_path: Path) -> None:
+    """The validate_workspace tool returns structured success."""
+    parent = _make_workspace(tmp_path, "parent.workspace", PARENT_FILES)
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    p = workspace_to_preset(str(factory), runtime={"workspace": str(tmp_path)})
+    r = p.tools.dispatch(
+        ToolCall(
+            tool="validate_workspace",
+            args={"workspace_path": "parent.workspace", "strict": True},
+        )
+    )
+    assert r.data.get("valid") is True
+    assert sorted(r.data.get("tools", [])) == ["done", "greet"]
+    assert r.data.get("system_prompt_chars") == 0
+    assert "system_prompt is empty" in str(r.data.get("warnings", []))
+
+
+def test_validate_workspace_tool_missing_workspace_json(tmp_path: Path) -> None:
+    """Validator returns FileNotFoundError when workspace.json is missing."""
+    bad = tmp_path / "broken.workspace"
+    bad.mkdir()
+    (bad / "config.yaml").write_text("max_steps: 10\n")
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    p = workspace_to_preset(str(factory), runtime={"workspace": str(tmp_path)})
+    r = p.tools.dispatch(
+        ToolCall(
+            tool="validate_workspace",
+            args={"workspace_path": "broken.workspace"},
+        )
+    )
+    assert "FileNotFoundError" in r.data.get("error", "")
+    assert r.data.get("missing") == "workspace.json"
+    assert "schema_version" in r.data.get("recovery", "")
+
+
+def test_validate_workspace_tool_outside_project(tmp_path: Path) -> None:
+    """Validator refuses paths outside the project root."""
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    p = workspace_to_preset(str(factory), runtime={"workspace": str(tmp_path)})
+    r = p.tools.dispatch(ToolCall(tool="validate_workspace", args={"workspace_path": "/etc"}))
+    assert "outside the project" in r.data.get("error", "")


### PR DESCRIPTION
Adds the foundational primitive for **composing looplet workspaces** and the first product use case: an **agent factory** that builds new agents from a one-paragraph English brief.

## What's new

### `extends:` in `config.yaml`

```yaml
# child.workspace/config.yaml
extends: ../coder.workspace
max_steps: 80
```

At load time the parent is recursively materialized and overlaid with the child via a tempdir. Child files override parent files at matching paths; missing child files are inherited; new child files are added.

- Multi-level extends works (grandparent → parent → child).
- Cycle detection → `WorkspaceSerializationError`.
- Missing parent path → clear error.
- ~70 LOC in `src/looplet/workspace.py`.

### `examples/agent_factory.workspace`

First product built on `extends:`. Inherits everything from `coder.workspace` and adds:

- `validate_workspace(path)` — calls `workspace_to_preset()` and returns structured success/error so the agent gets a tight feedback loop.
- A 4500-char system prompt covering workspace v2 grammar, required files, pitfalls, and `extends:` usage.

## Dogfood validation

Two end-to-end dogfoods with claude-sonnet-4.6:

| Brief | Steps | Time | Denies | Verdict |
|---|---|---|---|---|
| Build a doc summarizer | 23 | 83s | 2 (self-corrected) | ✅ load + tools + e2e all PASS |
| Build a security_coder that itself extends coder.workspace | 75 | 295s | 20 (self-corrected) | ✅ load + extends + new_tools + tests all PASS |

The security_coder dogfood is particularly strong: the factory produced a 12-tool workspace (10 inherited + 2 new) AND wrote a pytest suite that all passes.

## Tests

- **9 new smoke tests** in `tests/test_workspace_extends_smoke.py` covering inheritance, override, cycles, 3-level recursive, missing-parent, agent_factory loads, validate_workspace tool.
- Full suite **1633/1633 passing**, ruff clean.

## Why this matters

Workspace-as-data is looplet's structural moat. `extends:` makes that moat composable. With this, the next two PRs become straightforward:

1. `looplet new <description>` CLI that runs `agent_factory` and writes the result locally.
2. Blueprint registry — community workspaces published as bases other agents `extends:`.