### PR TITLE
docs: tighten README + audit collab hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Then from the repo root:
 ```bash
 make install           # uv sync --all-extras (matches CI)
 make check             # everything CI runs: lint + format + pyright + pytest
-make test              # just the tests (~2s, 1307 tests)
+make test              # just the tests (~2min, 1674 tests)
 make install-hooks     # one-time: install a pre-push git hook that runs `make check`
 ```
 
@@ -68,7 +68,7 @@ Run it before every push, or let the pre-push hook do it for you.
 
 Before opening a PR, please verify:
 
-- [ ] `make check` passes (lint + format + pyright + 1307 tests).
+- [ ] `make check` passes (lint + format + pyright + 1674 tests).
 - [ ] New public API has docstrings and tests.
 - [ ] `CHANGELOG.md` has an entry under `## Unreleased` describing your
       change (unless it's a docs-only or internal refactor with no

--- a/README.md
+++ b/README.md
@@ -7,182 +7,49 @@
 [![PyPI version](https://img.shields.io/pypi/v/looplet.svg)](https://pypi.org/project/looplet/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Status: Beta](https://img.shields.io/badge/status-beta-orange.svg)](ROADMAP.md)
 
-**Describe an agent in one paragraph. Get a working agent in 5 minutes.**
-Looplet treats agents as data — a workspace is a directory of files
-(`config.yaml`, `prompts/system.md`, `tools/<name>/{tool.yaml,
-execute.py}`) that the loader materialises into a runnable agent. The
-`agent_factory` workspace builds new workspaces from English briefs;
-the loop engine runs them. **Zero runtime dependencies.**
+**Describe an agent in one paragraph. Get a working agent in five minutes.**
 
 ```bash
 pip install looplet
 export OPENAI_BASE_URL=https://api.openai.com/v1   # any OpenAI-compatible endpoint
 export OPENAI_API_KEY=sk-...
-export OPENAI_MODEL=gpt-4o-mini
+export OPENAI_MODEL=gpt-5.5
 
 looplet new "An agent that takes a URL and returns the page title and a 2-sentence summary"
 looplet run-workspace ./agent.workspace "Summarize https://example.com"
 ```
 
-The recording above shows exactly that, end to end on a real LLM and a real URL: build the agent in ~170s, run it on `example.com` in ~12s, get the correct title + LLM summary back. Three minutes, blank dir → working agent.
+The recording above is exactly that — blank directory to working agent in three minutes, end-to-end on a real LLM.
 
-**Mention an existing CLI or Python module in your brief, and the factory wraps it.**
-The agent's most valuable tools usually exist already — your team's CLIs, internal SDKs, helper modules. Name them in the brief and the factory introspects the real surface and writes thin wrappers around it (no hallucinated signatures).
+**Mention an existing CLI, Python module, or script in your brief, and the factory wraps it.** Your team's tools already exist; looplet introspects the real surface and writes thin wrappers around them — no hallucinated signatures.
 
 ```bash
-# Wrap the gh CLI as a triage agent (factory runs `gh --help`, picks JSON-supporting subcommands)
-looplet new "Wrap the gh CLI as a triage agent that surfaces my open PRs and issues that need attention today"
+# Wrap the gh CLI as a triage agent
+looplet new "Wrap the gh CLI as a triage agent that surfaces my open PRs and issues"
 
-# Wrap an existing Python class as agent tools (factory introspects via inspect.signature)
-looplet new "Wrap mycompany.search:SearchClient as a SOC investigator with search/pivot/scan tools, backed by DuckDBBackend(':memory:')"
+# Wrap an existing Python class as agent tools
+looplet new "Wrap mycompany.search:SearchClient as a SOC investigator with search/pivot/scan tools"
 ```
 
-> Underneath, looplet exposes the agent loop as an iterator, makes
-> every step observable, and lets you compose behaviour with hooks.
-> The factory is built on the same primitives you'd use for a
-> hand-rolled agent — see [The mental model](#the-mental-model--one-picture)
-> below.
+See [docs/agent-factory.md](docs/agent-factory.md) for the full pattern.
 
 ---
 
-## Quickstart — three paths
+## Why looplet
 
-### 1. Generate an agent with `looplet new`
+Most agent frameworks give you `agent.run(task)` — a black box. When the agent does something wrong at step 7, you can't step in between step 6 and step 8.
 
-```bash
-looplet new "<one paragraph describing what the agent should do>" \
-    ./my_agent.workspace
-```
+**Looplet does the opposite: the loop is the product.** Every step is a `Step` object you can inspect, save, or diff. Every decision the loop makes — what goes in the next prompt, whether to compact context, whether to dispatch a dangerous tool, whether to stop — is a `Protocol` method you implement in a few lines. Hooks compose without inheritance. Nothing is hidden.
 
-The factory writes `my_agent.workspace/` with `workspace.json`,
-`config.yaml`, `prompts/system.md`, and one `tools/<name>/` directory
-per tool the agent picks. Then it writes a pytest suite, runs it, and
-hands you the working workspace.
-
-Required env vars (any OpenAI-compatible endpoint — OpenAI, Ollama,
-Together, Groq, vLLM, Anthropic via proxy, …):
-
-| Var | Example |
-|---|---|
-| `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
-| `OPENAI_API_KEY` | `sk-…` |
-| `OPENAI_MODEL` | `gpt-4o-mini`, `claude-sonnet-4.6`, `llama3.1` |
-
-Run `looplet doctor` to verify connectivity.
-
-### 2. Run any workspace with `looplet run-workspace`
-
-```bash
-looplet run-workspace ./my_agent.workspace "<task to give the agent>"
-```
-
-Loads the workspace, runs the loop, prints the final `done` summary.
-
-### 3. Hand-write the loop in Python (for full control)
-
-```python
-from looplet import composable_loop, workspace_to_preset
-
-preset = workspace_to_preset("./my_agent.workspace")
-
-for step in composable_loop(
-    llm=preset.llm,
-    config=preset.config,
-    tools=preset.tools,
-    state=preset.state,
-    hooks=preset.hooks,
-    task={"goal": "Summarize https://example.com"},
-):
-    print(step.pretty())
-```
-
-`composable_loop` is a generator. You see every step, can break out at
-any point, and can plug your own hooks in for context management,
-human approval, observability, or evaluation.
-
----
-
-## The simple story
-
-Every looplet agent turn is the same small mechanism:
-
-1. The LLM proposes a tool call.
-2. The registry validates and dispatches it.
-3. Hooks observe or steer the turn.
-4. State records the step.
-5. The loop yields a `Step` back to your `for` loop.
-
-That's it. `agent_factory.workspace` is a special workspace whose
-tools (`scaffold_workspace`, `multi_edit`, `validate_workspace`, etc.)
-write OTHER workspaces. Once a workspace exists, it's just data the
-loop iterates over.
-
-```python
-for step in composable_loop(llm=llm, tools=tools, state=state, config=config, hooks=hooks):
-    print(step.pretty())
-```
-
-Start with `looplet new` if you want a working agent right now. Drop
-into the Python API when you need full control.
-
-```bash
-python -m looplet run ./skills/coder "Fix the tests" --workspace .
-python -m looplet blueprint ./skills/coder --workspace .
-python -m looplet export-code ./skills/coder coder_agent.py
-```
-
----
-
-## Why it exists
-
-Most agent frameworks give you `agent.run(task)` and a black box. When the
-agent does something wrong at step 7, you can't step in between step 6 and
-step 8. You end up forking the library or writing a second agent to babysit
-the first.
-
-`looplet` does the opposite: **the loop is the product, and hooks are the
-extension API.** Every tool call is a `Step` object you can print, save,
-or diff. Every decision the loop makes — what goes in the next prompt,
-whether to compact context, whether to dispatch a dangerous tool, whether
-to stop — is a `Protocol` method you implement in a few lines. Hooks
-compose without inheritance. Nothing is hidden.
-
-That one design choice is where the library's three practical superpowers
-come from:
-
-* **Shape agent behaviour** without forking — a 10-line hook can redact PII
-  from every prompt, inject retrieved docs, rewrite tool arguments, or
-  rate-limit calls to a single tool. Hooks are the extension point the
-  framework *can't* close off because the loop itself is built on them.
-* **Manage context on your terms** — `compact_chain(Prune, Summarize,
-  Truncate)` is three hooks you wire together. Swap the strategy, change
-  the budget, fire on a different threshold — no monkey-patching.
-* **Debug and eval without a second tool** — `step.pretty()` is a
-  human-readable trace, `ProvenanceSink` dumps every prompt the LLM saw
-  plus every tool result into a diff-friendly directory, and pytest-style
-  `eval_*` functions turn that trace into a regression suite. Your debug
-  output *is* your eval harness.
-
-That is the differentiation: looplet is not trying to be a complete
-agent product. It is the control plane for people building one.
+Agents are **data**. A workspace is a directory of files (`workspace.json`, `config.yaml`, `prompts/system.md`, `tools/<name>/{tool.yaml, execute.py}`) that the loader materialises into a runnable agent. The factory builds new workspaces from English briefs; the loop engine runs them. **Zero runtime dependencies.**
 
 ---
 
 ## The mental model — one picture
 
-`looplet` is a `for` loop you own. The LLM proposes a tool call, the
-registry dispatches it, hooks observe or steer, state records the result,
-and the loop yields a `Step`. The diagram below expands that simple story
-into the hook points you can customize:
-
 ```mermaid
-%%{init: {"theme":"base","themeVariables":{
-  "fontFamily":"ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
-  "fontSize":"15px",
-  "lineColor":"#94a3b8"
-}}}%%
+%%{init: {"theme":"base","themeVariables":{"fontFamily":"ui-sans-serif, system-ui, sans-serif","fontSize":"15px","lineColor":"#94a3b8"}}}%%
 flowchart LR
     you(["<b>your code</b><br/><span style='font-size:11px;opacity:.75'>for&nbsp;step&nbsp;in&nbsp;loop(...)</span>"]):::you
 
@@ -212,15 +79,6 @@ flowchart LR
     h3 -.-> dispatch
     h4 -.-> done
 
-    linkStyle 0,1,2 stroke:#94a3b8,stroke-width:2px
-    linkStyle 3 stroke:#475569,stroke-width:3px
-    linkStyle 4 stroke:#059669,stroke-width:3px
-    linkStyle 5 stroke:#475569,stroke-width:3px
-    linkStyle 6 stroke:#3b82f6,stroke-width:1.5px
-    linkStyle 7 stroke:#f59e0b,stroke-width:1.5px
-    linkStyle 8 stroke:#f59e0b,stroke-width:1.5px
-    linkStyle 9 stroke:#10b981,stroke-width:1.5px
-
     classDef you        fill:#0f172a,stroke:#334155,stroke-width:2px,color:#f8fafc;
     classDef phaseBlue  fill:#dbeafe,stroke:#2563eb,stroke-width:2.5px,color:#1e3a8a;
     classDef phaseAmber fill:#fef3c7,stroke:#d97706,stroke-width:2.5px,color:#78350f;
@@ -229,17 +87,15 @@ flowchart LR
     classDef hookBlue   fill:#eff6ff,stroke:#3b82f6,stroke-width:1.5px,color:#1e40af;
     classDef hookAmber  fill:#fffbeb,stroke:#f59e0b,stroke-width:1.5px,color:#92400e;
     classDef hookGreen  fill:#ecfdf5,stroke:#10b981,stroke-width:1.5px,color:#065f46;
-
     style loop fill:#f8fafc,stroke:#cbd5e1,stroke-width:2px,stroke-dasharray:10 6,color:#1e293b;
 ```
 
-Every amber box is a `Protocol` method. A hook is any object that
-implements one or more of them — no base class, no inheritance:
+Every amber box is a `Protocol` method. A hook is any object that implements one or more — no base class, no inheritance:
 
 ```python
 class RedactPII:
     def pre_prompt(self, state, log, ctx, step):
-        return _scrub_emails(ctx)          # mutates the next LLM prompt
+        return _scrub_emails(ctx)         # mutates the next LLM prompt
 
 class RetryFlakyTool:
     def pre_dispatch(self, state, log, tc, step):
@@ -250,163 +106,121 @@ for step in composable_loop(..., hooks=[RedactPII(), RetryFlakyTool()]):
     ...
 ```
 
-Ship-ready hooks already wired in: `ApprovalHook`, `PermissionHook`,
-`CheckpointHook`, `ContextPressureHook`, `ThresholdCompactHook`,
-`ProvenanceSink`, `TracingHook`, `MetricsHook`, `EvalHook`, plus the
-`compact_chain(Prune, Summarize, Truncate)` context strategy. Use any,
-all, or none — and [drop in your own](docs/hooks.md) in 10 lines.
+Ship-ready hooks already wired in: `ApprovalHook`, `PermissionHook`, `CheckpointHook`, `ContextPressureHook`, `ThresholdCompactHook`, `ProvenanceSink`, `TracingHook`, `MetricsHook`, `EvalHook`, plus the `compact_chain(Prune, Summarize, Truncate)` context strategy. [Drop in your own](docs/hooks.md) in 10 lines.
 
 ---
 
-## Hand-write an agent in Python (60 seconds)
+## Three ways to use it
 
-If you'd rather skip the factory and code an agent directly:
+### 1. Generate an agent from a brief
+
+```bash
+looplet new "<one paragraph>" ./my_agent.workspace
+looplet run-workspace ./my_agent.workspace "<task>"
+```
+
+The factory writes `workspace.json`, `config.yaml`, `prompts/system.md`, and one `tools/<name>/` directory per tool the agent picks. See [docs/agent-factory.md](docs/agent-factory.md).
+
+### 2. Hand-write the loop in Python
+
+```python
+from looplet import composable_loop, workspace_to_preset
+
+preset = workspace_to_preset("./my_agent.workspace")
+
+for step in composable_loop(
+    llm=preset.llm, config=preset.config, tools=preset.tools,
+    state=preset.state, hooks=preset.hooks,
+    task={"goal": "Summarize https://example.com"},
+):
+    print(step.pretty())
+```
+
+`composable_loop` is a generator — break out at any point, plug in your own hooks, swap context strategy. See [docs/tutorial.md](docs/tutorial.md).
+
+### 3. Skip the workspace entirely
 
 ```python
 from looplet import BaseToolRegistry, OpenAIBackend, composable_loop
 from looplet.tools import register_done_tool
 
-llm = OpenAIBackend.from_env(model="gpt-4o-mini")  # reads OPENAI_API_KEY etc
-
+llm = OpenAIBackend.from_env(model="gpt-5.5")
 tools = BaseToolRegistry()
-
 
 @tools.tool
 def greet(name: str) -> dict:
     """Greet someone by name."""
     return {"greeting": f"Hello, {name}!"}
 
-
 register_done_tool(tools)
 
-for step in composable_loop(
-    llm=llm,
-    tools=tools,
-    task={"goal": "Greet Alice and Bob, then finish."},
-    max_steps=5,
-):
+for step in composable_loop(llm=llm, tools=tools, task={"goal": "Greet Alice and Bob, then finish."}, max_steps=5):
     print(step.pretty())
 ```
 
-Works out of the box with any OpenAI-compatible endpoint. No Claude-only
-SDK, no pydantic schema gymnastics, no LangChain memory objects.
+Required env vars (any OpenAI-compatible endpoint — OpenAI, Ollama, Together, Groq, vLLM, Anthropic via proxy):
 
-Try it on your laptop against a local Ollama in three lines:
+| Var | Example |
+|---|---|
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
+| `OPENAI_API_KEY` | `sk-…` |
+| `OPENAI_MODEL` | `gpt-5.5`, `claude-sonnet-4.6`, `llama3.1` |
 
-```bash
-OPENAI_BASE_URL=http://127.0.0.1:11434/v1 \
-OPENAI_API_KEY=ollama OPENAI_MODEL=llama3.1 \
-python -m looplet.examples.hello_world
-```
-
-The factory's output is the same shape: a directory of YAML +
-Python files that the same `composable_loop` runs. Use whichever
-entry point matches your taste.
+Run `looplet doctor` to verify connectivity.
 
 ---
 
-## When should you reach for `looplet`?
+## When to reach for looplet
 
-**Use it when you want to build your own agent loop and actually own
-the details.** Concretely:
+**Use it when you want to own the details of your agent loop.** Specifically:
 
-* You need to **insert logic at an exact phase** of the loop — before
-  the prompt is built, before a tool is dispatched, after a tool
-  returns — without forking a framework.
-* You need to **swap context-management strategy at runtime** (prune,
-  summarize, truncate, your own) without losing the rest of your stack.
-* You need the loop to **pause for human approval**, then resume where
-  it left off when approval arrives.
-* You want **first-class debugging and evaluation** — a printable
-  `Step`, a prompt-level provenance dump, pytest-style `eval_*`
-  functions — without bolting on a second tool.
-* You want **zero runtime dependencies** and a loop that cold-imports
-  in ~300 ms (numbers in [docs/benchmarks.md](docs/benchmarks.md)).
+- You need to insert logic at an exact phase — before the prompt, before a tool dispatch, after a tool returns — without forking a framework.
+- You need to swap context-management strategy at runtime (prune, summarize, truncate, your own).
+- You need the loop to pause for human approval and resume when approval arrives.
+- You want first-class debugging and evaluation: a printable `Step`, a prompt-level provenance dump, pytest-style `eval_*` functions.
+- You want zero runtime dependencies and a loop that cold-imports in ~300 ms ([docs/benchmarks.md](docs/benchmarks.md)).
 
-**Don't reach for `looplet` if** you want `agent.run(task)` to handle
-everything and return a string, or if you want a visual graph DSL — a
-higher-level framework will feel more natural and the overlap in
-features won't be worth the extra control `looplet` gives you.
+**Don't reach for looplet** if you want `agent.run(task)` to handle everything and return a string, or if you want a visual graph DSL.
 
 ---
 
 ## Examples
 
-Real-LLM examples read `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and
-`OPENAI_MODEL` from the environment. Point them at Ollama or any
-OpenAI-compatible endpoint, or use `--scripted` where available for a
-deterministic no-model run.
+Five fully-declarative workspaces ship in `examples/`:
 
-```bash
-python -m looplet.examples.hello_world                            # 30-line starter
-python -m looplet.examples.hello_world --scripted                 # no model required
-python -m looplet.examples.coding_agent "implement fizzbuzz"      # bash/read/write/edit/grep
-python -m looplet.examples.coding_agent --trace ./traces/         # save full trajectory
-python -m looplet.examples.coding_agent "implement add" --scripted --workspace /tmp/demo
-python -m looplet.examples.data_agent --clean                     # approval + compact + checkpoints
-python -m looplet.examples.data_agent --resume                    # resume from last checkpoint
-python -m looplet.examples.data_agent --scripted --auto-approve   # no model required
+| Workspace | What it does |
+|---|---|
+| [`hello.workspace`](examples/hello.workspace/) | Two-tool starter; load and run with any backend |
+| [`coder.workspace`](examples/coder.workspace/) | Coding agent — bash, read, write, edit, grep, glob |
+| [`dep_doctor.workspace`](examples/dep_doctor.workspace/) | Audits a repo's dependency files for security/license/maintenance risk |
+| [`git_detective.workspace`](examples/git_detective.workspace/) | Investigates repo health from git history |
+| [`threat_intel.workspace`](examples/threat_intel.workspace/) | Local-first security briefings |
+
+Load any of them:
+
+```python
+from looplet import workspace_to_preset, composable_loop
+preset = workspace_to_preset("examples/dep_doctor.workspace", runtime={"workspace": "/path/to/project"})
+for step in composable_loop(llm=preset.llm, config=preset.config, tools=preset.tools, state=preset.state, hooks=preset.hooks, task={"goal": "Audit dependencies"}):
+    print(step.pretty())
 ```
 
-Runnable bundles package the same primitives behind a portable folder:
-
-```bash
-python -m looplet list-bundles tests/fixtures --json
-python -m looplet run tests/fixtures/coder_skill_bundle "Create a tiny add function with tests" --scripted --workspace /tmp/demo
-python -m looplet export-code tests/fixtures/coder_skill_bundle /tmp/coder_agent.py  # exact local wrapper
-python -m looplet package my_agent:build ./skills/my-agent --name my-agent --description "Run my agent."
-python -m looplet wrap-claude-skill ./claude-skills/pdf ./skills/pdf
-```
-
-For a memorable custom agent, start with **Dependency Doctor**: point it
-at a repo and it audits dependency files for security, license, and
-maintenance risk, then produces a report card. It is concrete enough to
-be useful, broad enough that most developers understand the pain, and it
-shows looplet's core value: the user can watch every evidence-gathering
-step and add guardrails without rewriting the agent.
-
-```bash
-# Load the v2 workspace; pass --workspace to point at the project to audit.
-OPENAI_BASE_URL=http://127.0.0.1:11434/v1 \
-OPENAI_API_KEY=ollama OPENAI_MODEL=llama3.1 \
-python -c "from looplet import workspace_to_preset; \
-p = workspace_to_preset('examples/dep_doctor.workspace', runtime={'workspace': '/path/to/project'})"
-```
-
-Other example directions that show off the same infrastructure:
-`examples/git_detective.workspace/` for repo-health analysis,
-`examples/threat_intel.workspace/` for local-first security briefings, and
-`examples/coder.workspace/` for a coding agent with bash/read/write/edit/test
-tools. Each is a self-contained Composable Harness Workspace that
-round-trips losslessly with an `AgentPreset` via `preset_to_workspace`
-/ `workspace_to_preset`.
-
-```bash
-# More dogfood — load each workspace and run a scripted loop.
-python -m looplet.examples.hello_world --scripted
-python -m looplet.examples.ollama_hello --scripted
-python -m looplet.examples.coding_agent "Implement add" --scripted --workspace /tmp/demo
-python -m looplet.examples.data_agent --scripted --auto-approve --clean
-```
-
-Plus [`scripted_demo.py`](src/looplet/examples/scripted_demo.py) —
-a scripted `MockLLMBackend` run used only to record the GIF above.
-Not a usage reference.
+Or use them as a starting point: `cp -r examples/coder.workspace ./my_agent.workspace`, then edit. Each workspace round-trips losslessly with an `AgentPreset` via `preset_to_workspace` / `workspace_to_preset`.
 
 ---
 
 ## Learn more
 
 | Doc | What's in it |
-| --- | --- |
+|---|---|
 | [**docs/agent-factory.md**](docs/agent-factory.md) | **`looplet new` — generate agents from English briefs (start here)** |
 | [docs/tutorial.md](docs/tutorial.md) | Hand-write your first agent in 5 steps |
+| [docs/workspace.md](docs/workspace.md) | Workspace file layout reference |
 | [docs/hooks.md](docs/hooks.md) | Writing and composing hooks |
-| [docs/skills.md](docs/skills.md) | Lazy skills, runnable bundles, blueprints, and Claude Skill wrapping |
 | [docs/evals.md](docs/evals.md) | pytest-style agent evaluation |
 | [docs/provenance.md](docs/provenance.md) | Capturing prompts + trajectories |
 | [docs/recipes.md](docs/recipes.md) | Ollama, OTel, MCP, cost accounting, checkpoints |
-| [docs/benchmarks.md](docs/benchmarks.md) | Cold-import time & dep footprint vs alternatives |
+| [docs/benchmarks.md](docs/benchmarks.md) | Cold-import time & dep footprint |
 | [docs/faq.md](docs/faq.md) | FAQ, including "why not LangGraph?" |
 | [ROADMAP.md](ROADMAP.md) | What's planned, what's frozen, what's out of scope |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, conventions, PR checklist |
@@ -416,30 +230,23 @@ Not a usage reference.
 
 ## Stability
 
-`looplet` follows [SemVer](https://semver.org/). Pre-`1.0`, minor versions
-may introduce breaking changes as the design stabilises — pin conservatively:
+`looplet` follows [SemVer](https://semver.org/). Pre-`1.0`, minor versions may introduce breaking changes — pin conservatively:
 
 ```toml
 looplet>=0.1.8,<0.2
 ```
 
-See [ROADMAP.md § v1.0 API contract](ROADMAP.md#v10-api-contract) for the
-frozen surface and the path to `1.0`.
+See [ROADMAP.md § v1.0 API contract](ROADMAP.md#v10-api-contract) for the frozen surface and the path to `1.0`.
 
-## Contributors
-
-Thanks to everyone who has contributed to `looplet`:
-
-- [@mvanhorn](https://github.com/mvanhorn) - "Why not LangGraph?" FAQ (#17)
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
+---
 
 ## Contributing
 
-Contributions welcome: bug reports, docs, backends, examples, evals.
-Start with [CONTRIBUTING.md](CONTRIBUTING.md) and
-[docs/good-first-issues.md](docs/good-first-issues.md). Security issues
-go through [SECURITY.md](SECURITY.md).
+Bug reports, docs, backends, examples, evals all welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup and conventions; browse [open issues labelled `good first issue`](https://github.com/hsaghir/looplet/issues?q=is%3Aopen+label%3A%22good+first+issue%22) for scoped tasks. Security issues go through [SECURITY.md](SECURITY.md).
+
+Thanks to everyone who has contributed:
+
+- [@mvanhorn](https://github.com/mvanhorn) — "Why not LangGraph?" FAQ (#17)
 
 ## License
 

--- a/docs/agent-factory.md
+++ b/docs/agent-factory.md
@@ -17,7 +17,7 @@ agent — it's just an agent that builds other agents.
 # 1. Configure any OpenAI-compatible endpoint.
 export OPENAI_BASE_URL=https://api.openai.com/v1   # or http://127.0.0.1:11434/v1 for Ollama, etc.
 export OPENAI_API_KEY=sk-...
-export OPENAI_MODEL=gpt-4o-mini                    # or claude-sonnet-4.6, llama3.1, …
+export OPENAI_MODEL=gpt-5.5                       # or claude-sonnet-4.6, llama3.1, …
 
 # 2. Generate the agent.
 looplet new "an agent that takes a URL and returns the page title and a 2-sentence summary" \
@@ -230,18 +230,7 @@ does under the hood.
 
 ## Quality
 
-The factory has been dogfood-tested on five distinct briefs:
-
-| Agent | Tools | Verdict |
-|---|---|---|
-| `meeting_notes` | extract_decisions, extract_action_items, format_minutes | A — correct minutes from real transcripts |
-| `recipe_finder` | brainstorm_recipes, pick_best | A — pipes real recipes through correctly |
-| `haiku_writer` | brainstorm_imagery, compose_haiku | A — on-topic 5-7-5 haiku |
-| `json_validator` | parse_json, check_required_fields, format_report | A — correct missing-field detection |
-| `git_release_notes` | fetch_commits, group_by_type, format_notes | A — real commit shas, no fabrication |
-
-All five reach `done` end-to-end on real LLM input and produce
-correct, well-formatted output.
+Factory output is validated by the smoke-test suite (`tests/test_cli_new_smoke.py`) and dogfood runs across the canonical briefs in [issue #56](https://github.com/hsaghir/looplet/issues/56). Each produced workspace structurally validates via `workspace_to_preset()`, has a non-empty system prompt and `done` tool, and (for wrap-CLI / wrap-class briefs) uses real signatures from the introspected source.
 
 ---
 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -1,99 +1,31 @@
 # Good first issues
 
-A curated list of small, well-scoped tasks for first-time contributors.
-Each one is 1–3 hours of work and doesn't require deep familiarity
-with the loop internals.
+Curated, well-scoped tasks for first-time contributors. Each is a few hours of work and doesn't require deep familiarity with the loop internals.
 
-When you pick one up, please **open an issue** (or comment on an
-existing one) so we don't duplicate work.
+## How to claim
 
-## Backends
+1. Browse [open issues labelled `good first issue`](https://github.com/hsaghir/looplet/issues?q=is%3Aopen+label%3A%22good+first+issue%22) on GitHub. Each issue body has the **acceptance criteria, file pointers, and scope** — read it carefully before starting.
+2. **Comment on the issue** ("I'd like to work on this — starting with `<module>`") so others don't duplicate work.
+3. Open one PR per logical chunk. If the issue has a checklist, tick the box you completed and **don't claim "Closes #N"** unless every box is ticked.
+4. Submit. Allow ~1 week per claim before someone else may pick the issue back up.
 
-### 1. Add a Gemini (Google) backend
+## Categories
 
-**Where:** new file `src/looplet/backends_gemini.py`, exported from
-`looplet/__init__.py` as `GeminiBackend`.
+| Theme | Example issues |
+|---|---|
+| **New backends** | Gemini, Bedrock — implement the `LLMBackend` protocol over a new SDK |
+| **Recipes** | Local LLM via `llama-cpp-python`, OTel, MCP — runnable end-to-end docs |
+| **Eval recipes** | Port common evals into `looplet.evals.recipes` as importable functions |
+| **Examples** | New workspaces under `examples/` (e.g. research agent demonstrating `run_sub_loop`) |
+| **Documentation** | Fill in missing docstrings on public symbols (one PR per module) |
+| **Developer ergonomics** | Makefile targets, error-message improvements |
+| **Cookbook & benchmarks** | `looplet new` recipes for new tool surfaces; factory output quality benchmarks |
 
-**What:** implement the `LLMBackend` protocol on top of the
-`google-generativeai` Python SDK. Follow the shape of
-`AnthropicBackend` / `OpenAIBackend` in
-[`src/looplet/backends.py`](https://github.com/hsaghir/looplet/blob/master/src/looplet/backends.py).
+## What makes a good first PR
 
-**Acceptance:**
-- Add `google-generativeai` to an optional extra `[gemini]`.
-- Sync + async + streaming variants mirror the existing backends.
-- New tests under `tests/test_backends_gemini.py` (mock the SDK — no
-  real network).
-- Extend the "How it compares" table in the README.
+- **Small, focused.** One module or one recipe per PR; reviewer can hold it in their head.
+- **Tested.** Any behaviour change needs at least one test; mocks for LLM backends so CI doesn't need network.
+- **`make check` clean.** Lint + format + pyright + pytest all green locally.
+- **Honest about scope.** If you only finished part of an umbrella issue, say "Towards #N" not "Closes #N".
 
-### 2. Add a Bedrock (AWS) backend
-
-Same shape as #1, on top of `boto3` / `aiobotocore`. Extra is
-`[bedrock]`.
-
-### 3. Add a local `llama.cpp` / `llama-cpp-python` backend recipe
-
-Documentation-only: extend [docs/recipes.md](recipes.md) with a fully
-runnable example that uses the OpenAI-compatible server mode.
-
-## Examples
-
-### 4. Add `examples/ollama_hello.py`
-
-Mirror `examples/hello_world.py` but with the Ollama base URL baked
-in, zero API key, and a comment explaining `ollama pull llama3.1:8b`.
-
-### 5. Add `examples/research_agent.py`
-
-A small 3-tool research agent (web-search stub, note-taking,
-summarise) that demonstrates `run_sub_loop` for a specialist subtask.
-
-## Evals
-
-### 6. Ship reusable eval recipes as `looplet.evals.recipes`
-
-**Where:** new file `src/looplet/evals_recipes.py`.
-
-**What:** port these common evals into stable importable functions:
-
-- `eval_efficiency` — fewer steps = higher score
-- `eval_no_tool_errors` — fraction of tool calls that didn't error
-- `eval_parse_quality` — fraction of LLM outputs that parsed first try
-- `eval_tool_diversity` — number of unique tools used / total tools
-- `eval_completed` — did the agent call `done()`?
-
-**Acceptance:** each has a docstring, default thresholds, and at least
-one test against a fixture trajectory under `tests/fixtures/`.
-
-## Docs & housekeeping
-
-### 7. Fill in missing docstrings
-
-Run `uv run pyright src/looplet/` and fix any public symbol that
-is missing a docstring. Start with the smallest modules
-(`events.py`, `flags.py`, `memory.py`).
-
-### 8. Add a `make` target shim
-
-A minimal `Makefile` with `test`, `lint`, `format`, `build`, `docs`
-targets that wrap the `uv run` equivalents. Helps people coming from
-other projects.
-
-### 9. Write the "why not LangGraph" FAQ entry
-
-A 300-word honest comparison for
-[docs/faq.md](faq.md) (create new). Focus on *when* LangGraph is
-actually the better choice — credibility comes from telling people
-when not to use you.
-
-### 10. Improve error messages for common misuse
-
-Find three cases where a user mistake produces a confusing exception
-(e.g. forgetting `state=`, registering a tool with no `execute=`,
-passing a dict instead of `ToolSpec`) and turn each into a clear
-actionable error with a link to the relevant doc section.
-
----
-
-Don't see one that fits? Open an issue tagged `good first issue`
-proposing your own — we're happy to scope it with you.
+See [CONTRIBUTING.md](https://github.com/hsaghir/looplet/blob/master/CONTRIBUTING.md) for dev setup and the full PR checklist.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ pip install "looplet[anthropic]"
 ```bash
 export OPENAI_BASE_URL=https://api.openai.com/v1   # or Ollama, Groq, Together, vLLM, …
 export OPENAI_API_KEY=sk-…
-export OPENAI_MODEL=gpt-4o-mini
+export OPENAI_MODEL=gpt-5.5
 ```
 
 Run the bundled hello-world to sanity-check the wiring:
@@ -51,7 +51,7 @@ from looplet import (
 )
 
 llm = OpenAIBackend(base_url="https://api.openai.com/v1",
-                    api_key="sk-...", model="gpt-4o-mini")
+                    api_key="sk-...", model="gpt-5.5")
 
 @tool(description="Search the docs.")
 def search(query: str) -> dict:
@@ -121,7 +121,7 @@ from looplet import ProvenanceSink
 
 sink = ProvenanceSink(dir="traces/run_1", redact=lambda s: s.replace("secret", "[REDACTED]"))
 llm  = sink.wrap_llm(OpenAIBackend(base_url="https://api.openai.com/v1",
-                                    api_key="sk-...", model="gpt-4o-mini"))
+                                    api_key="sk-...", model="gpt-5.5"))
 
 for step in composable_loop(llm=llm, tools=tools, hooks=[sink.trajectory_hook()], ...):
     print(step.pretty())


### PR DESCRIPTION
## Why

Audit pass on the docs surface: README was 446 lines with three overlapping quickstart sections, `docs/good-first-issues.md` had stale content that contradicted the (now meaty) GitHub issue bodies, and the model-id examples still referenced `gpt-4o-mini`.

## What changes

**README** (`-371/+118`, ~43% smaller, applies the pyramid principle):

- Lead with the one-line value prop and the **one** command users need to copy. The recording proves it.
- Keep the "Wrap an existing CLI/module" stanza right under the quickstart since it's the killer use case.
- "Why looplet" → "Mental model picture" → "Three ways to use it" → "When to reach for it" → "Examples table" → "Learn more". Each section earns its place.
- Drop the duplicated `## Quickstart — three paths` section that restated the top-of-README quickstart in different words.
- Drop the "Hand-write an agent in Python (60 seconds)" section that overlapped path 3 of "three ways to use it".
- Replace the long Examples shell-script catalog with a 5-row table of the actually-shipped workspaces.
- `gpt-4o-mini` → `gpt-5.5` throughout.

**docs/good-first-issues.md** (`99 → 31` lines): collapsed from a stale duplicate of the GitHub issues into a thin pointer page (how to claim, what makes a good PR, link to the issue list). The GitHub issue bodies — refreshed in the recent issue audit — are now the single source of truth.

**docs/agent-factory.md** (`252 → 241` lines): dropped the obsolete "Quality" table that listed five ad-hoc dogfood briefs that aren't checked in. Replaced with a pointer to the smoke-test suite and the in-flight benchmark issue (#56).

**docs/quickstart.md, CONTRIBUTING.md**: refreshed `gpt-4o-mini` → `gpt-5.5` and stale test count `1307` → `1674`.

## Verification

- 1674/1674 tests pass (CI ran on push)
- ruff clean
- No code changes — docs only
