### PR TITLE
feat(factory): self-introspect existing CLIs/modules from the brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ looplet run-workspace ./agent.workspace "Summarize https://example.com"
 
 The recording above shows exactly that, end to end on a real LLM and a real URL: build the agent in ~170s, run it on `example.com` in ~12s, get the correct title + LLM summary back. Three minutes, blank dir → working agent.
 
+**Mention an existing CLI or Python module in your brief, and the factory wraps it.**
+The agent's most valuable tools usually exist already — your team's CLIs, internal SDKs, helper modules. Name them in the brief and the factory introspects the real surface and writes thin wrappers around it (no hallucinated signatures).
+
+```bash
+# Wrap the gh CLI as a triage agent (factory runs `gh --help`, picks JSON-supporting subcommands)
+looplet new "Wrap the gh CLI as a triage agent that surfaces my open PRs and issues that need attention today"
+
+# Wrap an existing Python class as agent tools (factory introspects via inspect.signature)
+looplet new "Wrap mycompany.search:SearchClient as a SOC investigator with search/pivot/scan tools, backed by DuckDBBackend(':memory:')"
+```
+
 > Underneath, looplet exposes the agent loop as an iterator, makes
 > every step observable, and lets you compose behaviour with hooks.
 > The factory is built on the same primitives you'd use for a

--- a/docs/agent-factory.md
+++ b/docs/agent-factory.md
@@ -83,6 +83,90 @@ Load a workspace and run it on a task.
 
 ---
 
+## Wrapping existing tools and data (the killer use case)
+
+Most useful agents aren't built on greenfield Python — they're built on tools and data the team already has: an internal CLI, a vendor SDK, a helper module, a shell script. Naming any of these in the brief makes the factory introspect the real surface and write thin wrappers, instead of hallucinating signatures from training data.
+
+The factory's planning phase recognises three patterns and uses bash + `inspect` to ground itself in the real source:
+
+| Pattern in the brief | What the factory does |
+|---|---|
+| Mentions a CLI on `$PATH` (e.g. `gh`, `kubectl`, `aws`, an internal CLI) | Runs `<cli> --help` and a couple of `<cli> <subcommand> --help` calls; detects `--json` support; writes subprocess-based tool bodies that call the real subcommands |
+| Mentions a Python dotted path (`pkg.module` or `pkg.module:Class`) | Imports it, runs `inspect.signature` on the public callables, and writes tool bodies that call the real methods. For class wraps it uses the workspace `resources/` mechanism: `resources/<name>.py` builds the singleton, every tool declares `requires: [<name>]`, the body looks it up via `ctx.resources["<name>"]` |
+| Mentions a local script (`./scripts/foo.sh`, `~/bin/bar.py`) | Reads the file and writes a subprocess- or import-based wrapper from the actual source |
+
+### Example: wrap the GitHub CLI
+
+```bash
+looplet new "Wrap the gh CLI as a triage agent that surfaces my open PRs and issues that need attention today" \
+    ./gh_triager.workspace
+```
+
+Produces tools like:
+
+```python
+# tools/list_my_prs/execute.py
+import json, subprocess
+
+def execute(ctx, *, limit: int = 20) -> dict:
+    result = subprocess.run(
+        ["gh", "pr", "list", "--author", "@me", "--state", "open",
+         "--limit", str(limit), "--json",
+         "number,title,repository,updatedAt,reviewDecision,isDraft,url"],
+        capture_output=True, text=True, check=True,
+    )
+    return {"prs": json.loads(result.stdout)}
+```
+
+The agent picked the right `--json` field set and the right `--author @me` flag because it ran `gh pr list --help` first.
+
+### Example: wrap an existing Python class
+
+```bash
+looplet new "Wrap mycompany.search:SearchClient as a SOC investigator with search/pivot/scan tools, backed by DuckDBBackend(':memory:')" \
+    ./soc_investigator.workspace
+```
+
+Produces a workspace with the `resources/` mechanism wired correctly:
+
+```python
+# resources/searchclient.py
+from mycompany.search import SearchClient
+from mycompany.backends.duckdb_backend import DuckDBBackend
+
+def build():
+    return SearchClient(DuckDBBackend(":memory:"))
+```
+
+```yaml
+# tools/search/tool.yaml
+name: search
+parameters:
+  pattern: { type: string }
+  window: { type: array, default: null }
+  tables: { type: array, default: null }
+requires:
+  - searchclient
+```
+
+```python
+# tools/search/execute.py
+def execute(ctx, *, pattern, window=None, tables=None) -> dict:
+    ep = ctx.resources["searchclient"]
+    hits = ep.search(pattern, window=window, tables=tables)
+    return {"hits": [h.__dict__ for h in hits], "count": len(hits)}
+```
+
+Every signature matches the real class — including default values like `mode="full"` and `profile_top_k=10` — because the factory ran `inspect.signature` first.
+
+### Why this works without flags
+
+The factory's system prompt tells the agent to introspect *first* (before scaffolding) whenever the brief mentions an existing CLI / module / script. The agent has `bash`, `read_file`, and `multi_edit` tools already; a one-line `bash("python -c 'import inspect; ...'")` is all the introspection it needs. There is no special CLI flag — naming the thing in the brief is enough.
+
+If the brief is purely greenfield ("an agent that takes a URL and returns the title…"), the factory falls through to ordinary scaffold-and-fill behaviour. The introspection step only fires when there's something concrete to wrap.
+
+---
+
 ## What the factory does internally
 
 `agent_factory.workspace` is a workspace itself — see

--- a/examples/agent_factory.workspace/prompts/system.md
+++ b/examples/agent_factory.workspace/prompts/system.md
@@ -27,6 +27,14 @@ Every agent **must** have a `done` tool — it's the completion sentinel.
    - What tools does it need? Aim for the smallest set (3-6 tools).
    - Does it need any hook? (most agents don't — only add if you have a real reason)
    - Does it need any resource? (rarely — only for shared state)
+   - **Does the brief mention an existing CLI, Python module, or script?** If yes, you MUST introspect it FIRST (step 1a below) — before scaffolding. Hallucinated signatures are the #1 way the produced agent breaks at runtime.
+
+1a. **Ground-truth introspection (do this BEFORE scaffolding when applicable).**
+
+   - Brief mentions a CLI like `gh`, `kubectl`, `aws`, an internal CLI? → run `bash("<cli> --help")` and a couple of `bash("<cli> <subcommand> --help")` calls to learn the real subcommand list and whether `--json` is supported. Then write subprocess-based tool bodies that wrap the actual subcommands.
+   - Brief mentions a Python module or class like `mypkg.api:Client`, `mycompany.search:SearchClient`? → run `bash("python -c 'import inspect, mypkg.api as m; print(inspect.signature(m.Client.method))'")` (or similar) to capture the REAL signature. Hallucinated signatures are the #1 way the produced agent breaks at runtime — never guess. For class wraps, you MUST use the workspace `resources/` mechanism: write `resources/<name>.py` with a `build()` function that constructs the singleton, declare `requires: [<name>]` in every tool.yaml that uses it, and look it up via `ctx.resources["<name>"]` in the execute body. Module-level singletons like `_obj = Class(...)` will not work — the loader expects the resources path.
+   - Brief mentions a local script (`./scripts/foo.sh`, `~/bin/bar.py`)? → use `read_file` to read it, then write a subprocess- or import-based wrapper from the actual source.
+   - Skipping ground-truth introspection is the most expensive shortcut you can take.
 
 2. **Scaffold the skeleton FIRST** with one `scaffold_workspace(path=..., name=..., tools=[...])` call. This creates `workspace.json`, `config.yaml`, `prompts/system.md` (with TODOs), and `tools/<name>/{tool.yaml, execute.py}` stubs (raise `NotImplementedError`) for every tool you listed. The standard `done` tool is added automatically.
 

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -123,8 +123,6 @@ def _factory_workspace_path() -> Path:
 
 
 # ── ``looplet new`` ─────────────────────────────────────────────
-
-
 def cmd_new(args: argparse.Namespace) -> int:
     if _check_env() != 0:
         return 1
@@ -141,7 +139,6 @@ def cmd_new(args: argparse.Namespace) -> int:
         print(_dim(f"  tools:  {', '.join(tools)} (pre-scaffolded)"))
     print(_dim(f"  model:  {os.environ['OPENAI_MODEL']}"))
     print()
-
     try:
         from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
         from looplet.types import DefaultState  # noqa: PLC0415
@@ -253,8 +250,6 @@ def cmd_new(args: argparse.Namespace) -> int:
 
 
 # ── ``looplet run-workspace`` ───────────────────────────────────
-
-
 def cmd_run_workspace(args: argparse.Namespace) -> int:
     if _check_env() != 0:
         return 1
@@ -334,8 +329,6 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
 
 
 # ── argparse wiring (called from __main__.main) ─────────────────
-
-
 def add_subparsers(sub: "argparse._SubParsersAction") -> None:
     """Register ``new`` and ``run-workspace`` on the top-level parser.
 


### PR DESCRIPTION
## What this changes

Mention an existing CLI, Python module, or local script in your `looplet new` brief and the factory now introspects the real surface and writes thin wrappers around it — no new flags, no hallucinated signatures.

```bash
# Wrap an existing CLI
looplet new "Wrap the gh CLI as a triage agent that surfaces my open PRs and issues that need attention today"

# Wrap an existing Python class
looplet new "Wrap mycompany.search:SearchClient as a SOC investigator with search/pivot/scan tools"

# Greenfield still works as before
looplet new "An agent that takes a URL and returns the page title and a 2-sentence summary"
```

## Why prompt-only beat flags + dedicated tools

I tried two more invasive shapes first: `--from-cli` / `--from-module` CLI flags (deterministic introspection at invocation time), and exposing the same introspectors as factory tools (`introspect_cli` / `introspect_module`). Both worked but were strictly worse than just letting the coder agent run `bash("<cli> --help")` or `bash("python -c 'import inspect, ...'")` directly:

| Variant | gh build | sec investigator build |
|---|---|---|
| `--from-module` flag | — | 542s / 72 steps / 12 denies |
| `introspect_*` factory tools | 232s / 34 steps / 4 denies | (parse-recovery cascades) |
| **bare-coder + prompt section (this PR)** | **159s / 24 steps / 2 denies** | **271s / 51 steps / 1 deny** |

The deterministic introspectors padded context with 60-line addendums that triggered parse-recovery cycles in the longer trajectories. The agent already has `bash`, `read_file`, and `multi_edit` — a single one-shot subprocess call is cheaper.

## What's in the diff

- `examples/agent_factory.workspace/prompts/system.md` (+8 lines): adds step `1a. Ground-truth introspection` to the planning checklist with three patterns (CLI / Python module / local script) and the **non-negotiable wiring contract** for class wraps (`resources/<name>.py` + `requires:` + `ctx.resources["<name>"]`)
- `README.md` (+11 lines): adds a "wrap an existing CLI/module" stanza below the URL-summariser quickstart
- `docs/agent-factory.md` (+84 lines): adds a full "Wrapping existing tools and data" section with two worked examples showing the produced files
- `src/looplet/cli/factory_commands.py` (-7 lines): cosmetic whitespace from ruff-format

## Verification

- 8/8 factory CLI smoke tests pass
- 1674/1674 full suite passes (CI ran on push)
- ruff clean
- End-to-end dogfooded on:
  - `gh` CLI → produces `subprocess`-based tools with correct `--json` field selection
  - A vendor Python class → produces `resources/<name>.py` builder + `requires:` declarations + `ctx.resources` lookups, with signatures matching the real class (including default values like `mode="full"`, `profile_top_k=10`)

No new flags, no new dependencies, ~+95 lines net.
