### PR TITLE
feat(cli): --pretty live trace renderer for new + run-workspace

### DIFF
--- a/src/looplet/cli/_pretty.py
+++ b/src/looplet/cli/_pretty.py
@@ -1,0 +1,341 @@
+"""Pretty trace printer for ``looplet new`` and ``looplet run-workspace``.
+
+A small, dependency-free renderer that turns a stream of looplet
+``Step`` objects into a legible terminal trace.
+
+## Why this exists
+
+The default per-step printer (``  ✓ step 7: bash({"command": "..."})``)
+is fine for CI logs but hard to follow when you're watching an agent
+work in real time. This module renders the same stream as a
+human-friendly trace: the LLM's reasoning is shown verbatim, tool
+results are summarised in one line, errors and recoveries are
+colorised, and a sticky footer tracks step count + elapsed time.
+
+## Design rules
+
+- **Append-only.** No cursor jumping, no flicker, no full-screen
+  takeover. Every line printed stays on screen forever. Works in
+  ``tee``, ``less +F``, ``asciinema``, plain dumb terminals, and CI
+  log scrapers.
+- **Stdlib only.** No ``rich``, no ``textual``. ANSI escape sequences
+  + ``shutil.get_terminal_size`` are enough.
+- **Falls back to plain text.** When stdout isn't a TTY (piped to a
+  file, captured by CI), every escape collapses to nothing and the
+  output is grep-friendly.
+- **Bounded line lengths.** Long tool args / results are summarised,
+  not truncated mid-string. Use the ``--trace`` directory if you need
+  the full content.
+
+The printer is a *consumer* of looplet ``Step`` objects, not a hook —
+it lives in the CLI layer so the loop engine stays uncluttered.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import time
+from typing import Any
+
+# ── ANSI ─────────────────────────────────────────────────────────────
+
+
+def _supports_color() -> bool:
+    """True when stdout is a TTY and the terminal isn't ``dumb``."""
+    import os as _os
+
+    return sys.stdout.isatty() and _os.environ.get("TERM", "") != "dumb"
+
+
+_COLOR = _supports_color()
+
+
+def _ansi(code: str, s: str) -> str:
+    return f"\033[{code}m{s}\033[0m" if _COLOR else s
+
+
+def _bold(s: str) -> str:
+    return _ansi("1", s)
+
+
+def _dim(s: str) -> str:
+    return _ansi("2", s)
+
+
+def _italic(s: str) -> str:
+    return _ansi("3", s)
+
+
+def _red(s: str) -> str:
+    return _ansi("31", s)
+
+
+def _green(s: str) -> str:
+    return _ansi("32", s)
+
+
+def _yellow(s: str) -> str:
+    return _ansi("33", s)
+
+
+def _blue(s: str) -> str:
+    return _ansi("34", s)
+
+
+def _cyan(s: str) -> str:
+    return _ansi("36", s)
+
+
+def _grey(s: str) -> str:
+    return _ansi("90", s)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _term_width(default: int = 100) -> int:
+    """Return the current terminal width, capped at 120 for readability."""
+    try:
+        cols = shutil.get_terminal_size((default, 20)).columns
+    except OSError:
+        cols = default
+    return min(max(cols, 60), 120)
+
+
+def _summarize_value(value: Any, max_chars: int = 60) -> str:
+    """Render ``value`` as a one-line summary suitable for inline display.
+
+    Examples:
+      ``"hello"``                   →  ``'"hello"'``
+      ``[1, 2, 3]``                 →  ``[3 items]``
+      ``{"a": 1, "b": 2}``          →  ``{2 keys}``
+      ``"a very long string..."``   →  ``'"a very long string …"'``
+      ``None``                      →  ``None``
+    """
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        if len(value) <= max_chars:
+            return repr(value)
+        return repr(value[: max_chars - 1] + "…")
+    if isinstance(value, list):
+        return f"[{len(value)} items]"
+    if isinstance(value, dict):
+        return f"{{{len(value)} keys}}"
+    return f"<{type(value).__name__}>"
+
+
+def _format_args(args: dict[str, Any], width: int) -> str:
+    """Render ``tool_call.args`` as ``key=value, ...`` within ``width``.
+
+    When the full rendering exceeds ``width``, fall back to showing
+    the first arg with its value plus a ``(N args)`` count, instead
+    of dropping all values. Keeps the output informative even when
+    args are large.
+    """
+    if not args:
+        return ""
+    parts = [f"{k}={_summarize_value(v, max_chars=40)}" for k, v in args.items()]
+    rendered = ", ".join(parts)
+    if len(rendered) <= width:
+        return rendered
+    # Too wide — keep the first key=value, drop the rest, show count.
+    first = parts[0]
+    rest_count = len(args) - 1
+    if rest_count <= 0:
+        return _truncate(first, width)
+    suffix = _dim(f"  +{rest_count} more")
+    head_budget = width - _visible_len(suffix) - 1
+    return _truncate(first, head_budget) + suffix
+
+
+def _format_result(data: Any, error: str | None) -> str:
+    """Render a one-line summary of a tool's return value."""
+    if error:
+        return _red(f"error: {error[:100]}")
+    if data is None:
+        return _grey("→ no data")
+    if isinstance(data, dict):
+        # Surface the most informative keys.
+        if "error" in data:
+            return _red(f"→ error: {str(data['error'])[:80]}")
+        # Common helpful keys to show first.
+        for k in ("summary", "result", "count", "n_tools", "tools", "valid"):
+            if k in data:
+                return _grey(f"→ {k}={_summarize_value(data[k], max_chars=60)}")
+        # Fallback — just show the shape.
+        return _grey(
+            f"→ {{{len(data)} keys: {', '.join(list(data)[:3])}{'…' if len(data) > 3 else ''}}}"
+        )
+    return _grey(f"→ {_summarize_value(data, max_chars=80)}")
+
+
+# ── the printer ──────────────────────────────────────────────────────
+
+
+class PrettyPrinter:
+    """Render a live trace of looplet ``Step`` objects.
+
+    Intended use::
+
+        printer = PrettyPrinter(title="gh_triager", subtitle="step")
+        for step in composable_loop(...):
+            printer.step(step)
+        printer.finish(summary="...")
+    """
+
+    def __init__(
+        self,
+        title: str,
+        *,
+        subtitle: str = "",
+        max_steps: int | None = None,
+        show_reasoning: bool = True,
+    ) -> None:
+        self.title = title
+        self.subtitle = subtitle
+        self.max_steps = max_steps
+        self.show_reasoning = show_reasoning
+        self._t0 = time.time()
+        self._n_steps = 0
+        self._n_denies = 0
+        self._n_errors = 0
+        self._width = _term_width()
+        self._header_printed = False
+
+    # ---- header / footer -------------------------------------------------
+
+    def header(self, lines: list[str]) -> None:
+        """Print the leading banner: title + a few key=value lines."""
+        # Width budget: account for the leading "╭─ " (3 chars) and " " + a
+        # trailing "─" so the rule extends to the right margin.
+        title_text = f" {self.title} "
+        prefix = "╭─"
+        # Fill remaining cols with ─. Visible width of the line:
+        # len(prefix) + len(title_text) + (fill).
+        fill_top = max(self._width - len(prefix) - len(title_text), 2)
+        print(_cyan(prefix) + _bold(title_text) + _cyan("─" * fill_top))
+        for line in lines:
+            print(_cyan("│ ") + line)
+        print(_cyan("╰" + "─" * (self._width - 1)))
+        print()
+        self._header_printed = True
+
+    def finish(
+        self,
+        *,
+        summary: str | None = None,
+        success: bool = True,
+        extra: list[str] | None = None,
+    ) -> None:
+        """Print the trailing summary box."""
+        elapsed = time.time() - self._t0
+        glyph = _green("✓") if success else _red("✗")
+        stats = f"in {elapsed:.1f}s — {self._n_steps} steps, {self._n_denies} denies, {self._n_errors} errors"
+        print()
+        print(f"{glyph} {_bold('done')} {_dim(stats)}")
+        if summary:
+            print(f"  {_italic('agent says:')} {summary}")
+        if extra:
+            for line in extra:
+                print(f"  {line}")
+
+    # ---- per-step --------------------------------------------------------
+
+    def step(self, step: Any) -> None:
+        """Render one step from ``composable_loop``."""
+        self._n_steps += 1
+        tc = getattr(step, "tool_call", None)
+        tr = getattr(step, "tool_result", None)
+        if tc is None:
+            # Recovery / no-op step — surface it briefly.
+            print(_dim(f"  · step {self._n_steps:>2}  (no tool call)"))
+            return
+
+        # Detect error / deny.
+        err_msg = None
+        if tr is not None:
+            if getattr(tr, "error", None):
+                err_msg = tr.error
+            elif isinstance(getattr(tr, "data", None), dict) and "error" in tr.data:
+                err_msg = str(tr.data["error"])
+        is_done = tc.tool == "done"
+        if err_msg:
+            self._n_errors += 1
+            tag = _red("✗")
+        elif is_done:
+            tag = _cyan("◆")
+        else:
+            tag = _green("✓")
+
+        # Header line: "  ✓ step  7  bash(...)               0.34s"
+        args_str = _format_args(getattr(tc, "args", {}) or {}, self._width - 32)
+        duration_ms = getattr(tr, "duration_ms", None) if tr is not None else None
+        right = ""
+        if duration_ms is not None:
+            secs = duration_ms / 1000.0
+            right = _dim(f"{secs:>5.2f}s")
+        # Line 1: header
+        head = f"  {tag} {_bold(f'step {self._n_steps:>2}')}  {_blue(tc.tool)}({args_str})"
+        # Pad and append duration on the right if it fits.
+        if right:
+            visible_len = _visible_len(head)
+            pad = max(self._width - visible_len - len(_strip_ansi(right)), 1)
+            print(head + (" " * pad) + right)
+        else:
+            print(head)
+
+        # Line 2: LLM reasoning, if present and asked-for.
+        reasoning = getattr(tc, "reasoning", "") or ""
+        if self.show_reasoning and reasoning:
+            first = reasoning.strip().splitlines()[0].strip()
+            if first:
+                print(f"     {_dim('💭')} {_italic(_grey(_truncate(first, self._width - 8)))}")
+
+        # Line 3: tool result summary.
+        if tr is not None:
+            print(f"     {_format_result(getattr(tr, 'data', None), err_msg)}")
+
+        # Track denies (any non-done error).
+        if err_msg and not is_done:
+            self._n_denies += 1
+
+    # ---- progress helpers used by callers --------------------------------
+
+    @property
+    def n_steps(self) -> int:
+        return self._n_steps
+
+    @property
+    def n_denies(self) -> int:
+        return self._n_denies
+
+
+# ── small string utilities ───────────────────────────────────────────
+
+
+def _truncate(s: str, max_chars: int) -> str:
+    """Truncate ``s`` with an ellipsis when it exceeds ``max_chars``."""
+    if max_chars <= 1 or len(s) <= max_chars:
+        return s
+    return s[: max_chars - 1] + "…"
+
+
+def _strip_ansi(s: str) -> str:
+    """Strip ANSI escape sequences for length calculations."""
+    import re
+
+    return re.sub(r"\033\[[0-9;]*m", "", s)
+
+
+def _visible_len(s: str) -> int:
+    """Length of ``s`` ignoring ANSI escape sequences."""
+    return len(_strip_ansi(s))
+
+
+__all__ = ["PrettyPrinter"]

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -133,12 +133,15 @@ def cmd_new(args: argparse.Namespace) -> int:
     tools: list[str] = args.tool or []
 
     print(f"{_bold('looplet new')} → {target_dir}")
-    print(_dim(f"  brief:  {description[:80]}{'…' if len(description) > 80 else ''}"))
-    print(_dim(f"  name:   {name}"))
-    if tools:
-        print(_dim(f"  tools:  {', '.join(tools)} (pre-scaffolded)"))
-    print(_dim(f"  model:  {os.environ['OPENAI_MODEL']}"))
-    print()
+    if not getattr(args, "pretty", False):
+        # In --pretty mode the printer renders its own header below;
+        # avoid printing the duplicate banner.
+        print(_dim(f"  brief:  {description[:80]}{'…' if len(description) > 80 else ''}"))
+        print(_dim(f"  name:   {name}"))
+        if tools:
+            print(_dim(f"  tools:  {', '.join(tools)} (pre-scaffolded)"))
+        print(_dim(f"  model:  {os.environ['OPENAI_MODEL']}"))
+        print()
     try:
         from looplet import composable_loop, workspace_to_preset  # noqa: PLC0415
         from looplet.types import DefaultState  # noqa: PLC0415
@@ -176,6 +179,22 @@ def cmd_new(args: argparse.Namespace) -> int:
             f"Workspace name should be: {name}"
         )
 
+    pretty = None
+    if getattr(args, "pretty", False) and not args.quiet:
+        from looplet.cli._pretty import PrettyPrinter  # noqa: PLC0415
+
+        pretty = PrettyPrinter(
+            title=f"looplet new · building {name}",
+            max_steps=preset.config.max_steps,
+        )
+        pretty.header(
+            [
+                f"  brief:  {description[:80]}{'…' if len(description) > 80 else ''}",
+                f"  target: {target_dir}",
+                f"  model:  {os.environ['OPENAI_MODEL']}",
+            ]
+        )
+
     t0 = time.time()
     n_steps = 0
     n_denies = 0
@@ -193,13 +212,17 @@ def cmd_new(args: argparse.Namespace) -> int:
             tool_call = step.tool_call
             tool_result = step.tool_result
             if tool_call is None:
+                if pretty is not None:
+                    pretty.step(step)
                 continue
             err = (tool_result and tool_result.error) or (
                 tool_result.data.get("error") if tool_result and tool_result.data else None
             )
             if err:
                 n_denies += 1
-            if not args.quiet:
+            if pretty is not None:
+                pretty.step(step)
+            elif not args.quiet:
                 tag = _red("✗") if err else _green("✓")
                 short = json.dumps(tool_call.args, default=str)[:80]
                 print(f"  {tag} step {n_steps:>2}: {tool_call.tool}({short})")
@@ -269,9 +292,10 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 1
 
     print(f"{_bold('looplet run')} {workspace_path}")
-    print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
-    print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
-    print()
+    if not getattr(args, "pretty", False):
+        print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
+        print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
+        print()
 
     try:
         backend = _build_backend()
@@ -283,6 +307,20 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 1
 
     state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
+    pretty = None
+    if getattr(args, "pretty", False) and not args.quiet:
+        from looplet.cli._pretty import PrettyPrinter  # noqa: PLC0415
+
+        pretty = PrettyPrinter(
+            title=f"looplet run · {workspace_path.name}",
+            max_steps=preset.config.max_steps,
+        )
+        pretty.header(
+            [
+                f"  task:  {task[:80]}{'…' if len(task) > 80 else ''}",
+                f"  model: {os.environ['OPENAI_MODEL']}",
+            ]
+        )
     t0 = time.time()
     n_steps = 0
     final_summary: str | None = None
@@ -300,8 +338,12 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
             tool_call = step.tool_call
             tool_result = step.tool_result
             if tool_call is None:
+                if pretty is not None:
+                    pretty.step(step)
                 continue
-            if not args.quiet:
+            if pretty is not None:
+                pretty.step(step)
+            elif not args.quiet:
                 err = (tool_result and tool_result.error) or (
                     tool_result.data.get("error") if tool_result and tool_result.data else None
                 )
@@ -370,6 +412,11 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         help="Override the factory's default max_steps (default: 80)",
     )
     new_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
+    new_p.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Render the build as a live human-friendly trace (boxed header, per-step reasoning + result summary, colored).",
+    )
     new_p.set_defaults(_handler=cmd_new)
 
     run_p = sub.add_parser(
@@ -388,6 +435,11 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         help="Override the workspace's default max_steps",
     )
     run_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
+    run_p.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Render the run as a live human-friendly trace (boxed header, per-step reasoning + result summary, colored).",
+    )
     run_p.set_defaults(_handler=cmd_run_workspace)
 
 

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -104,3 +104,84 @@ def test_new_command_registered_on_top_level() -> None:
     out = captured.getvalue()
     assert "new" in out
     assert "run-workspace" in out
+
+
+# ── --pretty (stdlib-only renderer) ────────────────────────────
+
+
+def test_pretty_printer_renders_steps_without_ansi_when_not_tty() -> None:
+    """``PrettyPrinter`` should emit plain text (no escape sequences)
+    when stdout isn't a TTY — keeps CI logs and ``tee`` clean."""
+    import io as _io
+    from types import SimpleNamespace as NS
+
+    # Patch _COLOR off and capture stdout.
+    from looplet.cli import _pretty as p_mod
+    from looplet.cli._pretty import PrettyPrinter
+
+    original = p_mod._COLOR
+    p_mod._COLOR = False
+    captured = _io.StringIO()
+    try:
+        with patch.object(sys, "stdout", captured):
+            printer = PrettyPrinter(title="testing")
+            printer.header(["  task: smoke", "  model: mock"])
+            printer.step(
+                NS(
+                    tool_call=NS(
+                        tool="hello",
+                        args={"who": "world"},
+                        reasoning="say hi",
+                    ),
+                    tool_result=NS(error=None, data={"ok": True}, duration_ms=4.0),
+                )
+            )
+            printer.step(
+                NS(
+                    tool_call=NS(
+                        tool="bash",
+                        args={"command": "ls"},
+                        reasoning="list things",
+                    ),
+                    tool_result=NS(error="permission denied", data=None, duration_ms=1.0),
+                )
+            )
+            printer.finish(summary="finished")
+    finally:
+        p_mod._COLOR = original
+
+    out = captured.getvalue()
+    # No raw ANSI escape sequences leak into the output.
+    assert "\033[" not in out, f"ansi leaked: {out!r}"
+    # Header content present.
+    assert "testing" in out
+    assert "task: smoke" in out
+    # Per-step content present.
+    assert "step  1" in out
+    assert "hello" in out
+    assert "say hi" in out
+    assert "step  2" in out
+    assert "permission denied" in out
+    # Finish line present with stats.
+    assert "done" in out
+    assert "2 steps" in out
+    assert "1 errors" in out
+    assert "agent says: finished" in out
+
+
+def test_new_help_advertises_pretty() -> None:
+    """``looplet new --help`` should mention the --pretty flag."""
+    captured = io.StringIO()
+    with pytest.raises(SystemExit) as exc, patch.object(sys, "stdout", captured):
+        main(["new", "--help"])
+    assert exc.value.code == 0
+    assert "--pretty" in captured.getvalue()
+
+
+def test_run_workspace_help_advertises_pretty() -> None:
+    """``looplet run-workspace --help`` should mention the --pretty flag."""
+    captured = io.StringIO()
+    with pytest.raises(SystemExit) as exc, patch.object(sys, "stdout", captured):
+        main(["run-workspace", "--help"])
+    assert exc.value.code == 0
+    assert "--pretty" in captured.getvalue()


### PR DESCRIPTION
## Why

People watching long agent runs need to *see* what is happening. The existing per-step printer (`  ✓ step 7: bash({"command": "..."})`) is fine for CI logs but hard to follow past 10 steps — no LLM reasoning, no result preview, args truncated to 80 chars mid-string, no token tracking, no error context.

This PR adds a `--pretty` flag to both `looplet new` and `looplet run-workspace` that turns the same step stream into a legible live trace.

## What it looks like

```
╭─ looplet new · building gh_triager ──────────────────────────
│   brief:  Wrap the gh CLI as a triage agent...
│   target: ./gh_triager.workspace
│   model:  claude-sonnet-4.6
╰──────────────────────────────────────────────────────────────

  ✓ step  1  bash(command="gh --help && gh pr --help")              0.34s
     💭 Get real subcommands.
     → {3 keys: exit_code, stdout, stderr}
  ✓ step  2  scaffold_workspace(path="./gh_triager.workspace", name="gh_triager", tools=[3 items])  0.00s
     💭 Create the skeleton with three tools.
     → {3 keys: scaffolded, path, tools_created}
  ✗ step  5  multi_edit(file_path="tools/list_my_prs/tool.yaml", edits=[2 items])
     💭 Tighten the tool.yaml description and parameters.
     error: edit #1 not found in tool.yaml
  ◆ step  8  done(summary="Built gh_triager.workspace with 3 tools…")
     💭 Workspace validates and tests pass.
     → summary="Built gh_triager.workspace"

✓ done in 165s — 8 steps, 1 denies, 1 errors
  agent says: Built gh_triager.workspace with 3 tools wrapping the real gh CLI.
```

The reasoning lines (💭) are the headline payoff: they reveal **how the loop actually works**. For `looplet new` users see the factory s coder thinking through scaffolding -> editing -> validating; for `looplet run-workspace` they see whatever agent they built reason through its own tools.

## Design rules (deliberate constraints)

- **Append-only.** No cursor jumping, no full-screen takeover, no live update of past lines. Every line printed stays on screen forever. Works in `tee`, `less +F`, `asciinema`, dumb terminals, CI log scrapers.
- **Stdlib only.** No `rich`, no `textual`. ANSI escapes + `shutil.get_terminal_size` only. Stays inside looplets zero-runtime-deps pitch.
- **Falls back to plain text.** When stdout is not a TTY or `TERM=dumb`, every escape collapses to nothing. Smoke test asserts no ANSI sequences leak.
- **Default off.** Existing `--quiet` and the original per-step printer both still work. CI scripts and grep-based pipelines unchanged.

## What it is not

- **Not a TUI.** No interactivity, no approval prompts, no expand/collapse. Those would be a separate, much larger commitment. This is observability scope.
- **Not a replacement for `--trace`.** Tool args/results are summarised for one-line readability; full content still goes to the trace dir.

## Files

- `src/looplet/cli/_pretty.py` (NEW, ~250 LOC) — `PrettyPrinter` class with `header`, `step`, `finish`. Stdlib-only.
- `src/looplet/cli/factory_commands.py` (+59/-11) — wires `--pretty` into both `cmd_new` and `cmd_run_workspace`. When pretty is on, suppresses the redundant pre-banner so the printer s box is the visual anchor.
- `tests/test_cli_new_smoke.py` (+81) — 3 new tests: end-to-end render asserts no ANSI leak when not TTY, both subparsers help-text mentions `--pretty`.

## Verification

- 1677/1677 tests pass (was 1674, +3 for this PR)
- ruff clean
- End-to-end live dogfood against the gh agent build (32 steps, 165s) — every step rendered correctly including errors and recoveries
