### PR TITLE
feat(cli): `looplet new` + `looplet run-workspace` — single-command agent generation

### DIFF
--- a/src/looplet/__main__.py
+++ b/src/looplet/__main__.py
@@ -766,6 +766,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Arguments forwarded to looplet.evals.eval_cli",
     )
 
+    # ── factory subcommands (``new``, ``run-workspace``) ──
+    # Lives in a dedicated module so the two factory-facing commands
+    # can evolve independently of the bundle / trace / eval CLI.
+    from looplet.cli.factory_commands import add_subparsers as _add_factory  # noqa: PLC0415
+
+    _add_factory(sub)
+
     args = parser.parse_args(argv)
 
     if args.command == "show":
@@ -821,6 +828,13 @@ def main(argv: list[str] | None = None) -> int:
         from looplet.evals import eval_cli  # noqa: PLC0415
 
         return eval_cli(args.eval_args)
+    # Factory subcommands (``new``, ``run-workspace``) attach their
+    # handler via ``set_defaults(_handler=...)`` so we dispatch
+    # generically here. Keeps ``__main__`` from growing per-command
+    # branches as more factory commands land.
+    handler = getattr(args, "_handler", None)
+    if handler is not None:
+        return int(handler(args))
     # Unreachable — argparse rejects unknown commands.
     return 2
 

--- a/src/looplet/cli/__init__.py
+++ b/src/looplet/cli/__init__.py
@@ -1,0 +1,8 @@
+"""looplet CLI subcommand modules.
+
+Each module here exposes an ``add_subparsers(sub)`` function that
+registers one or more subcommands on the top-level argparse parser
+in :mod:`looplet.__main__`.
+"""
+
+from __future__ import annotations

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -1,0 +1,401 @@
+"""``looplet new`` and ``looplet run-workspace`` CLI implementation.
+
+These two commands are the user-facing entry points to the agent
+factory. The vision is: a developer with one hour to spare can pip
+install looplet, write one paragraph describing the agent they want,
+run a single command, and have a working agent that operates on
+their input.
+
+## ``looplet new <description>``
+
+Runs the bundled :mod:`agent_factory.workspace` against a brief and
+writes the produced workspace to a directory. After this completes,
+``./<name>.workspace/`` contains a fully-loaded looplet workspace.
+
+Required env vars (any OpenAI-compatible endpoint):
+
+* ``OPENAI_BASE_URL`` — e.g. ``http://127.0.0.1:19823/v1`` for a
+  local proxy or ``https://api.openai.com/v1`` for direct OpenAI.
+* ``OPENAI_API_KEY`` — your key (or any string for proxies that
+  don't validate it).
+* ``OPENAI_MODEL`` — model id, e.g. ``gpt-4o-mini`` or
+  ``claude-sonnet-4.6``.
+
+## ``looplet run-workspace <path> <task>``
+
+Runs an existing workspace on a task and prints the final result.
+Same env vars as above. This is the "watch the agent work" command
+once ``looplet new`` has produced a workspace.
+
+## Why split into two modules?
+
+``__main__.py`` already has ten subcommands. This module isolates the
+two factory-facing ones so they can evolve independently of the
+bundle / trace / eval CLI machinery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _bold(s: str) -> str:
+    return f"\033[1m{s}\033[0m" if sys.stdout.isatty() else s
+
+
+def _green(s: str) -> str:
+    return f"\033[32m{s}\033[0m" if sys.stdout.isatty() else s
+
+
+def _dim(s: str) -> str:
+    return f"\033[2m{s}\033[0m" if sys.stdout.isatty() else s
+
+
+def _red(s: str) -> str:
+    return f"\033[31m{s}\033[0m" if sys.stdout.isatty() else s
+
+
+def _check_env() -> int:
+    """Verify required env vars are set. Returns 0 on success."""
+    missing: list[str] = []
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_MODEL"):
+        if not os.environ.get(var):
+            missing.append(var)
+    if missing:
+        print(
+            _red(f"error: missing required env vars: {', '.join(missing)}"),
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print("Set them to point at any OpenAI-compatible endpoint:", file=sys.stderr)
+        print(
+            _dim('    export OPENAI_BASE_URL="http://127.0.0.1:19823/v1"'),
+            file=sys.stderr,
+        )
+        print(_dim('    export OPENAI_API_KEY="sk-..."'), file=sys.stderr)
+        print(_dim('    export OPENAI_MODEL="gpt-4o-mini"'), file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            _dim("Run ``looplet doctor`` to verify connectivity."),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def _build_backend():
+    """Construct an OpenAIBackend from env vars."""
+    from looplet.backends import OpenAIBackend  # noqa: PLC0415
+
+    return OpenAIBackend(
+        base_url=os.environ["OPENAI_BASE_URL"],
+        api_key=os.environ["OPENAI_API_KEY"],
+        model=os.environ["OPENAI_MODEL"],
+    )
+
+
+def _factory_workspace_path() -> Path:
+    """Locate the bundled ``examples/agent_factory.workspace`` directory.
+
+    Looplet ships with this workspace in the repo's ``examples/``
+    folder. When installed via ``pip install``, the examples may not
+    be co-packaged; in that case we fall back to ``LOOPLET_FACTORY_DIR``
+    or print a clear error.
+    """
+    # Walk up from this file looking for examples/agent_factory.workspace.
+    here = Path(__file__).resolve()
+    for parent in [here.parent, *here.parents]:
+        candidate = parent / "examples" / "agent_factory.workspace"
+        if candidate.is_dir():
+            return candidate
+    env_override = os.environ.get("LOOPLET_FACTORY_DIR")
+    if env_override and Path(env_override).is_dir():
+        return Path(env_override)
+    raise FileNotFoundError(
+        "Could not locate examples/agent_factory.workspace. "
+        "Set LOOPLET_FACTORY_DIR to point at it, or run from the looplet repo."
+    )
+
+
+# ── ``looplet new`` ─────────────────────────────────────────────
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    if _check_env() != 0:
+        return 1
+
+    description: str = args.description
+    target_dir: Path = args.target.resolve()
+    name: str = args.name or target_dir.name.replace(".workspace", "").replace("-", "_")
+    tools: list[str] = args.tool or []
+
+    print(f"{_bold('looplet new')} → {target_dir}")
+    print(_dim(f"  brief:  {description[:80]}{'…' if len(description) > 80 else ''}"))
+    print(_dim(f"  name:   {name}"))
+    if tools:
+        print(_dim(f"  tools:  {', '.join(tools)} (pre-scaffolded)"))
+    print(_dim(f"  model:  {os.environ['OPENAI_MODEL']}"))
+    print()
+
+    try:
+        from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
+        from looplet.types import DefaultState  # noqa: PLC0415
+
+        factory = _factory_workspace_path()
+    except Exception as exc:
+        print(_red(f"error: {exc}"), file=sys.stderr)
+        return 1
+
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    # The factory's setup.py honours scaffold_to + scaffold_tools at
+    # load time. When the user passed --tool flags, pre-scaffold the
+    # skeleton so the agent skips the boilerplate; otherwise the agent
+    # picks the tool list itself from the brief.
+    runtime: dict = {"workspace": str(target_dir.parent)}
+    if tools:
+        runtime["scaffold_to"] = target_dir.name
+        runtime["scaffold_name"] = name
+        runtime["scaffold_tools"] = tools
+
+    try:
+        backend = _build_backend()
+        preset = workspace_to_preset(str(factory), runtime=runtime)
+    except Exception as exc:
+        print(_red(f"error: factory load failed: {exc}"), file=sys.stderr)
+        return 1
+
+    state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
+    brief_for_factory = description
+    if not tools:
+        brief_for_factory = (
+            f"Build a workspace at ./{target_dir.name}/ for the following agent:\n\n"
+            f"{description}\n\n"
+            f"Workspace name should be: {name}"
+        )
+
+    t0 = time.time()
+    n_steps = 0
+    n_denies = 0
+    last_done_summary: str | None = None
+    try:
+        for step in composable_loop(
+            llm=backend,
+            config=preset.config,
+            tools=preset.tools,
+            state=state,
+            hooks=preset.hooks,
+            task={"goal": brief_for_factory},
+        ):
+            n_steps += 1
+            tool_call = step.tool_call
+            tool_result = step.tool_result
+            if tool_call is None:
+                continue
+            err = (tool_result and tool_result.error) or (
+                tool_result.data.get("error") if tool_result and tool_result.data else None
+            )
+            if err:
+                n_denies += 1
+            if not args.quiet:
+                tag = _red("✗") if err else _green("✓")
+                short = json.dumps(tool_call.args, default=str)[:80]
+                print(f"  {tag} step {n_steps:>2}: {tool_call.tool}({short})")
+            if (
+                tool_call.tool == "done"
+                and tool_result
+                and tool_result.data
+                and "summary" in tool_result.data
+            ):
+                last_done_summary = str(tool_result.data["summary"])
+    except KeyboardInterrupt:
+        print(_red("\ninterrupted"), file=sys.stderr)
+        return 130
+    except Exception as exc:
+        print(_red(f"error during build: {type(exc).__name__}: {exc}"), file=sys.stderr)
+        return 1
+
+    elapsed = time.time() - t0
+    print()
+    print(f"{_green('✓')} built in {elapsed:.1f}s — {n_steps} steps, {n_denies} denies")
+
+    # Verify the workspace actually loads.
+    if not target_dir.is_dir():
+        print(_red(f"\nerror: workspace not created at {target_dir}"), file=sys.stderr)
+        return 1
+    try:
+        sub_preset = workspace_to_preset(str(target_dir))
+        produced_tools = sorted(sub_preset.tools._tools.keys())
+        n_tools = len(produced_tools)
+        sys_prompt_chars = len(sub_preset.config.system_prompt or "")
+    except Exception as exc:
+        print(
+            _red(f"\nerror: produced workspace failed to load: {exc}"),
+            file=sys.stderr,
+        )
+        return 1
+
+    print()
+    print(f"{_bold('produced workspace:')} {target_dir}")
+    print(f"  tools:  {', '.join(produced_tools)}  ({n_tools})")
+    print(f"  prompt: {sys_prompt_chars} chars")
+    if last_done_summary:
+        print(f"  agent says: {last_done_summary[:120]}")
+    print()
+    print(_bold("next:"))
+    print(f'  looplet run-workspace {target_dir} "<your task>"')
+    return 0
+
+
+# ── ``looplet run-workspace`` ───────────────────────────────────
+
+
+def cmd_run_workspace(args: argparse.Namespace) -> int:
+    if _check_env() != 0:
+        return 1
+
+    workspace_path: Path = args.workspace.resolve()
+    task: str = args.task
+
+    if not workspace_path.is_dir():
+        print(_red(f"error: workspace not found at {workspace_path}"), file=sys.stderr)
+        return 1
+
+    try:
+        from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
+        from looplet.types import DefaultState  # noqa: PLC0415
+    except Exception as exc:
+        print(_red(f"error: {exc}"), file=sys.stderr)
+        return 1
+
+    print(f"{_bold('looplet run')} {workspace_path}")
+    print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
+    print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
+    print()
+
+    try:
+        backend = _build_backend()
+        preset = workspace_to_preset(
+            str(workspace_path), runtime={"workspace": str(workspace_path.parent)}
+        )
+    except Exception as exc:
+        print(_red(f"error: workspace load failed: {exc}"), file=sys.stderr)
+        return 1
+
+    state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
+    t0 = time.time()
+    n_steps = 0
+    final_summary: str | None = None
+    final_data: dict | None = None
+    try:
+        for step in composable_loop(
+            llm=backend,
+            config=preset.config,
+            tools=preset.tools,
+            state=state,
+            hooks=preset.hooks,
+            task={"goal": task},
+        ):
+            n_steps += 1
+            tool_call = step.tool_call
+            tool_result = step.tool_result
+            if tool_call is None:
+                continue
+            if not args.quiet:
+                err = (tool_result and tool_result.error) or (
+                    tool_result.data.get("error") if tool_result and tool_result.data else None
+                )
+                tag = _red("✗") if err else _green("✓")
+                short = json.dumps(tool_call.args, default=str)[:80]
+                print(f"  {tag} step {n_steps:>2}: {tool_call.tool}({short})")
+            if tool_call.tool == "done" and tool_result and tool_result.data:
+                final_data = dict(tool_result.data)
+                final_summary = str(tool_result.data.get("summary", ""))
+    except KeyboardInterrupt:
+        print(_red("\ninterrupted"), file=sys.stderr)
+        return 130
+
+    elapsed = time.time() - t0
+    print()
+    print(f"{_green('✓')} done in {elapsed:.1f}s — {n_steps} steps")
+    print()
+    if final_summary:
+        print(_bold("result:"))
+        print(final_summary)
+    elif final_data:
+        print(_bold("result:"))
+        print(json.dumps(final_data, indent=2, default=str)[:2000])
+    return 0
+
+
+# ── argparse wiring (called from __main__.main) ─────────────────
+
+
+def add_subparsers(sub: "argparse._SubParsersAction") -> None:
+    """Register ``new`` and ``run-workspace`` on the top-level parser.
+
+    Called from :mod:`looplet.__main__` so the two commands are
+    available as ``looplet new ...`` and ``looplet run-workspace ...``.
+    """
+    new_p = sub.add_parser(
+        "new",
+        help="Generate a new agent workspace from a brief (uses agent_factory)",
+        description=(
+            "Generate a working looplet agent workspace from a one-paragraph "
+            "English brief. Requires OPENAI_BASE_URL / OPENAI_API_KEY / "
+            "OPENAI_MODEL env vars (any OpenAI-compatible endpoint)."
+        ),
+    )
+    new_p.add_argument(
+        "description",
+        help="Plain-English description of what the agent should do",
+    )
+    new_p.add_argument(
+        "target",
+        nargs="?",
+        type=Path,
+        default=Path("./agent.workspace"),
+        help="Target directory for the produced workspace (default: ./agent.workspace)",
+    )
+    new_p.add_argument(
+        "--name",
+        help="Workspace name (default: derived from target directory)",
+    )
+    new_p.add_argument(
+        "--tool",
+        action="append",
+        help="Pre-scaffold a tool by name (repeatable). When omitted, the agent picks tools from the brief.",
+    )
+    new_p.add_argument(
+        "--max-steps",
+        type=int,
+        help="Override the factory's default max_steps (default: 80)",
+    )
+    new_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
+    new_p.set_defaults(_handler=cmd_new)
+
+    run_p = sub.add_parser(
+        "run-workspace",
+        help="Run a workspace on a task and print the final result",
+        description=(
+            "Load an existing looplet workspace and run it against a task. "
+            "Requires the same env vars as ``looplet new``."
+        ),
+    )
+    run_p.add_argument("workspace", type=Path, help="Path to a workspace directory")
+    run_p.add_argument("task", help="Task to give the agent")
+    run_p.add_argument(
+        "--max-steps",
+        type=int,
+        help="Override the workspace's default max_steps",
+    )
+    run_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
+    run_p.set_defaults(_handler=cmd_run_workspace)
+
+
+__all__ = ["add_subparsers", "cmd_new", "cmd_run_workspace"]

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -1,0 +1,106 @@
+"""Smoke tests for ``looplet new`` and ``looplet run-workspace`` CLI.
+
+The CLI's job is straightforward plumbing — load the factory, run a
+loop, surface results — so most of these tests exercise UX paths
+(missing env vars, bad workspace path, factory location lookup)
+without spinning up a real LLM.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from looplet.__main__ import main
+
+
+def test_new_help() -> None:
+    """``looplet new --help`` exits 0 and prints usage."""
+    with pytest.raises(SystemExit) as exc, patch("sys.stdout", new=io.StringIO()):
+        main(["new", "--help"])
+    assert exc.value.code == 0
+
+
+def test_run_workspace_help() -> None:
+    with pytest.raises(SystemExit) as exc, patch("sys.stdout", new=io.StringIO()):
+        main(["run-workspace", "--help"])
+    assert exc.value.code == 0
+
+
+def test_new_missing_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When required env vars are unset, ``new`` prints a clear error
+    and exits 1."""
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    captured = io.StringIO()
+    with patch.object(sys, "stderr", captured):
+        rc = main(["new", "a brief", str(tmp_path / "out.workspace")])
+    assert rc == 1
+    err = captured.getvalue()
+    assert "missing required env vars" in err
+    # All three should be named.
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_MODEL"):
+        assert var in err
+    # The hint surface (the env-var template) must appear.
+    assert "OPENAI_MODEL=" in err
+
+
+def test_new_partial_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Setting some but not all env vars still errors and names the missing ones."""
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    captured = io.StringIO()
+    with patch.object(sys, "stderr", captured):
+        rc = main(["new", "a brief", str(tmp_path / "out.workspace")])
+    assert rc == 1
+    err = captured.getvalue()
+    assert "OPENAI_API_KEY" in err
+    assert "OPENAI_MODEL" in err
+    # The one we DID set should NOT appear in the missing list.
+    assert "missing required env vars: OPENAI_BASE_URL" not in err
+
+
+def test_run_workspace_missing_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    rc = main(["run-workspace", str(tmp_path), "do something"])
+    assert rc == 1
+
+
+def test_run_workspace_path_must_exist(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_MODEL", "test-model")
+    captured = io.StringIO()
+    nonexistent = tmp_path / "no_such_dir"
+    with patch.object(sys, "stderr", captured):
+        rc = main(["run-workspace", str(nonexistent), "do x"])
+    assert rc == 1
+    assert "workspace not found" in captured.getvalue()
+
+
+def test_factory_workspace_path_resolves_in_repo() -> None:
+    """``_factory_workspace_path`` finds the bundled
+    examples/agent_factory.workspace when run from the repo."""
+    from looplet.cli.factory_commands import _factory_workspace_path
+
+    p = _factory_workspace_path()
+    assert p.is_dir()
+    assert (p / "workspace.json").is_file()
+    assert (p / "config.yaml").is_file()
+
+
+def test_new_command_registered_on_top_level() -> None:
+    """``looplet`` (no subcommand) should mention ``new`` and ``run-workspace``."""
+    captured = io.StringIO()
+    with pytest.raises(SystemExit) as exc, patch.object(sys, "stdout", captured):
+        main(["--help"])
+    assert exc.value.code == 0
+    out = captured.getvalue()
+    assert "new" in out
+    assert "run-workspace" in out


### PR DESCRIPTION
## The killer-app's user-facing entry point

A new user with one hour to spare can now go from zero to working agent in 5-10 minutes:

```bash
pip install looplet
export OPENAI_BASE_URL=http://127.0.0.1:19823/v1   # any OpenAI-compatible endpoint
export OPENAI_API_KEY=sk-...
export OPENAI_MODEL=gpt-4o-mini

looplet new "a one-paragraph description of the agent I want"
looplet run-workspace ./agent.workspace "my task"
```

## Live end-to-end demo (real LLM, real network)

```bash
$ looplet new "An agent that takes a URL and returns the page title
  and a 2-sentence summary of the content. Tools: fetch_url(url) using
  stdlib urllib, extract_title(html), summarize_text(text) using ctx.llm." \
  ./url_summarizer.workspace

looplet new → /tmp/cli_demo/url_summarizer.workspace
  ✓ step  1: scaffold_workspace(...)
  ✓ step  2: write_file(prompts/system.md)
  …42 steps…
  ✓ step 42: done("Built url_summarizer.workspace…")

✓ built in 294.2s — 42 steps, 7 denies

produced workspace: /tmp/cli_demo/url_summarizer.workspace
  tools:  done, extract_title, fetch_url, summarize_text  (4)
  prompt: 1080 chars
  agent says: Built url_summarizer.workspace … all 4 tests pass.

$ looplet run-workspace ./url_summarizer.workspace "Summarize https://example.com"

  ✓ step  1: fetch_url({"url": "https://example.com"})
  ✓ step  2: extract_title(...)
  ✓ step  3: summarize_text(...)
  ✓ step  4: done(...)

✓ done in 96.3s — 4 steps

result:
Title: Example Domain
Summary: Example Domain is a reserved domain intended for use in illustrative
documentation and examples. It is not meant for operational use, and more
information is available via a linked resource.
```

The agent the factory built **actually works** on a real URL — real network fetch, real title extraction, real LLM summary, all correct.

## What's new

### `looplet new <description> [target]`
Runs the bundled agent_factory against a brief, writes the workspace, verifies it loads. Optional `--tool` flags pre-scaffold the skeleton (saves ~5 turns).

### `looplet run-workspace <path> <task>`
Loads any workspace and runs it on a task. Prints final `done` summary.

Both share an `_check_env()` gate that reports missing env vars with copy-pastable export hints.

### Module structure
- New `looplet.cli` subpackage so factory commands evolve independently of the existing bundle/trace/eval CLI machinery.
- Generic `set_defaults(_handler=fn)` dispatch in `__main__.py` — no per-command branch needed.

## Tests
8 new smoke tests covering: `--help` exits 0 for both commands; missing env vars produce structured error with copy-pastable hints; partial env vars name the missing ones specifically; `run-workspace` requires a real workspace path; factory location lookup finds `examples/agent_factory.workspace`; both commands appear in top-level `--help`.

Full suite: **1674/1674 passing**, ruff + pyright clean.