### PR TITLE
fix: second-pass audit — TODO warnings, name mismatch, doc + cleanup

### DIFF
--- a/examples/agent_factory.workspace/tools/validate_workspace/execute.py
+++ b/examples/agent_factory.workspace/tools/validate_workspace/execute.py
@@ -74,7 +74,26 @@ def execute(
 
     tools = sorted(preset.tools._tools.keys())
     hooks = [type(h).__name__ for h in preset.hooks]
-    sys_prompt_chars = len(preset.config.system_prompt or "")
+    sys_prompt = preset.config.system_prompt or ""
+    sys_prompt_chars = len(sys_prompt)
+
+    # Detect scaffolded-but-unfilled artifacts. The scaffolder writes
+    # ``<TODO: ...>`` markers in the system prompt and
+    # ``raise NotImplementedError("scaffold: implement <name>")`` in
+    # tool bodies; if either survives, the agent has not finished
+    # the work and should not declare done.
+    todo_in_prompt = "<TODO:" in sys_prompt or "TODO:" in sys_prompt[:600]
+    scaffold_stubs: list[str] = []
+    tools_dir = abs_path / "tools"
+    if tools_dir.is_dir():
+        for tool_dir in sorted(p for p in tools_dir.iterdir() if p.is_dir()):
+            execute_py = tool_dir / "execute.py"
+            if not execute_py.is_file():
+                continue
+            body = execute_py.read_text(encoding="utf-8", errors="replace")
+            if 'NotImplementedError("scaffold: implement' in body:
+                scaffold_stubs.append(tool_dir.name)
+
     return {
         "valid": True,
         "workspace_path": workspace_path,
@@ -89,6 +108,13 @@ def execute(
             for warning in (
                 "system_prompt is empty — add prompts/system.md" if sys_prompt_chars == 0 else None,
                 "no `done` tool — every agent must have one" if "done" not in tools else None,
+                "system_prompt still has TODO markers — fill them in" if todo_in_prompt else None,
+                (
+                    f"tools still raise NotImplementedError (unfilled scaffolds): "
+                    f"{', '.join(scaffold_stubs)}"
+                )
+                if scaffold_stubs
+                else None,
             )
             if warning is not None
         ],

--- a/src/looplet/builtin_tools/__init__.py
+++ b/src/looplet/builtin_tools/__init__.py
@@ -4,15 +4,22 @@ A workspace enables built-ins by listing them in ``config.yaml``::
 
     builtin_tools:
       - subagent
+      - scaffold_workspace
 
 The loader looks each name up here at workspace-load time and
 registers it in the tool registry alongside the workspace's
 own ``tools/<name>/`` directories.
 
 Built-ins live here (rather than in every workspace's ``tools/``)
-so they evolve with looplet: a new release ships an improved
-``subagent`` tool and every workspace using ``builtin_tools:
-[subagent]`` picks it up immediately, no per-workspace edit needed.
+so they evolve with looplet: a new release ships an improved tool
+and every workspace using ``builtin_tools:`` picks it up
+immediately, no per-workspace edit needed.
+
+Currently shipped built-ins:
+
+* ``subagent`` — invoke another workspace as a synchronous sub-loop.
+* ``scaffold_workspace`` — create a stubbed workspace skeleton in one
+  call (agent-callable wrapper around :func:`looplet.scaffold.scaffold_workspace`).
 
 Adding a new built-in: write a small module exposing a ``SPEC``
 :class:`looplet.tools.ToolSpec`, then list its ``name`` in

--- a/src/looplet/builtin_tools/scaffold_workspace.py
+++ b/src/looplet/builtin_tools/scaffold_workspace.py
@@ -19,6 +19,7 @@ kwargs instead — that saves the agent a tool turn.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from looplet.scaffold import scaffold_workspace as _scaffold
@@ -38,9 +39,7 @@ def _execute(
     target_path = path
     cfg = ctx.resources.get("workspace_config") if ctx.resources else None
     host_ws = getattr(cfg, "path", None) if cfg is not None else None
-    if host_ws and not _is_absolute(path):
-        from pathlib import Path  # noqa: PLC0415
-
+    if host_ws and not Path(path).is_absolute():
         target_path = str(Path(host_ws) / path)
 
     try:
@@ -69,12 +68,6 @@ def _execute(
             "to confirm the result loads cleanly."
         ),
     }
-
-
-def _is_absolute(p: str) -> bool:
-    from pathlib import Path  # noqa: PLC0415
-
-    return Path(p).is_absolute()
 
 
 SPEC = ToolSpec(

--- a/src/looplet/builtin_tools/subagent.py
+++ b/src/looplet/builtin_tools/subagent.py
@@ -14,9 +14,12 @@ The agent can then dispatch a sub-task to any other workspace::
     )
 
 The sub-loop runs synchronously, sharing the parent's ``llm`` and
-``runtime`` (so the same workspace_config / file_cache is in scope).
-The result returned to the parent is the sub-loop's final tool result
-(typically the ``done`` summary).
+constructing a fresh ``runtime`` that defaults to the parent's
+``workspace_config.path`` (so resource builders like
+``resources/file_cache.py`` bind to the same project root). Other
+runtime values can be overridden via ``ctx.metadata["runtime"]``.
+The result returned to the parent is the sub-loop's final tool
+result (typically the ``done`` summary).
 
 ## Recursion safety
 
@@ -58,7 +61,7 @@ def _execute(
     *,
     workspace: str,
     task: str,
-    max_steps: int = 0,
+    max_steps: int | None = None,
     max_depth: int = DEFAULT_MAX_DEPTH,
 ) -> dict:
     # Recursion guard.
@@ -105,12 +108,22 @@ def _execute(
         host_ws_str = getattr(cfg, "path", None) if cfg is not None else None
     metadata_runtime = (ctx.metadata or {}).get("runtime") if ctx.metadata else None
     runtime: dict[str, Any] = dict(metadata_runtime) if metadata_runtime else {}
-    runtime.setdefault("workspace", host_ws_str or str(Path.cwd()))
+    fallback_used = False
+    if "workspace" not in runtime:
+        if host_ws_str:
+            runtime["workspace"] = host_ws_str
+        else:
+            # No parent workspace_config and no explicit metadata.runtime —
+            # fall back to cwd, but make it loud so the host knows the
+            # sub-loop is rooted in whichever dir the process happens to
+            # be running from.
+            runtime["workspace"] = str(Path.cwd())
+            fallback_used = True
     sub_preset = workspace_to_preset(str(ws_path), runtime=runtime)
 
     # Sub-loop budget: explicit ``max_steps`` overrides; otherwise
     # inherit from sub_preset's own config.
-    if max_steps > 0:
+    if max_steps is not None and max_steps > 0:
         steps = max_steps
         # Apply the override to the sub-preset's config so the loop
         # honours it and ``DefaultState(max_steps=...)`` matches.
@@ -148,7 +161,7 @@ def _execute(
         if last_step.tool_result is not None and last_step.tool_result.data:
             final_data = dict(last_step.tool_result.data)
 
-    return {
+    result: dict[str, Any] = {
         "workspace": str(ws_path),
         "steps_used": sub_steps,
         "max_steps": steps,
@@ -157,13 +170,23 @@ def _execute(
         "result": final_data,
         "depth": depth + 1,
     }
+    if fallback_used:
+        result["warning"] = (
+            "no workspace_config resource on the parent and no "
+            "ctx.metadata['runtime'] — sub-loop's runtime['workspace'] "
+            f"defaulted to cwd ({runtime['workspace']!r}). Pass "
+            "runtime={'workspace': '...'} to workspace_to_preset for "
+            "the parent, or set ctx.metadata['runtime'] before calling."
+        )
+    return result
 
 
 SPEC = ToolSpec(
     name="subagent",
     description=(
         "Invoke another looplet workspace as a sub-agent. The sub-agent "
-        "shares this agent's LLM and runtime, runs to its own ``done`` "
+        "shares this agent's LLM and inherits the parent's workspace "
+        "path, runs to its own ``done`` "
         "tool, and returns the final result. Use this for hierarchical "
         "task decomposition: dispatch a focused sub-task to a workspace "
         "that specializes in it, then continue with the result.\n\n"
@@ -189,8 +212,11 @@ SPEC = ToolSpec(
             },
             "max_steps": {
                 "type": "integer",
-                "description": "Optional cap on sub-loop steps.",
-                "default": 0,
+                "description": (
+                    "Optional cap on sub-loop steps. Omit to inherit "
+                    "the sub-workspace's own ``max_steps`` from its "
+                    "config.yaml."
+                ),
             },
             "max_depth": {
                 "type": "integer",

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -1870,19 +1870,24 @@ def _register_extends_tempdir(path: Path) -> None:
     workspace-load completion). Best-effort cleanup at exit is safer
     than relying on the OS to garbage-collect ``/tmp``.
     """
-    import atexit  # noqa: PLC0415
+    _EXTENDS_TEMPDIRS.append(path)
+
+
+_EXTENDS_TEMPDIRS: list[Path] = []
+
+
+def _cleanup_extends_tempdirs() -> None:
+    """Best-effort rmtree of every merged-extends tempdir at exit."""
     import shutil  # noqa: PLC0415
 
-    if not getattr(_register_extends_tempdir, "_registered", False):
-        _register_extends_tempdir._dirs = []  # type: ignore[attr-defined]
+    while _EXTENDS_TEMPDIRS:
+        d = _EXTENDS_TEMPDIRS.pop()
+        shutil.rmtree(d, ignore_errors=True)
 
-        def _cleanup() -> None:
-            for d in _register_extends_tempdir._dirs:  # type: ignore[attr-defined]
-                shutil.rmtree(d, ignore_errors=True)
 
-        atexit.register(_cleanup)
-        _register_extends_tempdir._registered = True  # type: ignore[attr-defined]
-    _register_extends_tempdir._dirs.append(path)  # type: ignore[attr-defined]
+import atexit as _atexit  # noqa: E402, PLC0415
+
+_atexit.register(_cleanup_extends_tempdirs)
 
 
 def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
@@ -1952,7 +1957,7 @@ def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
     merged_cfg = merged / WorkspaceLayout.CONFIG_YAML
     if merged_cfg.is_file():
         lines = merged_cfg.read_text(encoding="utf-8").splitlines()
-        kept = [ln for ln in lines if not (ln.startswith("extends:") or ln.startswith("extends: "))]
+        kept = [ln for ln in lines if not ln.startswith("extends:")]
         merged_cfg.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
     return merged
 
@@ -2107,6 +2112,23 @@ def _workspace_to_preset_inner(
                 timeout_s=yaml_payload.get("timeout_s"),
                 requires=list(yaml_payload.get("requires", []) or []),
             )
+            # Surface tool name ↔ directory name mismatches. The agent's
+            # system prompt and tool catalog use ``spec.name``, but
+            # users debug via the directory layout. A typo in
+            # ``name:`` silently registers the wrong tool name and
+            # makes the agent lose access to the tool. Warn (loose
+            # mode) or raise (strict mode) so the mismatch is caught
+            # at load time.
+            if spec.name != tool_dir.name:
+                msg = (
+                    f"tool name mismatch: directory is {tool_dir.name!r} but "
+                    f"tool.yaml declares name: {spec.name!r}. The registered "
+                    f"tool name will be {spec.name!r} (yaml wins). Rename "
+                    f"the directory or fix the yaml so they match."
+                )
+                if strict:
+                    raise WorkspaceSerializationError(msg)
+                logger.warning("%s", msg)
             # Surface ``requires:`` typos at load time. Without this,
             # a tool that declares ``requires: [my_resoruce]`` (typo)
             # silently receives ``ctx.resources["my_resoruce"] = None``

--- a/tests/test_scaffold_and_subagent_smoke.py
+++ b/tests/test_scaffold_and_subagent_smoke.py
@@ -261,8 +261,6 @@ def test_subagent_forwards_workspace_to_subloop_runtime(tmp_path: Path) -> None:
     # The factory normally injects ``workspace_config`` via ``requires``,
     # but a scaffold-only parent has no such resource — so we exercise
     # the documented ``ctx.metadata['runtime']`` fall-through path.
-    from looplet.types import ToolContext
-
     ctx = ToolContext(
         llm=mock,
         resources={},
@@ -274,3 +272,64 @@ def test_subagent_forwards_workspace_to_subloop_runtime(tmp_path: Path) -> None:
     assert seen == str(tmp_path), (
         f"sub-loop saw runtime['workspace']={seen!r}, expected {str(tmp_path)!r}"
     )
+
+
+def test_validate_workspace_warns_on_unfilled_scaffold(tmp_path: Path) -> None:
+    """A freshly scaffolded workspace must surface TODO + NotImplementedError
+    warnings so the agent doesn't ``done`` on an empty agent."""
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    # Pre-scaffold a child via the factory's setup.py.
+    workspace_to_preset(
+        str(factory),
+        runtime={
+            "workspace": str(tmp_path),
+            "scaffold_to": "auto.workspace",
+            "scaffold_tools": ["alpha"],
+        },
+    )
+    p = workspace_to_preset(str(factory), runtime={"workspace": str(tmp_path)})
+    from looplet.types import ToolCall as _TC
+
+    r = p.tools.dispatch(_TC(tool="validate_workspace", args={"workspace_path": "auto.workspace"}))
+    warnings = (r.data or {}).get("warnings", [])
+    assert any("TODO" in w for w in warnings), warnings
+    assert any("NotImplementedError" in w for w in warnings), warnings
+
+
+def test_loader_warns_on_tool_name_mismatch(tmp_path: Path, caplog) -> None:
+    p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["foo"])
+    # Edit tool.yaml to use a different name than the directory.
+    (p / "tools" / "foo" / "tool.yaml").write_text(
+        "name: BADNAME\ndescription: x\nparameters: {}\n"
+    )
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        workspace_to_preset(p)
+    assert any("tool name mismatch" in rec.message for rec in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+def test_loader_strict_raises_on_tool_name_mismatch(tmp_path: Path) -> None:
+    p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["foo"])
+    (p / "tools" / "foo" / "tool.yaml").write_text(
+        "name: BADNAME\ndescription: x\nparameters: {}\n"
+    )
+    with pytest.raises(WorkspaceSerializationError, match="tool name mismatch"):
+        workspace_to_preset(p, strict=True)
+
+
+def test_subagent_warns_on_cwd_fallback(tmp_path: Path) -> None:
+    parent = _make_parent_with_subagent(tmp_path)
+    child = tmp_path / "child.workspace"
+    scaffold_workspace(child, name="child", tools=[])
+    p = workspace_to_preset(parent)
+    spec = p.tools._tools["subagent"]
+    mock = MockLLMBackend(responses=[json.dumps({"tool": "done", "args": {"summary": "ok"}})])
+    # Empty resources + empty metadata -> cwd fallback fires.
+    ctx = ToolContext(llm=mock, resources={}, metadata={})
+    result = spec.execute(ctx, workspace=str(child), task="hi", max_steps=3)
+    assert "warning" in result, result
+    assert "defaulted to cwd" in result["warning"]


### PR DESCRIPTION
Second-pass review of #47 surfaced 10 more issues. None block functionality, but several are easy quality wins (silent stub validation, silent name mismatches) that catch real-world mistakes early.

## 🟡 Behavioral

1. **`validate_workspace` was silent on TODO-laden scaffolds.** A freshly-scaffolded workspace with all `<TODO:>` markers and `raise NotImplementedError("scaffold:")` stubs passed validation cleanly. Now scans for both and surfaces as warnings — agents can no longer `done` on an empty agent.

2. **`subagent` cwd-fallback was silent.** When neither `workspace_config` resource nor `ctx.metadata['runtime']` is present, the sub-loop's `runtime['workspace']` falls back to `Path.cwd()` — fine but surprising. Now surfaces a structured `warning` field with explicit recovery hints.

## 🟠 Wiring

3. **Tool name vs directory name mismatch was silent.** `tools/foo/` with `name: WRONG_NAME` registered as `'WRONG_NAME'` and the agent silently lost access to `foo`. Loader now warns in loose mode and raises `WorkspaceSerializationError` in strict mode.

## 🟠 Docs

4. **`subagent` module docstring** claimed *'shares parent's runtime'* — no longer true after #47 (runtime is constructed). Reworded.
5. **`builtin_tools/__init__.py` docstring** only listed `subagent`. Now documents both `subagent` and `scaffold_workspace`.

## 🟢 Code quality

6. Redundant `startswith` arm in extends-stripping — `'extends: '` is a strict subset of `'extends:'`. Simplified.
7. `_register_extends_tempdir` rewritten with module-level state + single `atexit.register` at import time. Cleaner and threadsafe (was using mutable function attributes).
8. `_is_absolute()` one-liner inlined.
9. Duplicate `from looplet.types import ToolContext` inside a test removed.
10. `subagent`'s `max_steps` sentinel switched from `0` to `None` — no more misleading `"default": 0` in the JSON schema.

## Tests
- 4 new tests covering: TODO/stub validation warnings, tool-name-mismatch (loose + strict modes), subagent cwd-fallback warning.
- Full suite **1653/1653 passing**, ruff clean.