### PR TITLE
fix: third-pass audit — TODO false positive, doc accuracy, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,32 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **`subagent` recursion depth via process-global env var
   (`LOOPLET_SUBAGENT_DEPTH`)** — two parallel parent loops in the
   same process raced. Replaced with a `ContextVar` (threadsafe and
-  per-async-task).
+  per-async-task). The sub-loop receives a freshly-constructed
+  `runtime` (it does NOT share the parent's `resources` /
+  `file_cache` instances — only the workspace path is forwarded).
+- **`validate_workspace` was silent on TODO-laden scaffolds.** Now
+  scans the system prompt for `<TODO:` markers and tool execute.py
+  files for `NotImplementedError("scaffold:` and surfaces both as
+  warnings — agents can no longer `done` on an unfilled skeleton. (#48)
+- **`subagent` cwd-fallback was silent.** When neither the parent's
+  `workspace_config` resource nor `ctx.metadata['runtime']` is
+  present, the sub-loop's `runtime['workspace']` falls back to
+  `Path.cwd()` AND the response now includes a structured
+  `warning` field with explicit recovery hints. (#48)
+- **Tool name vs directory name mismatches** (e.g. `tools/foo/`
+  whose `tool.yaml` declares `name: WRONG_NAME`) used to silently
+  register the wrong name and leave the agent unable to use `foo`.
+  The loader now warns in loose mode and raises
+  `WorkspaceSerializationError` in strict mode. (#48)
+- **Documentation cleanups (#48).** `subagent` module docstring no
+  longer claims to "share the parent's runtime" (it constructs a
+  fresh one). `builtin_tools/__init__.py` now lists both shipped
+  built-ins (`subagent`, `scaffold_workspace`).
+- **Internal cleanup (#48).** Removed redundant `extends:` line
+  check; rewrote tempdir registry as module-level state with single
+  `atexit.register`; inlined a one-line `_is_absolute` helper;
+  removed duplicate import; switched `subagent.max_steps` sentinel
+  from `0` to `None`.
 
 - **`examples/coder.workspace` per-tool guidance + safety.** Three
   information-additive improvements modelled on patterns observed in

--- a/examples/agent_factory.workspace/tools/validate_workspace/execute.py
+++ b/examples/agent_factory.workspace/tools/validate_workspace/execute.py
@@ -81,8 +81,10 @@ def execute(
     # ``<TODO: ...>`` markers in the system prompt and
     # ``raise NotImplementedError("scaffold: implement <name>")`` in
     # tool bodies; if either survives, the agent has not finished
-    # the work and should not declare done.
-    todo_in_prompt = "<TODO:" in sys_prompt or "TODO:" in sys_prompt[:600]
+    # the work and should not declare done. We only check for the
+    # exact scaffold marker (``<TODO:``) so legitimate prompts that
+    # mention "TODO:" comments don't trigger a false positive.
+    todo_in_prompt = "<TODO:" in sys_prompt
     scaffold_stubs: list[str] = []
     tools_dir = abs_path / "tools"
     if tools_dir.is_dir():
@@ -108,7 +110,9 @@ def execute(
             for warning in (
                 "system_prompt is empty — add prompts/system.md" if sys_prompt_chars == 0 else None,
                 "no `done` tool — every agent must have one" if "done" not in tools else None,
-                "system_prompt still has TODO markers — fill them in" if todo_in_prompt else None,
+                "system_prompt still has <TODO:> markers — fill them in"
+                if todo_in_prompt
+                else None,
                 (
                     f"tools still raise NotImplementedError (unfilled scaffolds): "
                     f"{', '.join(scaffold_stubs)}"

--- a/src/looplet/builtin_tools/subagent.py
+++ b/src/looplet/builtin_tools/subagent.py
@@ -76,14 +76,19 @@ def _execute(
             "max_depth": max_depth,
         }
 
+    # Resolve the host workspace path once. Both the path-resolution
+    # below (for relative ``workspace=`` args) and the runtime
+    # construction further down need it; doing the lookup here keeps
+    # the two consumers in sync and avoids a duplicated try/getattr
+    # dance.
+    cfg = ctx.resources.get("workspace_config") if ctx.resources else None
+    host_ws_str: str | None = getattr(cfg, "path", None) if cfg is not None else None
+
     # Resolve the target workspace path. Allow either absolute or
     # relative-to-the-host-workspace if a workspace_config resource is
     # available; otherwise relative to cwd.
     ws_path = Path(workspace)
-    host_ws_str: str | None = None
     if not ws_path.is_absolute():
-        cfg = ctx.resources.get("workspace_config") if ctx.resources else None
-        host_ws_str = getattr(cfg, "path", None) if cfg is not None else None
         if host_ws_str:
             ws_path = Path(host_ws_str) / workspace
         else:
@@ -103,9 +108,6 @@ def _execute(
     # (which read ``runtime['workspace']``) bind to the same project
     # root. Caller may override via ctx.metadata['runtime'] when they
     # want the sub-loop to operate on a different workspace.
-    if host_ws_str is None:
-        cfg = ctx.resources.get("workspace_config") if ctx.resources else None
-        host_ws_str = getattr(cfg, "path", None) if cfg is not None else None
     metadata_runtime = (ctx.metadata or {}).get("runtime") if ctx.metadata else None
     runtime: dict[str, Any] = dict(metadata_runtime) if metadata_runtime else {}
     fallback_used = False

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -1862,22 +1862,17 @@ def workspace_to_preset(
                 pass
 
 
-def _register_extends_tempdir(path: Path) -> None:
-    """Register a merged-extends tempdir for cleanup at interpreter exit.
-
-    The merged dir holds Python module caches that may still be bound
-    to its path until process end (so we can't ``shutil.rmtree`` on
-    workspace-load completion). Best-effort cleanup at exit is safer
-    than relying on the OS to garbage-collect ``/tmp``.
-    """
-    _EXTENDS_TEMPDIRS.append(path)
-
-
 _EXTENDS_TEMPDIRS: list[Path] = []
 
 
 def _cleanup_extends_tempdirs() -> None:
-    """Best-effort rmtree of every merged-extends tempdir at exit."""
+    """Best-effort rmtree of every merged-extends tempdir at exit.
+
+    Registered as an :mod:`atexit` hook at module import time so the
+    process leaves no per-load tempdirs behind. Cleared in LIFO order
+    (children before parents) which matches the order they were
+    materialized in :func:`_resolve_extends`.
+    """
     import shutil  # noqa: PLC0415
 
     while _EXTENDS_TEMPDIRS:
@@ -1909,9 +1904,10 @@ def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
     far; revisiting raises :class:`WorkspaceSerializationError`.
 
     The merged workspace dir is created via :func:`tempfile.mkdtemp`
-    with a stable prefix; it is NOT cleaned up automatically because
-    the loaded preset's modules may continue importing from it. The OS
-    handles cleanup on process exit (``/tmp`` is volatile).
+    with a stable prefix and tracked in :data:`_EXTENDS_TEMPDIRS`,
+    which means it survives until interpreter exit (the loaded preset's
+    modules may continue importing from it) and is then cleaned up
+    via the module-level ``atexit`` hook.
     """
     cfg_path = root / WorkspaceLayout.CONFIG_YAML
     if not cfg_path.is_file():
@@ -1946,7 +1942,7 @@ def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
     # Register for cleanup at interpreter exit so the OS doesn't have
     # to (the merged dir holds .pyc caches and may import modules that
     # are still bound to its path until process end).
-    _register_extends_tempdir(merged)
+    _EXTENDS_TEMPDIRS.append(merged)
     # Copy parent first, then overlay child.
     _shutil.copytree(parent_root, merged, dirs_exist_ok=True, symlinks=False)
     _shutil.copytree(root, merged, dirs_exist_ok=True, symlinks=False)

--- a/tests/test_scaffold_and_subagent_smoke.py
+++ b/tests/test_scaffold_and_subagent_smoke.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -297,14 +298,14 @@ def test_validate_workspace_warns_on_unfilled_scaffold(tmp_path: Path) -> None:
     assert any("NotImplementedError" in w for w in warnings), warnings
 
 
-def test_loader_warns_on_tool_name_mismatch(tmp_path: Path, caplog) -> None:
+def test_loader_warns_on_tool_name_mismatch(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["foo"])
     # Edit tool.yaml to use a different name than the directory.
     (p / "tools" / "foo" / "tool.yaml").write_text(
         "name: BADNAME\ndescription: x\nparameters: {}\n"
     )
-    import logging
-
     with caplog.at_level(logging.WARNING):
         workspace_to_preset(p)
     assert any("tool name mismatch" in rec.message for rec in caplog.records), [
@@ -333,3 +334,32 @@ def test_subagent_warns_on_cwd_fallback(tmp_path: Path) -> None:
     result = spec.execute(ctx, workspace=str(child), task="hi", max_steps=3)
     assert "warning" in result, result
     assert "defaulted to cwd" in result["warning"]
+
+
+def test_validate_workspace_no_false_positive_on_legitimate_todo_prose(tmp_path: Path) -> None:
+    """Agents whose mission legitimately mentions 'TODO:' (e.g. a code reviewer)
+    must NOT trigger the scaffold-leftover warning.
+
+    Regression for the over-loose detector that fired on any 'TODO:' in
+    the first 600 chars of the prompt.
+    """
+    p = scaffold_workspace(tmp_path / "x.workspace", name="x", tools=["a"])
+    # Replace the system prompt with a legitimate one that mentions TODO.
+    (p / "prompts" / "system.md").write_text(
+        "# Code Reviewer\n\nLook for TODO: comments in the code and "
+        "report them. Always finish with `done`.\n"
+    )
+    # Replace the tool stub with a real implementation so no NotImplementedError.
+    (p / "tools" / "a" / "execute.py").write_text(
+        "def execute(ctx, **kwargs):\n    return {'ok': True}\n"
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    factory = repo_root / "examples" / "agent_factory.workspace"
+    p_factory = workspace_to_preset(str(factory), runtime={"workspace": str(tmp_path)})
+    from looplet.types import ToolCall as _TC
+
+    r = p_factory.tools.dispatch(
+        _TC(tool="validate_workspace", args={"workspace_path": "x.workspace"})
+    )
+    warnings = (r.data or {}).get("warnings", [])
+    assert not any("TODO" in w for w in warnings), warnings


### PR DESCRIPTION
Third-pass review of master (post #44–#48) caught 8 issues. The first is a real false-positive in factory output validation; the rest are docs and minor cleanup.

## 🟡 Behavioral

1. **`validate_workspace` TODO detector fired on legitimate prose.** The check `'TODO:' in sys_prompt[:600]` matched any agent whose mission mentioned 'TODO:' — e.g. *'A code reviewer that looks for TODO: comments'* triggered a spurious 'fill in TODOs' warning. Tightened to only match the exact scaffolder marker `<TODO:`. Regression test added.

## 🟠 Docs

2. **CHANGELOG missing PR #48 entries.** Added entries for TODO/stub warnings, name mismatch detection, cwd-fallback warning, doc updates, and internal cleanup.
3. **CHANGELOG subagent entry now clarifies** that the sub-loop receives a freshly-constructed runtime — does NOT share parent's resources / file_cache.
4. **`_resolve_extends` docstring** still claimed *'OS handles cleanup on process exit'*. Updated to describe the actual `atexit`-based cleanup path landed in #47.

## 🟢 Cleanup

5. Hoisted `import logging` to the top of `tests/test_scaffold_and_subagent_smoke.py` (was importing it inside a test function).
6. Added `pytest.LogCaptureFixture` type annotation to `caplog` parameter.
7. Inlined the one-line `_register_extends_tempdir` helper into the call site. Cleanup `atexit` registration stays at module level.
8. Hoisted the `workspace_config` lookup in `subagent._execute` so path resolution and runtime construction share one resolved value (was looked up twice).

## Tests
- 1 new test (`test_validate_workspace_no_false_positive_on_legitimate_todo_prose`).
- Full suite **1654/1654 passing**, ruff clean.