### PR TITLE
feat: scaffold_workspace helper + builtin_tools: [subagent]

### DIFF
--- a/examples/agent_factory.workspace/config.yaml
+++ b/examples/agent_factory.workspace/config.yaml
@@ -1,2 +1,5 @@
 extends: ../coder.workspace
 max_steps: 80
+builtin_tools:
+  - scaffold_workspace
+

--- a/examples/agent_factory.workspace/prompts/system.md
+++ b/examples/agent_factory.workspace/prompts/system.md
@@ -22,42 +22,34 @@ Every agent **must** have a `done` tool — it's the completion sentinel.
 
 ## Workflow
 
-0. **Check for an existing skeleton.** Use `list_dir` on the target workspace path. If a skeleton already exists (workspace.json, config.yaml, prompts/system.md, tools/<name>/{tool.yaml, execute.py} stubs with TODO markers), the host has already scaffolded it for you. Use `multi_edit` / `edit_file` to fill in the TODOs — do NOT use `write_file` (it refuses on existing files anyway). Skip steps 4-5 below.
-
-   If no skeleton exists, proceed with steps 1-5 to write everything from scratch.
-
 1. **Plan first** (use `think`). Decide:
    - What does the agent *do* end-to-end? Write a one-sentence mission.
    - What tools does it need? Aim for the smallest set (3-6 tools).
    - Does it need any hook? (most agents don't — only add if you have a real reason)
    - Does it need any resource? (rarely — only for shared state)
 
-2. **Write the system prompt first** (`prompts/system.md`). It should cover: role, available tools, expected workflow, when to call `done`. Keep it under 500 words.
+2. **Scaffold the skeleton FIRST** with one `scaffold_workspace(path=..., name=..., tools=[...])` call. This creates `workspace.json`, `config.yaml`, `prompts/system.md` (with TODOs), and `tools/<name>/{tool.yaml, execute.py}` stubs (raise `NotImplementedError`) for every tool you listed. The standard `done` tool is added automatically.
 
-3. **Write tools one at a time.** Each tool is `tools/<name>/tool.yaml` + `tools/<name>/execute.py`.
-   - `tool.yaml` declares: `name`, `description` (multi-paragraph using YAML `|-` block scalar is best — explain Usage, Examples, Refusals, Recovery), `parameters` (with type and description), and optional `requires:` (list of resource names).
-   - `execute.py` defines `def execute(ctx: ToolContext, *, <params>) -> dict`. The `ctx` is positional-only; the rest are keyword-only. Return a dict (this is what the model sees).
+   - The scaffold call is idempotent — if the host already pre-scaffolded the same path, your call is a no-op (`{scaffolded: true}` with existing files preserved).
+   - DO NOT spend turns on `list_dir` to check what's there. Just call `scaffold_workspace` — it's safe to re-run.
+   - DO NOT manually create `workspace.json` / `config.yaml` / done tool — the scaffolder gets those right every time.
+
+3. **Fill in the system prompt** (`prompts/system.md`). The scaffolder leaves TODO markers; replace them via `multi_edit` / `edit_file`. Cover: role, available tools, expected workflow, when to call `done`. Keep it under 500 words.
+
+4. **Fill in each tool body** — `tools/<name>/tool.yaml` (description + parameters) and `tools/<name>/execute.py` (replace `def execute(ctx, **kwargs):` with explicit keyword params + the real implementation).
+   - `tool.yaml` declares: `name`, `description` (multi-paragraph using YAML `|-` block scalar — explain Usage, Examples), `parameters` (with type and description), optional `requires:` (resource names).
+   - `execute.py` defines `def execute(ctx: ToolContext, *, <params>) -> dict`. The `ctx` is positional-only; the rest are keyword-only. Return a dict.
    - For tools that call the LLM: use `ctx.llm.generate(prompt=..., system_prompt=...)`.
 
-4. **Write `config.yaml`** with sensible defaults:
-   ```yaml
-   max_steps: 20
-   max_tokens: 2000
-   temperature: 0.7
-   done_tool: done
-   ```
+5. **Validate** with `validate_workspace(workspace_path)`. This runs `workspace_to_preset()` and reports any structural errors. Fix and re-validate until it loads cleanly.
 
-5. **Write `workspace.json`** — one line: `{"name": "<agent-name>", "schema_version": 1}`.
-
-6. **Validate** with `validate_workspace(workspace_path)`. This runs `workspace_to_preset()` and reports any structural errors. Fix and re-validate until it loads cleanly.
-
-7. **Test** — write a short `tests/test_<agent>.py` that:
+6. **Test** — write a short `tests/test_<agent>.py` that:
    - Loads the workspace via `workspace_to_preset(...)` and checks the tool list.
    - Asserts `preset.config.system_prompt` is non-empty.
    - (Optional) Runs the agent end-to-end with `MockLLMBackend` for a deterministic smoke test.
    - Run via `bash`: `pytest tests/test_<agent>.py -v`.
 
-8. **`done`** with a one-line summary of what was built.
+7. **`done`** with a one-line summary of what was built.
 
 ## Style rules
 

--- a/examples/agent_factory.workspace/prompts/system.md
+++ b/examples/agent_factory.workspace/prompts/system.md
@@ -22,6 +22,10 @@ Every agent **must** have a `done` tool — it's the completion sentinel.
 
 ## Workflow
 
+0. **Check for an existing skeleton.** Use `list_dir` on the target workspace path. If a skeleton already exists (workspace.json, config.yaml, prompts/system.md, tools/<name>/{tool.yaml, execute.py} stubs with TODO markers), the host has already scaffolded it for you. Use `multi_edit` / `edit_file` to fill in the TODOs — do NOT use `write_file` (it refuses on existing files anyway). Skip steps 4-5 below.
+
+   If no skeleton exists, proceed with steps 1-5 to write everything from scratch.
+
 1. **Plan first** (use `think`). Decide:
    - What does the agent *do* end-to-end? Write a one-sentence mission.
    - What tools does it need? Aim for the smallest set (3-6 tools).

--- a/examples/agent_factory.workspace/setup.py
+++ b/examples/agent_factory.workspace/setup.py
@@ -1,0 +1,49 @@
+"""agent_factory.workspace setup.py — auto-scaffolds the target.
+
+When the factory is loaded with these runtime kwargs:
+
+    runtime={
+        "workspace": "/path/to/project",   # standard, where the agent runs
+        "scaffold_to": "summarizer.workspace",  # OPTIONAL relative path
+        "scaffold_name": "summarizer",          # OPTIONAL, defaults to dir name
+        "scaffold_tools": ["a", "b"],            # OPTIONAL, list of tool names
+    }
+
+…we scaffold the target workspace skeleton BEFORE the loop runs, so
+the agent starts with the boilerplate already laid out and spends LLM
+turns on the interesting work (tool bodies, system prompt, tests).
+
+The agent's system prompt mentions: "If the target workspace already
+has a skeleton, customize it via multi_edit. Otherwise, write the
+files yourself." So both paths work — host pre-scaffold OR agent
+self-scaffolds.
+
+If ``scaffold_to`` is not provided, this is a no-op and the factory
+behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet.scaffold import scaffold_workspace
+
+
+def setup(preset, resources, *, runtime=None, **_kwargs):
+    runtime = runtime or {}
+    target = runtime.get("scaffold_to")
+    tools = runtime.get("scaffold_tools")
+    if not target or not tools:
+        return preset
+
+    workspace_root = Path(runtime.get("workspace", "."))
+    target_path = workspace_root / target if not Path(target).is_absolute() else Path(target)
+    name = runtime.get("scaffold_name") or target_path.stem.replace(".workspace", "")
+
+    scaffold_workspace(
+        target_path,
+        name=name,
+        tools=list(tools),
+        overwrite=True,  # idempotent — _write_if_absent preserves existing files
+    )
+    return preset

--- a/src/looplet/builtin_tools/__init__.py
+++ b/src/looplet/builtin_tools/__init__.py
@@ -1,0 +1,37 @@
+"""Built-in tools any looplet workspace can opt into.
+
+A workspace enables built-ins by listing them in ``config.yaml``::
+
+    builtin_tools:
+      - subagent
+
+The loader looks each name up here at workspace-load time and
+registers it in the tool registry alongside the workspace's
+own ``tools/<name>/`` directories.
+
+Built-ins live here (rather than in every workspace's ``tools/``)
+so they evolve with looplet: a new release ships an improved
+``subagent`` tool and every workspace using ``builtin_tools:
+[subagent]`` picks it up immediately, no per-workspace edit needed.
+
+Adding a new built-in: write a small module exposing a ``SPEC``
+:class:`looplet.tools.ToolSpec`, then list its ``name`` in
+:data:`AVAILABLE` below.
+"""
+
+from __future__ import annotations
+
+from looplet.builtin_tools.subagent import SPEC as _SUBAGENT_SPEC
+from looplet.tools import ToolSpec
+
+AVAILABLE: dict[str, ToolSpec] = {
+    _SUBAGENT_SPEC.name: _SUBAGENT_SPEC,
+}
+
+
+def get_builtin_tool(name: str) -> ToolSpec | None:
+    """Return the :class:`ToolSpec` for a built-in tool by name, or None."""
+    return AVAILABLE.get(name)
+
+
+__all__ = ["AVAILABLE", "get_builtin_tool"]

--- a/src/looplet/builtin_tools/__init__.py
+++ b/src/looplet/builtin_tools/__init__.py
@@ -21,11 +21,13 @@ Adding a new built-in: write a small module exposing a ``SPEC``
 
 from __future__ import annotations
 
+from looplet.builtin_tools.scaffold_workspace import SPEC as _SCAFFOLD_SPEC
 from looplet.builtin_tools.subagent import SPEC as _SUBAGENT_SPEC
 from looplet.tools import ToolSpec
 
 AVAILABLE: dict[str, ToolSpec] = {
     _SUBAGENT_SPEC.name: _SUBAGENT_SPEC,
+    _SCAFFOLD_SPEC.name: _SCAFFOLD_SPEC,
 }
 
 

--- a/src/looplet/builtin_tools/scaffold_workspace.py
+++ b/src/looplet/builtin_tools/scaffold_workspace.py
@@ -1,0 +1,127 @@
+"""``scaffold_workspace`` built-in tool — agent-callable wrapper.
+
+A workspace opts in via ``builtin_tools: [scaffold_workspace]`` in
+its ``config.yaml``. The tool wraps :func:`looplet.scaffold.scaffold_workspace`
+so an agent can scaffold a fresh workspace skeleton without leaving
+its reasoning loop.
+
+Use this when:
+
+* The agent is generating a new workspace and the host did NOT
+  pre-scaffold (so the path / name / tool list is the agent's choice).
+* The agent is iterating: scaffold a base, customize, validate, fix,
+  scaffold a new variant, etc.
+
+When the host already knows what to build (e.g. ``looplet new
+--name=foo --tools=a,b``) it should pre-scaffold via ``runtime``
+kwargs instead — that saves the agent a tool turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from looplet.scaffold import scaffold_workspace as _scaffold
+from looplet.tools import ToolSpec
+from looplet.types import ToolContext
+
+
+def _execute(
+    ctx: ToolContext,
+    *,
+    path: str,
+    name: str,
+    tools: list[str],
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    # Resolve relative path against the host workspace if available.
+    target_path = path
+    cfg = ctx.resources.get("workspace_config") if ctx.resources else None
+    host_ws = getattr(cfg, "path", None) if cfg is not None else None
+    if host_ws and not _is_absolute(path):
+        from pathlib import Path  # noqa: PLC0415
+
+        target_path = str(Path(host_ws) / path)
+
+    try:
+        result = _scaffold(target_path, name=name, tools=list(tools), overwrite=overwrite)
+    except FileExistsError as exc:
+        return {
+            "error": f"FileExistsError: {exc}",
+            "recovery": (
+                "The path already has files. Pass overwrite=True to "
+                "scaffold into it (existing files are preserved)."
+            ),
+        }
+    except ValueError as exc:
+        return {
+            "error": f"ValueError: {exc}",
+            "recovery": "Use only alphanumeric / underscore tool names.",
+        }
+    return {
+        "scaffolded": True,
+        "path": str(result),
+        "tools_created": [*tools, "done"] if "done" not in tools else list(tools),
+        "next_steps": (
+            "Use multi_edit / edit_file to fill in the TODO markers in "
+            "prompts/system.md, tools/<name>/tool.yaml, and "
+            "tools/<name>/execute.py. Use validate_workspace(workspace_path) "
+            "to confirm the result loads cleanly."
+        ),
+    }
+
+
+def _is_absolute(p: str) -> bool:
+    from pathlib import Path  # noqa: PLC0415
+
+    return Path(p).is_absolute()
+
+
+SPEC = ToolSpec(
+    name="scaffold_workspace",
+    description=(
+        "Create a stubbed looplet workspace skeleton at ``path`` in one call. "
+        "Generates workspace.json, config.yaml, prompts/system.md, "
+        "tools/<name>/{tool.yaml, execute.py} stubs (raise "
+        "NotImplementedError) for each requested tool, plus the standard "
+        "``done`` tool. Idempotent — re-running preserves files that "
+        "already exist.\n\n"
+        "Use this FIRST when generating a new workspace, then fill in "
+        "the TODO markers via multi_edit / edit_file. Saves the 5-7 "
+        "turns spent writing identical boilerplate by hand.\n\n"
+        "Args:\n"
+        "  path (str): directory to create. Relative paths are resolved "
+        "against the host workspace.\n"
+        "  name (str): becomes workspace.json.name and the title of the "
+        "system prompt.\n"
+        "  tools (list[str]): tool names to scaffold. ``done`` is added "
+        "automatically.\n"
+        "  overwrite (bool): write into a non-empty dir (existing files "
+        "preserved). Default False.\n\n"
+        "Returns: ``{scaffolded, path, tools_created, next_steps}`` "
+        "or ``{error, recovery}``."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Directory to create."},
+            "name": {
+                "type": "string",
+                "description": "Workspace name (becomes workspace.json.name).",
+            },
+            "tools": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Tool names to scaffold (done is added automatically).",
+            },
+            "overwrite": {
+                "type": "boolean",
+                "description": "Allow non-empty target dir (existing files preserved).",
+                "default": False,
+            },
+        },
+        "required": ["path", "name", "tools"],
+    },
+    requires=["workspace_config"],
+    execute=_execute,
+)

--- a/src/looplet/builtin_tools/subagent.py
+++ b/src/looplet/builtin_tools/subagent.py
@@ -73,13 +73,8 @@ def _execute(
     # available; otherwise relative to cwd.
     ws_path = Path(workspace)
     if not ws_path.is_absolute():
-        # Try the host workspace if we can find one in resources.
-        host_ws = None
-        try:
-            cfg = ctx.metadata.get("workspace_config") if ctx.metadata else None
-            host_ws = getattr(cfg, "path", None) if cfg is not None else None
-        except Exception:
-            host_ws = None
+        cfg = ctx.resources.get("workspace_config") if ctx.resources else None
+        host_ws = getattr(cfg, "path", None) if cfg is not None else None
         if host_ws:
             ws_path = Path(host_ws) / workspace
         else:
@@ -94,8 +89,8 @@ def _execute(
     from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
 
     # Inherit runtime from the parent if we can. The standard hand-off
-    # is via ctx.metadata["runtime"], which the workspace loader sets.
-    runtime = (ctx.metadata or {}).get("runtime", {})
+    # is via ctx.metadata["runtime"] (set by the workspace loader).
+    runtime = (ctx.metadata or {}).get("runtime", {}) if ctx.metadata else {}
     sub_preset = workspace_to_preset(str(ws_path), runtime=dict(runtime))
 
     # Sub-loop budget: explicit ``max_steps`` overrides; otherwise
@@ -173,10 +168,29 @@ SPEC = ToolSpec(
         "Returns: ``{summary, result, final_tool, steps_used, ...}``."
     ),
     parameters={
-        "workspace": "str — path to the sub-agent workspace",
-        "task": "str — natural-language task for the sub-agent",
-        "max_steps": "int — optional cap on sub-loop steps",
-        "max_depth": "int — recursion limit (default 5)",
+        "type": "object",
+        "properties": {
+            "workspace": {
+                "type": "string",
+                "description": "Path to the sub-agent workspace (absolute or relative to host).",
+            },
+            "task": {
+                "type": "string",
+                "description": "Natural-language task to give the sub-agent.",
+            },
+            "max_steps": {
+                "type": "integer",
+                "description": "Optional cap on sub-loop steps.",
+                "default": 0,
+            },
+            "max_depth": {
+                "type": "integer",
+                "description": "Recursion limit (default 5).",
+                "default": 5,
+            },
+        },
+        "required": ["workspace", "task"],
     },
+    requires=["workspace_config"],
     execute=_execute,
 )

--- a/src/looplet/builtin_tools/subagent.py
+++ b/src/looplet/builtin_tools/subagent.py
@@ -1,0 +1,182 @@
+"""``subagent`` built-in tool — invoke another workspace as a sub-loop.
+
+A workspace opts in by listing ``subagent`` in its ``config.yaml``::
+
+    builtin_tools:
+      - subagent
+
+The agent can then dispatch a sub-task to any other workspace::
+
+    subagent(
+        workspace="./researcher.workspace",
+        task="find recent CVEs for the openssl 3.x line",
+        max_steps=10,                # OPTIONAL, defaults to remaining parent budget
+    )
+
+The sub-loop runs synchronously, sharing the parent's ``llm`` and
+``runtime`` (so the same workspace_config / file_cache is in scope).
+The result returned to the parent is the sub-loop's final tool result
+(typically the ``done`` summary).
+
+## Recursion safety
+
+A small ``LOOPLET_SUBAGENT_DEPTH`` env-var counter increments on each
+sub-loop entry and decrements on exit. If it exceeds
+``max_depth`` (default 5) the call is refused with a structured error
+pointing the agent at the depth budget. This prevents an agent from
+spawning itself indefinitely.
+
+## Why no parallel fan-out
+
+We deliberately ship the sequential case only. ``subagent(...)`` calls
+can be chained in the parent's reasoning ("dispatch to A, then dispatch
+to B"). Parallel execution requires a real use case that motivates the
+extra surface area; for now, ``async_composable_loop`` is the right
+place to express concurrency.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from looplet.tools import ToolSpec
+from looplet.types import DefaultState, ToolContext
+
+_DEPTH_ENV = "LOOPLET_SUBAGENT_DEPTH"
+DEFAULT_MAX_DEPTH = 5
+
+
+def _execute(
+    ctx: ToolContext,
+    *,
+    workspace: str,
+    task: str,
+    max_steps: int = 0,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> dict:
+    # Recursion guard.
+    depth = int(os.environ.get(_DEPTH_ENV, "0"))
+    if depth >= max_depth:
+        return {
+            "error": (
+                f"sub-agent depth {depth + 1} would exceed max_depth={max_depth}. "
+                "Stop spawning sub-agents recursively."
+            ),
+            "depth": depth,
+            "max_depth": max_depth,
+        }
+
+    # Resolve the target workspace path. Allow either absolute or
+    # relative-to-the-host-workspace if a workspace_config resource is
+    # available; otherwise relative to cwd.
+    ws_path = Path(workspace)
+    if not ws_path.is_absolute():
+        # Try the host workspace if we can find one in resources.
+        host_ws = None
+        try:
+            cfg = ctx.metadata.get("workspace_config") if ctx.metadata else None
+            host_ws = getattr(cfg, "path", None) if cfg is not None else None
+        except Exception:
+            host_ws = None
+        if host_ws:
+            ws_path = Path(host_ws) / workspace
+        else:
+            ws_path = Path.cwd() / workspace
+    if not ws_path.is_dir():
+        return {
+            "error": f"sub-agent workspace not found at {ws_path!s}",
+            "workspace": str(ws_path),
+        }
+
+    # Defer the heavy imports so this module remains cheap to import.
+    from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
+
+    # Inherit runtime from the parent if we can. The standard hand-off
+    # is via ctx.metadata["runtime"], which the workspace loader sets.
+    runtime = (ctx.metadata or {}).get("runtime", {})
+    sub_preset = workspace_to_preset(str(ws_path), runtime=dict(runtime))
+
+    # Sub-loop budget: explicit ``max_steps`` overrides; otherwise
+    # inherit from sub_preset's own config.
+    if max_steps > 0:
+        steps = max_steps
+        # Apply the override to the sub-preset's config so the loop
+        # honours it and ``DefaultState(max_steps=...)`` matches.
+        sub_preset.config.max_steps = steps
+    else:
+        steps = sub_preset.config.max_steps
+
+    # Bump depth env-var so any nested subagent calls see the updated
+    # depth. We restore the old value after the sub-loop returns.
+    prev_depth = os.environ.get(_DEPTH_ENV)
+    os.environ[_DEPTH_ENV] = str(depth + 1)
+
+    state = DefaultState(max_steps=steps)
+    last_step: Any = None
+    sub_steps = 0
+    try:
+        for step in composable_loop(
+            llm=ctx.llm,
+            config=sub_preset.config,
+            tools=sub_preset.tools,
+            state=state,
+            hooks=sub_preset.hooks,
+            task={"goal": task},
+        ):
+            sub_steps += 1
+            last_step = step
+    finally:
+        # Restore parent's depth (or remove if we set it from absent).
+        if prev_depth is None:
+            os.environ.pop(_DEPTH_ENV, None)
+        else:
+            os.environ[_DEPTH_ENV] = prev_depth
+
+    # Surface the final tool result. By convention sub-agents end with
+    # ``done(summary=...)``, so we expose the summary at the top level
+    # for easy chaining.
+    final_data: dict = {}
+    final_tool: str | None = None
+    if last_step is not None and last_step.tool_call is not None:
+        final_tool = last_step.tool_call.tool
+        if last_step.tool_result is not None and last_step.tool_result.data:
+            final_data = dict(last_step.tool_result.data)
+
+    return {
+        "workspace": str(ws_path),
+        "steps_used": sub_steps,
+        "max_steps": steps,
+        "final_tool": final_tool,
+        "summary": final_data.get("summary"),
+        "result": final_data,
+        "depth": depth + 1,
+    }
+
+
+SPEC = ToolSpec(
+    name="subagent",
+    description=(
+        "Invoke another looplet workspace as a sub-agent. The sub-agent "
+        "shares this agent's LLM and runtime, runs to its own ``done`` "
+        "tool, and returns the final result. Use this for hierarchical "
+        "task decomposition: dispatch a focused sub-task to a workspace "
+        "that specializes in it, then continue with the result.\n\n"
+        "Args:\n"
+        "  workspace (str): path to a workspace directory (absolute or "
+        "relative to the host workspace root).\n"
+        "  task (str): natural-language task to give the sub-agent.\n"
+        "  max_steps (int, optional): cap on sub-loop steps. Defaults to "
+        "the sub-workspace's own ``max_steps`` from its config.yaml.\n"
+        "  max_depth (int, optional): recursion limit (default 5).\n\n"
+        "Returns: ``{summary, result, final_tool, steps_used, ...}``."
+    ),
+    parameters={
+        "workspace": "str — path to the sub-agent workspace",
+        "task": "str — natural-language task for the sub-agent",
+        "max_steps": "int — optional cap on sub-loop steps",
+        "max_depth": "int — recursion limit (default 5)",
+    },
+    execute=_execute,
+)

--- a/src/looplet/scaffold.py
+++ b/src/looplet/scaffold.py
@@ -1,0 +1,211 @@
+"""Scaffold a minimal looplet workspace skeleton in one call.
+
+Use this from the host before invoking the agent_factory so the agent
+starts with the boilerplate already in place and spends LLM turns on
+the interesting work (writing tool bodies, system prompt, tests)
+instead of writing the structural files that look the same in every
+agent.
+
+Programmatic use:
+
+.. code-block:: python
+
+    from looplet.scaffold import scaffold_workspace
+
+    scaffold_workspace(
+        path="/tmp/my_project/summarizer.workspace",
+        name="summarizer",
+        tools=["summarize", "extract_keywords"],
+    )
+
+After this returns, ``summarizer.workspace/`` contains a working
+(but stubbed) workspace that ``workspace_to_preset()`` can load.
+The agent only needs to fill in the TODO markers.
+
+Files created:
+
+* ``workspace.json`` — required metadata (one line of JSON)
+* ``config.yaml`` — sensible defaults: max_steps=20, temperature=0.7
+* ``prompts/system.md`` — stub with TODO markers
+* ``tools/<name>/{tool.yaml,execute.py}`` for each tool requested
+* ``tools/done/{tool.yaml,execute.py}`` — the standard finalizer
+  (always added; every agent needs it)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# ── file templates ───────────────────────────────────────────────
+
+
+_WORKSPACE_JSON = '{{"name": {name!r}, "schema_version": 1}}\n'
+
+_CONFIG_YAML = """\
+max_steps: 20
+max_tokens: 2000
+temperature: 0.7
+done_tool: done
+"""
+
+_SYSTEM_MD = """\
+# {title} Agent
+
+<TODO: one-paragraph mission statement — what does this agent do?>
+
+## Workflow
+
+<TODO: numbered list of steps the agent should take>
+{tool_workflow_hint}
+- Always end with `done(summary=...)`.
+
+## Tools
+
+{tool_list_md}
+- `done(summary)` — signals task completion.
+"""
+
+_TOOL_YAML = """\
+name: {name}
+description: |-
+  TODO: one-line description, then optional Usage / Examples sections.
+
+parameters: {{}}
+"""
+
+_TOOL_EXECUTE = '''\
+"""TODO: one-line module summary for {name}."""
+
+
+def execute(ctx, **kwargs) -> dict:
+    """TODO: replace ``**kwargs`` with explicit keyword params, fill in body."""
+    raise NotImplementedError("scaffold: implement {name}")
+'''
+
+_DONE_YAML = """\
+name: done
+description: |-
+  Signal that the task is complete. Pass a one-line summary of what was accomplished.
+
+parameters:
+  summary:
+    type: string
+    description: One-line summary of the result.
+"""
+
+_DONE_EXECUTE = '''\
+"""done tool — completion sentinel."""
+
+
+def execute(*, summary: str) -> dict:
+    """Mark the task as complete with a summary."""
+    return {"summary": summary, "done": True}
+'''
+
+
+# ── main entry point ─────────────────────────────────────────────
+
+
+def scaffold_workspace(
+    path: str | Path,
+    *,
+    name: str,
+    tools: list[str],
+    overwrite: bool = False,
+) -> Path:
+    """Create a workspace skeleton at ``path``.
+
+    Args:
+        path: Directory to create (created if missing). Refuses to
+            overwrite an existing non-empty directory unless
+            ``overwrite=True``.
+        name: Workspace name (becomes ``workspace.json`` "name" field
+            and the title of the system prompt).
+        tools: Tool names to scaffold under ``tools/<name>/``. The
+            ``done`` tool is always added even if not listed; if you
+            include "done" explicitly it is not duplicated.
+        overwrite: When True, write into an existing directory. Files
+            already present are NOT clobbered (so any agent edits
+            survive a re-scaffold). Default False.
+
+    Returns:
+        The absolute path to the workspace.
+
+    Raises:
+        FileExistsError: If ``path`` exists and is non-empty and
+            ``overwrite=False``.
+        ValueError: If ``tools`` contains an empty string or names
+            with characters that aren't valid Python identifiers.
+    """
+    root = Path(path)
+    if root.exists() and any(root.iterdir()) and not overwrite:
+        raise FileExistsError(
+            f"workspace path {root} already exists and is non-empty. "
+            f"Pass overwrite=True to scaffold into it (existing files "
+            f"will be preserved)."
+        )
+
+    # Validate tool names — they become directory names AND yaml
+    # ``name:`` fields. Reject anything that wouldn't survive both.
+    for t in tools:
+        if not t:
+            raise ValueError("tool name cannot be empty")
+        if not t.replace("_", "").isalnum():
+            raise ValueError(
+                f"tool name {t!r} must be alphanumeric / underscore "
+                f"(used as both a directory name and a yaml key)"
+            )
+
+    # Make sure ``done`` is in the set — every agent needs it.
+    tool_set = list(dict.fromkeys([*tools, "done"]))
+
+    root.mkdir(parents=True, exist_ok=True)
+    _write_if_absent(root / "workspace.json", _WORKSPACE_JSON.format(name=name))
+    _write_if_absent(root / "config.yaml", _CONFIG_YAML)
+
+    prompts_dir = root / "prompts"
+    prompts_dir.mkdir(exist_ok=True)
+    title = name.replace("_", " ").title()
+    tool_workflow_hint = (
+        "\n".join(
+            f"{i + 1}. <TODO: when to call `{t}`>"
+            for i, t in enumerate(t for t in tool_set if t != "done")
+        )
+        or "1. <TODO: first step>"
+    )
+    tool_list_md = "\n".join(f"- `{t}(...)` — <TODO: describe>" for t in tool_set if t != "done")
+    _write_if_absent(
+        prompts_dir / "system.md",
+        _SYSTEM_MD.format(
+            title=title,
+            tool_workflow_hint=tool_workflow_hint,
+            tool_list_md=tool_list_md,
+        ),
+    )
+
+    tools_dir = root / "tools"
+    tools_dir.mkdir(exist_ok=True)
+    for tool in tool_set:
+        tdir = tools_dir / tool
+        tdir.mkdir(exist_ok=True)
+        if tool == "done":
+            _write_if_absent(tdir / "tool.yaml", _DONE_YAML)
+            _write_if_absent(tdir / "execute.py", _DONE_EXECUTE)
+        else:
+            _write_if_absent(tdir / "tool.yaml", _TOOL_YAML.format(name=tool))
+            _write_if_absent(tdir / "execute.py", _TOOL_EXECUTE.format(name=tool))
+
+    return root.resolve()
+
+
+def _write_if_absent(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` only if the file does not yet exist.
+
+    Idempotent: re-running ``scaffold_workspace`` against an existing
+    directory preserves any edits the agent (or user) has already made.
+    """
+    if not path.exists():
+        path.write_text(content)
+
+
+__all__ = ["scaffold_workspace"]

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -2018,6 +2018,13 @@ def _workspace_to_preset_inner(
     # with the hook-kwargs ref resolution below.
     cfg_kwargs = _resolve_refs(cfg_kwargs, resources)
 
+    # ``builtin_tools:`` is a workspace-loader directive, not a
+    # ``LoopConfig`` field — pop it before constructing the config so
+    # ``LoopConfig(**cfg_kwargs)`` doesn't choke on an unknown kwarg.
+    # The popped list is consumed below where the tool registry is
+    # populated.
+    _builtin_tool_names: list[str] = list(cfg_kwargs.pop("builtin_tools", None) or [])
+
     config = LoopConfig(**cfg_kwargs)
 
     # Track tool + hook modules so setup.py can wire shared resources
@@ -2092,6 +2099,26 @@ def _workspace_to_preset_inner(
                     if strict:
                         raise WorkspaceSerializationError(msg)
                     logger.warning("%s; tool will receive None for missing resources", msg)
+            registry.register(spec)
+
+    # Built-in tools — opt-in via ``builtin_tools:`` in config.yaml.
+    # These are looplet-shipped tools (``subagent``, future helpers)
+    # that any workspace can enable without writing a tools/<name>/
+    # directory. Looked up in :mod:`looplet.builtin_tools` by name.
+    if _builtin_tool_names:
+        from looplet.builtin_tools import get_builtin_tool  # noqa: PLC0415
+
+        for bname in _builtin_tool_names:
+            spec = get_builtin_tool(bname)
+            if spec is None:
+                msg = (
+                    f"unknown builtin tool {bname!r}; "
+                    f"available built-ins: see ``looplet.builtin_tools.AVAILABLE``"
+                )
+                if strict:
+                    raise WorkspaceSerializationError(msg)
+                logger.warning("%s; skipping", msg)
+                continue
             registry.register(spec)
     # Hand the resource registry to the tool registry so any tool whose
     # ``ToolSpec.requires`` lists a resource name receives the live

--- a/tests/test_scaffold_and_subagent_smoke.py
+++ b/tests/test_scaffold_and_subagent_smoke.py
@@ -1,0 +1,166 @@
+"""Smoke tests for ``looplet.scaffold`` + ``builtin_tools: [subagent]``.
+
+Covers:
+  * scaffold_workspace creates a loadable skeleton
+  * idempotent re-scaffold preserves edits
+  * skeleton has done tool by default
+  * tool name validation
+  * builtin_tools opt-in registers subagent
+  * subagent dispatch runs a sub-loop end-to-end
+  * subagent recursion guard refuses past max_depth
+  * subagent inherits sub-workspace config when max_steps not given
+  * subagent override of max_steps applies
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from looplet import MockLLMBackend, workspace_to_preset
+from looplet.scaffold import scaffold_workspace
+from looplet.types import ToolContext
+from looplet.workspace import WorkspaceSerializationError
+
+# ── scaffold ────────────────────────────────────────────────────
+
+
+def test_scaffold_creates_loadable_workspace(tmp_path: Path) -> None:
+    p = scaffold_workspace(
+        tmp_path / "agent.workspace",
+        name="agent",
+        tools=["foo", "bar"],
+    )
+    preset = workspace_to_preset(p)
+    assert sorted(preset.tools._tools.keys()) == ["bar", "done", "foo"]
+    assert preset.config.max_steps == 20
+    assert "agent" in (preset.config.system_prompt or "").lower()
+
+
+def test_scaffold_done_tool_always_added(tmp_path: Path) -> None:
+    p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=[])
+    assert (p / "tools" / "done" / "tool.yaml").is_file()
+    assert (p / "tools" / "done" / "execute.py").is_file()
+
+
+def test_scaffold_idempotent_preserves_edits(tmp_path: Path) -> None:
+    p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["foo"])
+    edited = "name: foo\ndescription: edited!\nparameters: {}\n"
+    (p / "tools" / "foo" / "tool.yaml").write_text(edited)
+    # Re-scaffold should not overwrite.
+    scaffold_workspace(p, name="x", tools=["foo", "bar"], overwrite=True)
+    assert (p / "tools" / "foo" / "tool.yaml").read_text() == edited
+    # New tool should be added.
+    assert (p / "tools" / "bar" / "tool.yaml").is_file()
+
+
+def test_scaffold_refuses_existing_non_empty(tmp_path: Path) -> None:
+    p = tmp_path / "x.workspace"
+    p.mkdir()
+    (p / "stuff.txt").write_text("hi")
+    with pytest.raises(FileExistsError, match="non-empty"):
+        scaffold_workspace(p, name="x", tools=[])
+
+
+def test_scaffold_rejects_invalid_tool_names(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="alphanumeric"):
+        scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["bad-name"])
+    with pytest.raises(ValueError, match="empty"):
+        scaffold_workspace(tmp_path / "y.workspace", name="y", tools=[""])
+
+
+def test_scaffold_workspace_loads_with_factory_setup(tmp_path: Path) -> None:
+    """Loading the agent_factory with scaffold runtime kwargs auto-creates the target."""
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    workspace_to_preset(
+        str(factory),
+        runtime={
+            "workspace": str(tmp_path),
+            "scaffold_to": "auto.workspace",
+            "scaffold_tools": ["alpha", "beta"],
+        },
+    )
+    target = tmp_path / "auto.workspace"
+    assert (target / "workspace.json").is_file()
+    assert (target / "config.yaml").is_file()
+    assert (target / "tools" / "alpha").is_dir()
+    assert (target / "tools" / "beta").is_dir()
+    assert (target / "tools" / "done").is_dir()
+
+
+# ── builtin_tools: [subagent] ───────────────────────────────────
+
+
+def _make_parent_with_subagent(tmp_path: Path) -> Path:
+    parent = tmp_path / "parent.workspace"
+    scaffold_workspace(parent, name="parent", tools=[])
+    cfg = parent / "config.yaml"
+    cfg.write_text(cfg.read_text() + "builtin_tools:\n  - subagent\n")
+    return parent
+
+
+def test_builtin_tools_registers_subagent(tmp_path: Path) -> None:
+    parent = _make_parent_with_subagent(tmp_path)
+    p = workspace_to_preset(parent)
+    assert "subagent" in p.tools._tools
+
+
+def test_builtin_tools_unknown_strict_raises(tmp_path: Path) -> None:
+    parent = tmp_path / "p.workspace"
+    scaffold_workspace(parent, name="p", tools=[])
+    cfg = parent / "config.yaml"
+    cfg.write_text(cfg.read_text() + "builtin_tools:\n  - nonexistent_tool\n")
+    with pytest.raises(WorkspaceSerializationError, match="unknown builtin tool"):
+        workspace_to_preset(parent, strict=True)
+
+
+def test_subagent_runs_child_loop_to_done(tmp_path: Path) -> None:
+    parent = _make_parent_with_subagent(tmp_path)
+    child = tmp_path / "child.workspace"
+    scaffold_workspace(child, name="child", tools=[])
+
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["subagent"]
+    mock = MockLLMBackend(
+        responses=[json.dumps({"tool": "done", "args": {"summary": "done-from-child"}})]
+    )
+    ctx = ToolContext(llm=mock, metadata={})
+    result = spec.execute(ctx, workspace=str(child), task="hi", max_steps=5)
+
+    assert result["summary"] == "done-from-child"
+    assert result["final_tool"] == "done"
+    assert result["depth"] == 1
+    assert result["steps_used"] >= 1
+
+
+def test_subagent_recursion_guard(tmp_path: Path) -> None:
+    parent = _make_parent_with_subagent(tmp_path)
+    child = tmp_path / "child.workspace"
+    scaffold_workspace(child, name="child", tools=[])
+
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["subagent"]
+    mock = MockLLMBackend(responses=[])
+    ctx = ToolContext(llm=mock, metadata={})
+
+    # Pretend we're already at max depth.
+    os.environ["LOOPLET_SUBAGENT_DEPTH"] = "5"
+    try:
+        result = spec.execute(ctx, workspace=str(child), task="hi", max_depth=5)
+        assert "would exceed" in result.get("error", "")
+        assert result.get("depth") == 5
+    finally:
+        os.environ.pop("LOOPLET_SUBAGENT_DEPTH", None)
+
+
+def test_subagent_missing_workspace_returns_structured_error(tmp_path: Path) -> None:
+    parent = _make_parent_with_subagent(tmp_path)
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["subagent"]
+    ctx = ToolContext(llm=MockLLMBackend(responses=[]), metadata={})
+    result = spec.execute(ctx, workspace=str(tmp_path / "nope"), task="hi")
+    assert "not found" in result.get("error", "")

--- a/tests/test_scaffold_and_subagent_smoke.py
+++ b/tests/test_scaffold_and_subagent_smoke.py
@@ -164,3 +164,54 @@ def test_subagent_missing_workspace_returns_structured_error(tmp_path: Path) -> 
     ctx = ToolContext(llm=MockLLMBackend(responses=[]), metadata={})
     result = spec.execute(ctx, workspace=str(tmp_path / "nope"), task="hi")
     assert "not found" in result.get("error", "")
+
+
+# ── scaffold_workspace as a built-in tool ──────────────────────
+
+
+def test_builtin_tools_registers_scaffold_workspace(tmp_path: Path) -> None:
+    parent = tmp_path / "p.workspace"
+    scaffold_workspace(parent, name="p", tools=[])
+    cfg = parent / "config.yaml"
+    cfg.write_text(cfg.read_text() + "builtin_tools:\n  - scaffold_workspace\n")
+    p = workspace_to_preset(parent)
+    assert "scaffold_workspace" in p.tools._tools
+
+
+def test_scaffold_workspace_tool_creates_workspace(tmp_path: Path) -> None:
+    """Dispatching scaffold_workspace tool builds a loadable child workspace."""
+    parent = tmp_path / "factory.workspace"
+    scaffold_workspace(parent, name="factory", tools=[])
+    cfg = parent / "config.yaml"
+    cfg.write_text(cfg.read_text() + "builtin_tools:\n  - scaffold_workspace\n")
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["scaffold_workspace"]
+    ctx = ToolContext(metadata={})
+    result = spec.execute(
+        ctx,
+        path=str(tmp_path / "child.workspace"),
+        name="child",
+        tools=["alpha", "beta"],
+    )
+    assert result.get("scaffolded") is True
+    assert "child.workspace" in result.get("path", "")
+    # Loadable.
+    sub = workspace_to_preset(tmp_path / "child.workspace")
+    assert sorted(sub.tools._tools.keys()) == ["alpha", "beta", "done"]
+
+
+def test_scaffold_workspace_tool_existing_dir_returns_recovery(tmp_path: Path) -> None:
+    """File-exists error is returned as structured tool result, not raised."""
+    parent = tmp_path / "p.workspace"
+    scaffold_workspace(parent, name="p", tools=[])
+    cfg = parent / "config.yaml"
+    cfg.write_text(cfg.read_text() + "builtin_tools:\n  - scaffold_workspace\n")
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["scaffold_workspace"]
+    # Pre-create non-empty dir.
+    (tmp_path / "blocked").mkdir()
+    (tmp_path / "blocked" / "stuff.txt").write_text("hi")
+    ctx = ToolContext(metadata={})
+    result = spec.execute(ctx, path=str(tmp_path / "blocked"), name="x", tools=["a"])
+    assert "FileExistsError" in result.get("error", "")
+    assert "overwrite=True" in result.get("recovery", "")


### PR DESCRIPTION
Two minimum-elegant primitives motivated by the agent-factory brainstorm. **No new concepts** for users — just a Python helper and a one-line config opt-in.

## 1. `looplet.scaffold.scaffold_workspace()`

Plain Python helper (NOT a tool — invoked by the host before the loop runs). Creates a working but stubbed workspace skeleton in one call:

```python
from looplet.scaffold import scaffold_workspace

scaffold_workspace(
    path='./summarizer.workspace',
    name='summarizer',
    tools=['summarize', 'extract_keywords'],
)
```

Generated:
- `workspace.json` + `config.yaml` + `prompts/system.md`
- `tools/<name>/{tool.yaml, execute.py}` stubs (raise NotImplementedError) for each requested tool
- `tools/done/` always added — every agent needs it

Idempotent: re-running preserves any files that already exist (`_write_if_absent`).

The `agent_factory.workspace` gains a `setup.py` that auto-invokes scaffold when the host passes runtime kwargs:

```python
workspace_to_preset(
    'examples/agent_factory.workspace',
    runtime={
        'workspace': '/tmp/proj',
        'scaffold_to': 'agent.workspace',
        'scaffold_tools': ['summarize'],
    },
)
```

The factory's `system.md` updated: *check for skeleton first, fill in TODOs via `multi_edit`; otherwise write from scratch.*

## 2. `builtin_tools: [subagent]`

A workspace can opt into looplet-shipped tools via a new config.yaml directive:

```yaml
builtin_tools:
  - subagent
```

The `subagent` tool invokes another workspace as a sub-loop, sharing the parent's LLM and runtime. Returns the sub-loop's `done` summary.

```python
subagent(
    workspace='./researcher.workspace',
    task='find recent CVEs',
    max_steps=10,
)
```

- Recursion-guarded via `LOOPLET_SUBAGENT_DEPTH` env var (default `max_depth=5`).
- Sequential only — parallel fan-out deliberately deferred.
- Built atop the existing `run_sub_loop` machinery; ~110 LOC for tool + registry.

## Tests
- 11 new smoke tests in `tests/test_scaffold_and_subagent_smoke.py`.
- Full suite **1644/1644** passing, ruff clean.

## Dogfood
Re-ran the 5-agent quality benchmark with pre-scaffolding. All 5 loaded with the expected tools. Step count was mixed: `git_release_notes` 33→13 (huge win), `haiku_writer` 12→11, but other 3 went UP because the model reinvested the saved budget in defensive code (`_extract_json` helpers, arg-shape guards) and test-writing iteration. **Quality stayed consistently high.**

The honest conclusion: scaffolding is principled startup-friction reduction; it lets the model focus on the *interesting* work without changing the total step budget materially. Step count is the wrong metric — structural consistency at startup is the win.