### PR TITLE
feat(context_budget): three-layer context budget — fix tool-result data elision

### DIFF
--- a/src/looplet/context_budget.py
+++ b/src/looplet/context_budget.py
@@ -1,0 +1,167 @@
+"""Central, env-overridable tunables for context-budget management.
+
+Looplet's context pipeline has THREE nested budgets that mirror Claude
+Code's design:
+
+1. **Per-tool-result cap** — at dispatch time, ``truncate_tool_result``
+   caps any single tool's ``data`` to :data:`TOOL_RESULT_MAX_CHARS`.
+   Persist-and-preview kicks in when the result exceeds
+   :data:`TOOL_RESULT_PERSIST_THRESHOLD_CHARS` and a persist directory
+   is configured.
+
+2. **Per-context-window aggregate cap** — at LLM-prompt assembly time,
+   ``state.context_summary()`` shows the last
+   :data:`CONTEXT_WINDOW_STEPS` steps with each step's data inlined
+   (truncated to :data:`CONTEXT_INLINE_PER_STEP_CHARS` per step). When
+   the aggregate exceeds :data:`CONTEXT_WINDOW_TOTAL_CHARS`, the
+   largest entries get persist-previewed until the total fits.
+
+3. **Whole-conversation compact** — when the loop's reactive-compact
+   layer detects context pressure (handled by
+   :class:`looplet.compact.CompactService` and the ``ThresholdCompactHook``).
+   Tunables live in those modules; the only knob here is
+   :data:`COMPACT_TRIGGER_FRACTION` (used by ThresholdCompactHook).
+
+## Environment variable overrides
+
+Every threshold can be overridden at process start via env vars with
+the ``LOOPLET_`` prefix (e.g. ``LOOPLET_TOOL_RESULT_MAX_CHARS=12000``).
+This lets ops teams tune budgets per-deployment without code changes.
+The mapping is identity: ``TOOL_RESULT_MAX_CHARS`` →
+``LOOPLET_TOOL_RESULT_MAX_CHARS``.
+
+Modules that consume these constants should import them lazily
+(``from looplet.context_budget import TOOL_RESULT_MAX_CHARS``) so a
+test that monkeypatches the module sees the new value.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read ``LOOPLET_<name>`` from the environment as an int.
+
+    Returns ``default`` when the var is unset, empty, or unparseable —
+    we never crash a process over a malformed budget knob.
+    """
+    raw = os.environ.get(f"LOOPLET_{name}", "")
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read ``LOOPLET_<name>`` from the environment as a float.
+
+    Returns ``default`` when the var is unset, empty, or unparseable.
+    """
+    raw = os.environ.get(f"LOOPLET_{name}", "")
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+# ── Layer 1 — per-tool-result cap ─────────────────────────────────
+
+
+TOOL_RESULT_MAX_CHARS: int = _env_int("TOOL_RESULT_MAX_CHARS", 6000)
+"""Max characters of any single tool result before in-result truncation kicks in.
+
+The dispatcher calls :func:`looplet.scaffolding.truncate_tool_result`
+on every result; that function applies this cap. Choose lower values
+(2-4K) to keep the LLM context tight; higher values (12-50K, mirroring
+Claude Code's 50K) when tool results are the agent's primary signal.
+"""
+
+
+TOOL_RESULT_MAX_ROWS: int = _env_int("TOOL_RESULT_MAX_ROWS", 50)
+"""Max rows in a list-typed tool result before list truncation kicks in.
+
+Applied when ``data`` is a ``list``. Beyond this row count, the result
+is wrapped in ``{rows: [...], total: N, note: "..."}``.
+"""
+
+
+TOOL_RESULT_PERSIST_THRESHOLD_CHARS: int = _env_int("TOOL_RESULT_PERSIST_THRESHOLD_CHARS", 50_000)
+"""Above this size, a tool result is persisted to disk + replaced with
+preview.
+
+Mirrors Claude Code's ``DEFAULT_MAX_RESULT_SIZE_CHARS = 50_000``.
+The dispatcher writes the full result to ``persist_dir/tool-output-<hash>.txt``
+and the model sees only a preview + the file path so it can read more
+on demand. Requires ``persist_dir`` to be set on the
+:func:`looplet.scaffolding.truncate_tool_result` call.
+"""
+
+
+TOOL_RESULT_PREVIEW_CHARS: int = _env_int("TOOL_RESULT_PREVIEW_CHARS", 2000)
+"""Length of the inline preview shown when a tool result is persisted.
+
+The model gets the first ``TOOL_RESULT_PREVIEW_CHARS`` characters of the
+serialized result, plus the persist-path. Mirrors Claude Code's
+``PREVIEW_SIZE_BYTES = 2000``.
+"""
+
+
+# ── Layer 2 — per-context-window aggregate cap ───────────────────
+
+
+CONTEXT_WINDOW_STEPS: int = _env_int("CONTEXT_WINDOW_STEPS", 5)
+"""How many recent steps to inline in ``state.context_summary()``.
+
+Older steps roll out of the window and are visible only via compact
+summaries (Layer 3). This is the sliding window before per-step caps.
+"""
+
+
+CONTEXT_INLINE_PER_STEP_CHARS: int = _env_int("CONTEXT_INLINE_PER_STEP_CHARS", 3000)
+"""Per-step soft cap when serializing tool results into the context window.
+
+Each step's result is JSON-serialized; if the serialization exceeds
+this cap, it gets per-step truncation with a "[truncated; full result
+N chars]" tail. Independent of Layer 1 — Layer 1 caps at dispatch
+time, this layer caps at prompt-assembly time.
+"""
+
+
+CONTEXT_WINDOW_TOTAL_CHARS: int = _env_int("CONTEXT_WINDOW_TOTAL_CHARS", 20_000)
+"""Aggregate cap across all inlined steps in one prompt.
+
+When the assembled context_summary exceeds this, the largest steps in
+the window are truncated to free budget until the total fits. Mirrors
+Claude Code's ``MAX_TOOL_RESULTS_PER_MESSAGE_CHARS = 200_000``,
+scaled down for typical looplet workloads.
+"""
+
+
+# ── Layer 3 — whole-conversation compact ──────────────────────────
+
+
+COMPACT_TRIGGER_FRACTION: float = _env_float("COMPACT_TRIGGER_FRACTION", 0.75)
+"""Fraction of model context window at which ``ThresholdCompactHook``
+proactively triggers compaction.
+
+When the loop's running token count exceeds this fraction of the
+configured model context window, the hook calls the configured
+``compact_service`` to summarize older history. Default 0.75.
+"""
+
+
+__all__ = [
+    "COMPACT_TRIGGER_FRACTION",
+    "CONTEXT_INLINE_PER_STEP_CHARS",
+    "CONTEXT_WINDOW_STEPS",
+    "CONTEXT_WINDOW_TOTAL_CHARS",
+    "TOOL_RESULT_MAX_CHARS",
+    "TOOL_RESULT_MAX_ROWS",
+    "TOOL_RESULT_PERSIST_THRESHOLD_CHARS",
+    "TOOL_RESULT_PREVIEW_CHARS",
+]

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -47,6 +47,19 @@ from looplet.tools import BaseToolRegistry, _summarize_args_dict
 from looplet.types import AgentState, Step, ToolCall, ToolContext, ToolResult
 from looplet.validation import validate_args as _validate_args
 
+
+def _get_persist_threshold() -> int:
+    """Read ``TOOL_RESULT_PERSIST_THRESHOLD_CHARS`` lazily.
+
+    Lazy lookup so tests / runtime tuning that overwrites the
+    constant on the :mod:`looplet.context_budget` module after import
+    sees the new value (the dispatcher reads it on every tool call).
+    """
+    from looplet.context_budget import TOOL_RESULT_PERSIST_THRESHOLD_CHARS  # noqa: PLC0415
+
+    return TOOL_RESULT_PERSIST_THRESHOLD_CHARS
+
+
 if TYPE_CHECKING:
     from looplet.cache import CachePolicy
     from looplet.checkpoint import Checkpoint
@@ -380,6 +393,19 @@ class LoopConfig:
     recovery_temperature: float = 0.1
     # Name of the tool that signals task completion.
     done_tool: str = "done"
+
+    tool_result_persist_dir: str | None = None
+    """Optional directory for Layer-1 persist-and-preview of large
+    tool results. When set, tool results whose serialized size exceeds
+    :data:`looplet.context_budget.TOOL_RESULT_PERSIST_THRESHOLD_CHARS`
+    are written to ``<persist_dir>/tool-output-<hash>.txt`` and the
+    LLM-facing result is replaced with a preview + the file path. The
+    model can then read more on demand via its own file-reading tools.
+
+    Mirrors Claude Code's per-session ``tool-results/`` directory.
+    When ``None`` (default) only inline truncation applies — the full
+    output simply gets capped at ``TOOL_RESULT_MAX_CHARS``.
+    """
 
     max_turn_continuations: int = 0
     """When > 0, ``llm_call_with_retry`` will issue up to this many
@@ -1997,7 +2023,11 @@ def composable_loop(
                 if not (tool_spec and tool_spec.free) and not was_intercepted:
                     state.queries_used += 1
 
-                tool_result.data = truncate_tool_result(tool_result.data)
+                tool_result.data = truncate_tool_result(
+                    tool_result.data,
+                    persist_dir=config.tool_result_persist_dir,
+                    persist_threshold=_get_persist_threshold(),
+                )
 
                 # Emit ToolDispatchEvent
                 if stream is not None and _ToolDispatchEvent is not None:

--- a/src/looplet/scaffolding.py
+++ b/src/looplet/scaffolding.py
@@ -28,8 +28,15 @@ logger = logging.getLogger(__name__)
 MAX_LLM_RETRIES = 2
 RETRY_BACKOFF_BASE = 1.0  # seconds
 PARSE_RECOVERY_MAX = 2  # max consecutive parse recovery attempts
-TOOL_RESULT_MAX_CHARS = 6000  # truncate tool result data
-TOOL_RESULT_MAX_ROWS = 50  # max rows per result
+# Re-export from the central context_budget module so single-source-of-truth
+# tunables live in one place and can be overridden via LOOPLET_* env vars.
+# Modules that have historically imported these names from scaffolding still
+# work; the values come from looplet.context_budget at module-import time.
+from looplet.context_budget import (  # noqa: E402, PLC0415
+    TOOL_RESULT_MAX_CHARS,
+    TOOL_RESULT_MAX_ROWS,
+)
+
 DIMINISHING_RETURNS_WINDOW = 5  # steps to track
 DIMINISHING_RETURNS_THRESHOLD = 0  # new items in window to be "diminishing"
 

--- a/src/looplet/types.py
+++ b/src/looplet/types.py
@@ -420,12 +420,99 @@ class DefaultState:
         return max(0, self.max_steps - len(self.steps))
 
     def context_summary(self) -> str:
+        """Render recent step results into the LLM's context.
+
+        Mirrors Claude Code's tool-result-block pattern: the model
+        sees the **actual data** that previous tools returned, not a
+        digest. This eliminates the fabrication failure mode where
+        the model invents plausible content for a chained tool's
+        argument because the previous step's data was elided.
+
+        Three nested budgets (centralised in
+        :mod:`looplet.context_budget`):
+
+        * ``CONTEXT_WINDOW_STEPS`` — sliding window of recent steps
+          (older are out of scope for this layer; the compact layer
+          handles them).
+        * ``CONTEXT_INLINE_PER_STEP_CHARS`` — per-step soft cap;
+          longer steps get a "[truncated; full result N chars]" tail.
+        * ``CONTEXT_WINDOW_TOTAL_CHARS`` — aggregate cap across the
+          whole window. When exceeded, the largest step contributions
+          are progressively truncated until the total fits.
+        """
         if not self.steps:
             return ""
-        lines = []
-        for step in self.steps[-5:]:
-            lines.append(step.summary() if hasattr(step, "summary") else str(step))
-        return "\n".join(lines)
+
+        # Lazy import keeps the module-import order stable and lets
+        # tests monkeypatch budgets without re-importing types.
+        import json as _json  # noqa: PLC0415
+
+        from looplet.context_budget import (  # noqa: PLC0415
+            CONTEXT_INLINE_PER_STEP_CHARS,
+            CONTEXT_WINDOW_STEPS,
+            CONTEXT_WINDOW_TOTAL_CHARS,
+        )
+
+        # Pass 1: render each step in the window with per-step cap.
+        # The first tuple element is just an ordering tag (we don't use
+        # it for anything but stable iteration) so ``int`` covers both
+        # the real step number and the ``id(step)`` fallback.
+        rendered: list[tuple[int, str]] = []
+        for step in self.steps[-CONTEXT_WINDOW_STEPS:]:
+            tr = getattr(step, "tool_result", None)
+            if tr is None:
+                rendered.append((id(step), str(step)))
+                continue
+            tool_name = getattr(tr, "tool", "?")
+            args_summary = getattr(tr, "args_summary", "") or ""
+            err = getattr(tr, "error", None)
+            data = getattr(tr, "data", None)
+            raw_number = getattr(step, "number", None)
+            number_int = int(raw_number) if isinstance(raw_number, int) else len(rendered) + 1
+            number_label = str(raw_number) if raw_number is not None else str(number_int)
+            if err:
+                block = f"S{number_label} ✗ {tool_name}({args_summary}) → ERROR: {err[:200]}"
+            else:
+                # Show the actual data so the model can reference it
+                # verbatim on the next turn (e.g. pipe ``commits`` from
+                # ``fetch_commits`` into ``group_by_type``). Pre-truncated
+                # at dispatch time by ``truncate_tool_result``; this layer
+                # caps the *serialized* form for prompt assembly.
+                payload = _json.dumps(data, default=str, ensure_ascii=False)
+                if len(payload) > CONTEXT_INLINE_PER_STEP_CHARS:
+                    keep = CONTEXT_INLINE_PER_STEP_CHARS
+                    payload = (
+                        payload[:keep] + f"\n... [truncated; full result {len(payload)} chars]"
+                    )
+                block = f"S{number_label} ✓ {tool_name}({args_summary}) → {payload}"
+            rendered.append((number_int, block))
+
+        # Pass 2: enforce aggregate cap. When the total exceeds budget,
+        # progressively shrink the LARGEST entries (not the most recent)
+        # so the most recent step retains as much detail as possible.
+        # We use a two-pointer / repeated-shrink loop because greedy
+        # one-shot truncation can over-cut a single block when many
+        # blocks are large.
+        def _total(blocks: list[tuple[int, str]]) -> int:
+            return sum(len(b) for _, b in blocks) + (len(blocks) - 1) * 2  # "\n\n" joins
+
+        while _total(rendered) > CONTEXT_WINDOW_TOTAL_CHARS:
+            # Find the largest block index.
+            largest_idx = max(range(len(rendered)), key=lambda i: len(rendered[i][1]))
+            num, block = rendered[largest_idx]
+            # If we can still meaningfully shrink it, halve it; otherwise drop oldest.
+            if len(block) > 200:
+                shrunk_to = max(200, len(block) // 2)
+                rendered[largest_idx] = (
+                    num,
+                    block[:shrunk_to] + f"\n... [aggregate-cap truncated; was {len(block)} chars]",
+                )
+            else:
+                # Every block is already minimal; drop the oldest until under cap.
+                rendered.pop(0)
+                if not rendered:
+                    break
+        return "\n\n".join(b for _, b in rendered)
 
     def snapshot(self) -> dict[str, Any]:
         return {

--- a/tests/test_context_budget_smoke.py
+++ b/tests/test_context_budget_smoke.py
@@ -1,0 +1,198 @@
+"""Smoke tests for the three-layer context budget system.
+
+Layer 1 — per-tool-result cap (``TOOL_RESULT_MAX_CHARS``,
+``TOOL_RESULT_PERSIST_THRESHOLD_CHARS``).
+Layer 2 — per-context-window aggregate cap
+(``CONTEXT_WINDOW_STEPS``, ``CONTEXT_INLINE_PER_STEP_CHARS``,
+``CONTEXT_WINDOW_TOTAL_CHARS``).
+Layer 3 — whole-conversation compact (existing
+:class:`looplet.compact.CompactService`; not exercised here, only
+the tunable's existence is asserted).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from looplet import context_budget
+from looplet.types import DefaultState, Step, ToolCall, ToolResult
+
+
+def _make_step(number: int, tool: str, data: Any) -> Step:
+    return Step(
+        number=number,
+        tool_call=ToolCall(tool=tool, args={}),
+        tool_result=ToolResult(tool=tool, args_summary="", data=data),
+    )
+
+
+# ── Layer 2: context_summary inlines actual data ────────────────
+
+
+def test_context_summary_inlines_full_data() -> None:
+    """The model must SEE the data, not a digest. Regression for the
+    fabrication bug where ``commits: (5)`` left the LLM no choice but
+    to invent commit shas on the next turn."""
+    state = DefaultState()
+    commits = [
+        {"sha": "7321837", "message": "fix: third-pass audit"},
+        {"sha": "7851476", "message": "fix: 10 second-pass audit findings"},
+    ]
+    state.steps.append(_make_step(1, "fetch_commits", {"commits": commits}))
+    summary = state.context_summary()
+    # The actual sha values must appear in the LLM-facing string.
+    assert "7321837" in summary
+    assert "7851476" in summary
+    # Tool name and step number too.
+    assert "fetch_commits" in summary
+    assert "S1" in summary
+
+
+def test_context_summary_per_step_cap_truncates_with_marker() -> None:
+    """A single huge step gets truncated with a clear marker."""
+    state = DefaultState()
+    big = "x" * 10_000  # bigger than default CONTEXT_INLINE_PER_STEP_CHARS=3000
+    state.steps.append(_make_step(1, "fetch", {"blob": big}))
+    summary = state.context_summary()
+    assert "[truncated; full result" in summary
+    # Per-step cap is 3000 chars by default; resulting block ~3000+marker.
+    assert len(summary) < 4000
+
+
+def test_context_summary_window_steps_limits_recent() -> None:
+    """Only the last ``CONTEXT_WINDOW_STEPS`` steps appear; older are
+    out of scope (Layer 3 / compact handles them)."""
+    state = DefaultState()
+    for i in range(1, 11):  # 10 steps, names 'tool_a'..'tool_j'
+        state.steps.append(_make_step(i, f"tool_{chr(96 + i)}", {"v": i}))
+    summary = state.context_summary()
+    # Default window = 5; steps 6..10 (tool_f..tool_j) appear, 1..5 (tool_a..tool_e) do not.
+    assert "tool_j" in summary  # step 10
+    assert "tool_f" in summary  # step 6
+    assert "tool_e" not in summary  # step 5 is out of window
+    assert "tool_a" not in summary  # step 1 is out of window
+
+
+def test_context_summary_aggregate_cap_shrinks_largest() -> None:
+    """When aggregate exceeds budget, the largest contributor shrinks."""
+    state = DefaultState()
+    # Five steps; one is far larger than the others.
+    for i in range(1, 5):
+        state.steps.append(_make_step(i, f"small_{i}", {"v": i}))
+    state.steps.append(_make_step(5, "huge_tool", {"blob": "Y" * 20_000}))
+
+    # Tighten the aggregate cap so the test exercises shrinking.
+    with patch.object(context_budget, "CONTEXT_WINDOW_TOTAL_CHARS", 5000):
+        summary = state.context_summary()
+    assert len(summary) <= 6000  # cap + small overhead
+    # Most-recent step is the huge one; it must remain visible (truncated).
+    assert "huge_tool" in summary
+    # Small steps are visible, full.
+    assert "small_4" in summary
+
+
+def test_context_summary_error_block_format() -> None:
+    state = DefaultState()
+    state.steps.append(
+        Step(
+            number=1,
+            tool_call=ToolCall(tool="x", args={}),
+            tool_result=ToolResult(tool="x", args_summary="", data=None, error="boom"),
+        )
+    )
+    summary = state.context_summary()
+    assert "✗" in summary
+    assert "boom" in summary
+
+
+def test_context_summary_empty_state() -> None:
+    state = DefaultState()
+    assert state.context_summary() == ""
+
+
+# ── env override ────────────────────────────────────────────────
+
+
+def test_env_override_tool_result_max_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``LOOPLET_TOOL_RESULT_MAX_CHARS`` overrides the default."""
+    monkeypatch.setenv("LOOPLET_TOOL_RESULT_MAX_CHARS", "12345")
+    # Re-import to pick up new env value.
+    importlib.reload(context_budget)
+    try:
+        assert context_budget.TOOL_RESULT_MAX_CHARS == 12345
+    finally:
+        monkeypatch.delenv("LOOPLET_TOOL_RESULT_MAX_CHARS", raising=False)
+        importlib.reload(context_budget)
+
+
+def test_env_override_unparseable_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A garbage env value must NOT crash the process; we fall back to
+    the hardcoded default."""
+    monkeypatch.setenv("LOOPLET_TOOL_RESULT_MAX_CHARS", "not-a-number")
+    importlib.reload(context_budget)
+    try:
+        assert context_budget.TOOL_RESULT_MAX_CHARS == 6000  # the default
+    finally:
+        monkeypatch.delenv("LOOPLET_TOOL_RESULT_MAX_CHARS", raising=False)
+        importlib.reload(context_budget)
+
+
+def test_env_override_compact_trigger_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOOPLET_COMPACT_TRIGGER_FRACTION", "0.85")
+    importlib.reload(context_budget)
+    try:
+        assert context_budget.COMPACT_TRIGGER_FRACTION == 0.85
+    finally:
+        monkeypatch.delenv("LOOPLET_COMPACT_TRIGGER_FRACTION", raising=False)
+        importlib.reload(context_budget)
+
+
+# ── Layer 1: persist-and-preview is wired through LoopConfig ────
+
+
+def test_loopconfig_has_tool_result_persist_dir() -> None:
+    """``LoopConfig`` exposes a knob for the persist directory."""
+    from looplet.loop import LoopConfig
+
+    cfg = LoopConfig()
+    assert cfg.tool_result_persist_dir is None
+    cfg2 = LoopConfig(tool_result_persist_dir="/tmp/looplet-tool-results")
+    assert cfg2.tool_result_persist_dir == "/tmp/looplet-tool-results"
+
+
+def test_truncate_tool_result_persists_when_threshold_exceeded(tmp_path: Path) -> None:
+    """When the result is huge AND persist_dir is set, full output goes
+    to disk and the model sees a preview + the path."""
+    from looplet.scaffolding import truncate_tool_result
+
+    big = "Z" * 60_000
+    result = truncate_tool_result(
+        {"big_string": big},
+        persist_dir=str(tmp_path),
+        persist_threshold=50_000,
+    )
+    assert isinstance(result, dict)
+    assert "persisted_output_path" in result
+    assert "truncated_output" in result
+    persisted = Path(result["persisted_output_path"])
+    assert persisted.exists()
+    # Full content is on disk.
+    assert big in persisted.read_text()
+
+
+def test_truncate_tool_result_no_persist_when_dir_unset() -> None:
+    """Without persist_dir, only inline truncation applies."""
+    from looplet.scaffolding import truncate_tool_result
+
+    big = {"k": "Y" * 60_000}
+    result = truncate_tool_result(big)
+    # No persistence keys.
+    assert "persisted_output_path" not in (result or {})


### PR DESCRIPTION
Mirrors Claude Code's tool-result architecture so the LLM **sees the data** its tools returned instead of receiving a digest like `commits: (5)` that forces it to fabricate plausible content on the next turn.

## The bug this fixes

Dogfood traces consistently showed the same fault on multi-step pipelines:
```
Step 1: fetch_commits → 5 real commits with shas 7321837, 7851476, …
Step 2: group_by_type(commits=[a1b2c3d, e4f5g6h, …])  ← FABRICATED
Step 3: format_notes(groups={feat: [a1b2c3d…]})         ← uses fake data
Step 4: done("Generated v2.0.0 release notes")          ← lies
```

Root cause: `state.context_summary()` called `step.summary()` which showed only `{key: (N)}` for list/dict values. The actual content never reached the LLM — so it had no choice but to invent.

## Design — three nested budgets

Centralised in **`looplet.context_budget`**, every tunable overridable at process start via `LOOPLET_<NAME>` env vars:

```bash
LOOPLET_TOOL_RESULT_MAX_CHARS=12000  LOOPLET_CONTEXT_WINDOW_STEPS=8 \
    uv run python my_app.py
```

### Layer 1 — per-tool-result cap (existing, now wired)
| Knob | Default | Purpose |
|---|---|---|
| `TOOL_RESULT_MAX_CHARS` | 6000 | Inline cap at dispatch time |
| `TOOL_RESULT_MAX_ROWS` | 50 | List rows before list-truncation |
| `TOOL_RESULT_PERSIST_THRESHOLD_CHARS` | 50 000 | Above this → write to disk + preview |
| `TOOL_RESULT_PREVIEW_CHARS` | 2000 | Inline preview length when persisted |

`LoopConfig` now exposes `tool_result_persist_dir`: when set, results exceeding the persist threshold are written to disk and the LLM sees a 2K preview + the file path (mirrors Claude Code's per-session `tool-results/` directory).

### Layer 2 — per-context-window aggregate cap (NEW)
| Knob | Default | Purpose |
|---|---|---|
| `CONTEXT_WINDOW_STEPS` | 5 | Last N steps inlined |
| `CONTEXT_INLINE_PER_STEP_CHARS` | 3000 | Per-step soft cap |
| `CONTEXT_WINDOW_TOTAL_CHARS` | 20 000 | Aggregate cap |

`DefaultState.context_summary()` rewritten to serialize each step's data inline. Per-step truncation kicks in if a single step exceeds its soft cap; aggregate cap kicks in if the assembled window exceeds the total — largest entries shrink first so the **most recent step keeps as much detail as possible**.

### Layer 3 — whole-conversation compact (existing, knob centralised)
| Knob | Default | Purpose |
|---|---|---|
| `COMPACT_TRIGGER_FRACTION` | 0.75 | Fraction of model context window before `ThresholdCompactHook` triggers |

## Tests
- 12 new smoke tests covering: data inlining, per-step truncation, window-size limit, aggregate cap shrinking, error block format, empty state, env-var overrides (valid + unparseable fallback), `LoopConfig.tool_result_persist_dir` wiring, persist-and-preview end-to-end.
- Full suite **1666/1666 passing**, ruff clean, pyright clean.

## Dogfood

Could not run live dogfood (Copilot proxy was down at commit time). Code is solid and unit-tested. **Strong prediction:** `git_release_notes` and `recipe_finder` jump from D-grade to A-grade once dogfooded because the model can now copy real data verbatim instead of inventing it.

Run after merge:
```bash
rm -rf scratch/factory_artifacts && \
COPILOT_MODEL=claude-sonnet-4.6 uv run python scratch/dogfood_quality_5agents.py
```