### PR TITLE
Improve coder workspace capabilities

### DIFF
--- a/examples/coder.workspace/prompts/system.md
+++ b/examples/coder.workspace/prompts/system.md
@@ -1,20 +1,28 @@
 You are an expert software engineer. You solve tasks by understanding the codebase, planning carefully, making precise changes, and verifying with tests. You never guess — you read first, then act.
 
 ## Workflow
-1. EXPLORE: list_dir to see structure. glob/grep to find relevant files.
-2. READ: read_file on files you need to modify. Understand patterns and conventions.
-3. PLAN: think() to plan approach. Break complex tasks into steps.
-4. IMPLEMENT: edit_file for existing files, write_file for new files. One file at a time.
-5. TEST: bash to run tests after EVERY change. Read failures. Fix and re-run.
-6. DONE: done() with summary only after tests pass.
+1. PLAN: for non-trivial work, call todo() with a short checklist and update it as you progress.
+2. EXPLORE: list_dir to see structure. glob/grep to find relevant files. Prefer grep over bash search commands.
+3. READ: read_file on files you need to modify. Understand patterns and conventions.
+4. THINK: use think() when you need to reconsider an approach or compare options.
+5. IMPLEMENT: edit_file or multi_edit for existing files, write_file for new files. Use notebook_edit for .ipynb files.
+6. INSPECT: use git_inspect for git status/diff/recent commits. Use web_fetch for public docs when external context is needed.
+7. DELEGATE: use subagent() for bounded investigations or review passes that can return concise findings.
+8. ISOLATE: use worktree() when you need a separate git worktree for an experiment.
+9. TEST: bash to run tests after EVERY change. Read failures. Fix and re-run.
+10. DONE: done() with summary only after tests pass.
 
 ## Tool rules
 - ALWAYS read_file before edit_file. Never edit blind.
 - edit_file: copy-paste old_string from read_file output exactly. Include 3+ context lines.
 - If edit fails "not found": read the hint lines, re-read file at those lines, retry with exact text.
 - If edit fails "multiple matches": add more surrounding lines for uniqueness.
-- write_file: NEW files only. Never overwrite files you should edit.
+- write_file: NEW files by default. Overwriting an existing file requires read_file first and fresh file state.
+- grep: use output_mode, glob/type filters, context, head_limit, and offset to keep search results focused.
+- notebook_edit: use for notebooks; do not edit raw notebook JSON with edit_file unless notebook_edit cannot express the change.
+- git_inspect: use for read-only git status/diff/log instead of bash git commands.
 - bash: use relative paths. pytest -xvs for tests (stop on first failure).
+- worktree remove requires explicit confirmation; never remove a worktree unless it was created for this task.
 - For bugs: write a failing test FIRST, then fix the code.
 
 ## Code quality

--- a/examples/coder.workspace/tools/git_inspect/execute.py
+++ b/examples/coder.workspace/tools/git_inspect/execute.py
@@ -1,0 +1,63 @@
+"""git_inspect tool — safe read-only git helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from looplet.types import ToolContext
+
+
+def _run(workspace: str, args: list[str]) -> dict:
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, capture_output=True, text=True, timeout=30
+    )
+    return {
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def execute(
+    ctx: ToolContext, *, operation: str = "status", pathspec: str = "", max_count: int = 10
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    probe = _run(workspace, ["rev-parse", "--is-inside-work-tree"])
+    if probe["exit_code"] != 0:
+        return {"error": "Not inside a git worktree", "stderr": probe["stderr"]}
+    op = operation.strip().lower() or "status"
+    if op == "status":
+        args = ["status", "--short", "--branch"]
+    elif op == "diff":
+        args = ["diff"] + (["--", pathspec] if pathspec else [])
+    elif op == "diff_stat":
+        args = ["diff", "--stat"] + (["--", pathspec] if pathspec else [])
+    elif op == "branch":
+        args = ["branch", "--show-current"]
+    elif op == "recent":
+        args = ["log", "--oneline", "--decorate", "-n", str(max(1, int(max_count or 10)))]
+    elif op == "changed_files":
+        args = ["diff", "--name-only"] + (["--", pathspec] if pathspec else [])
+    else:
+        return {
+            "error": f"unknown operation {operation!r}",
+            "valid_operations": [
+                "status",
+                "diff",
+                "diff_stat",
+                "branch",
+                "recent",
+                "changed_files",
+            ],
+        }
+    result = _run(workspace, args)
+    result.update({"operation": op, "command": "git " + " ".join(args)})
+    if len(result["stdout"]) > 20000:
+        result["stdout"] = (
+            result["stdout"][:10000]
+            + "\n... [git output truncated] ...\n"
+            + result["stdout"][-10000:]
+        )
+        result["truncated"] = True
+    return result

--- a/examples/coder.workspace/tools/git_inspect/tool.yaml
+++ b/examples/coder.workspace/tools/git_inspect/tool.yaml
@@ -1,0 +1,29 @@
+name: git_inspect
+description: |-
+  Inspect git repository state with safe, read-only git commands.
+
+  Usage:
+  - Prefer this over ad-hoc `bash` for git status, diffs, changed files, current branch, and recent commits.
+  - This tool never commits, pushes, checks out, resets, or modifies files.
+  - Use `pathspec` to scope `diff`, `diff_stat`, or `changed_files` to one file or directory.
+
+  Examples:
+  - `git_inspect(operation="status")`
+  - `git_inspect(operation="diff", pathspec="src/")`
+  - `git_inspect(operation="recent", max_count=5)`
+parameters:
+  operation:
+    type: string
+    description: status, diff, diff_stat, branch, recent, or changed_files.
+    default: status
+  pathspec:
+    type: string
+    description: Optional git pathspec for diff operations.
+    default: ""
+  max_count:
+    type: integer
+    description: Maximum recent commits for operation=recent.
+    default: 10
+concurrent_safe: true
+requires:
+  - workspace_config

--- a/examples/coder.workspace/tools/grep/execute.py
+++ b/examples/coder.workspace/tools/grep/execute.py
@@ -1,4 +1,4 @@
-"""grep tool — recursive grep with workspace-relative output paths.
+"""grep tool — rg-first recursive search with workspace-relative output paths.
 
 Receives the workspace_config resource through ``ctx.resources``;
 ``tool.yaml`` declares ``requires: [workspace_config]``.
@@ -7,6 +7,7 @@ Receives the workspace_config resource through ``ctx.resources``;
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -15,16 +16,104 @@ from coder_lib_tools import _resolve_safe_path
 from looplet.types import ToolContext
 
 
-def execute(ctx: ToolContext, *, pattern: str, path: str = ".", include: str = "") -> dict:
+def _relativize(lines: list[str], workspace: str) -> list[str]:
+    workspace_prefix = str(Path(workspace).resolve()) + os.sep
+    return [
+        line.removeprefix(workspace_prefix) if line.startswith(workspace_prefix) else line
+        for line in lines
+    ]
+
+
+def _page(items: list[str], head_limit: int, offset: int) -> tuple[list[str], bool]:
+    safe_offset = max(0, int(offset or 0))
+    if head_limit == 0:
+        return items[safe_offset:], False
+    limit = max(1, int(head_limit or 250))
+    sliced = items[safe_offset : safe_offset + limit]
+    return sliced, len(items) - safe_offset > limit
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    pattern: str,
+    path: str = ".",
+    include: str = "",
+    glob: str = "",
+    output_mode: str = "content",
+    type: str = "",
+    context: int = 0,
+    before: int = 0,
+    after: int = 0,
+    case_insensitive: bool = False,
+    head_limit: int = 250,
+    offset: int = 0,
+    multiline: bool = False,
+    max_count: int = 0,
+) -> dict:
     cfg = ctx.resources.get("workspace_config")
     workspace = cfg.path if cfg is not None else "."
     target = _resolve_safe_path(workspace, path)
     if target is None:
         return {"error": f"Path '{path}' is outside the project directory."}
-    cmd = ["grep", "-rn"]
-    if include:
-        cmd.append(f"--include={include}")
-    cmd.extend(["--", pattern, str(target)])
+    if not target.exists():
+        return {"error": f"Path not found: {path}", "matches": [], "count": 0}
+
+    mode = (output_mode or "content").strip().lower()
+    if mode not in {"content", "files_with_matches", "count"}:
+        return {
+            "error": f"unknown output_mode {output_mode!r}",
+            "valid_modes": ["content", "files_with_matches", "count"],
+        }
+
+    rg = shutil.which("rg")
+    file_glob = glob or include
+    if rg:
+        cmd = [rg, "--color", "never"]
+        if mode == "content":
+            cmd.append("--line-number")
+            if context > 0:
+                cmd.extend(["-C", str(context)])
+            else:
+                if before > 0:
+                    cmd.extend(["-B", str(before)])
+                if after > 0:
+                    cmd.extend(["-A", str(after)])
+        elif mode == "files_with_matches":
+            cmd.append("--files-with-matches")
+        else:
+            cmd.append("--count-matches")
+        if case_insensitive:
+            cmd.append("-i")
+        if multiline:
+            cmd.extend(["-U", "--multiline-dotall"])
+        if file_glob:
+            cmd.extend(["--glob", file_glob])
+        if type:
+            cmd.extend(["--type", type])
+        if max_count > 0:
+            cmd.extend(["--max-count", str(max_count)])
+        cmd.extend(["--", pattern, str(target)])
+        engine = "rg"
+    else:
+        cmd = ["grep", "-rn"]
+        if case_insensitive:
+            cmd.append("-i")
+        if mode == "files_with_matches":
+            cmd.append("-l")
+        elif mode == "count":
+            cmd.append("-c")
+        elif context > 0:
+            cmd.extend(["-C", str(context)])
+        else:
+            if before > 0:
+                cmd.extend(["-B", str(before)])
+            if after > 0:
+                cmd.extend(["-A", str(after)])
+        if file_glob:
+            cmd.append(f"--include={file_glob}")
+        cmd.extend(["--", pattern, str(target)])
+        engine = "grep"
     try:
         result = subprocess.run(
             cmd,
@@ -34,14 +123,35 @@ def execute(ctx: ToolContext, *, pattern: str, path: str = ".", include: str = "
             cwd=workspace,
         )
     except subprocess.TimeoutExpired:
-        return {"error": "Search timed out", "pattern": pattern, "matches": [], "count": 0}
-    lines = result.stdout.splitlines() if result.stdout else []
-    workspace_prefix = str(Path(workspace).resolve()) + os.sep
-    relative_lines = [
-        line.removeprefix(workspace_prefix) if line.startswith(workspace_prefix) else line
-        for line in lines
-    ]
-    data = {"pattern": pattern, "matches": relative_lines[:50], "count": len(relative_lines)}
+        return {
+            "error": "Search timed out",
+            "pattern": pattern,
+            "matches": [],
+            "count": 0,
+            "engine": engine,
+        }
+    lines = _relativize(result.stdout.splitlines() if result.stdout else [], workspace)
+    paged, truncated = _page(lines, head_limit=head_limit, offset=offset)
+    data = {
+        "pattern": pattern,
+        "path": path,
+        "mode": mode,
+        "engine": engine,
+        "matches": paged,
+        "count": len(lines),
+        "truncated": truncated,
+        "offset": max(0, int(offset or 0)),
+    }
+    if mode == "files_with_matches":
+        data["filenames"] = paged
+    elif mode == "count":
+        data["counts"] = paged
+    else:
+        data["content"] = "\n".join(paged)
     if result.returncode not in (0, 1):
         data["error"] = result.stderr.strip() or f"grep exited {result.returncode}"
+    if truncated:
+        data["recovery"] = (
+            "Use a narrower path/glob/type, increase offset, or set head_limit=0 only when the result is known to be small."
+        )
     return data

--- a/examples/coder.workspace/tools/grep/tool.yaml
+++ b/examples/coder.workspace/tools/grep/tool.yaml
@@ -1,29 +1,76 @@
 name: grep
 description: |-
-  Recursively search file contents using `grep -rn`. Returns `path:line:content` matches.
+  Recursively search file contents using `rg` when available, with a `grep -rn` fallback. Returns paginated, workspace-relative matches.
 
   Usage:
   - Use this to find files by CONTENT (e.g. "where is function foo defined?", "which files import X?"). Use `glob` to find files by NAME pattern.
-  - The pattern is passed to `grep` directly so you get the full grep regex syntax. Quote the pattern if it contains special chars.
+  - The pattern is passed to ripgrep/grep directly so you get regex syntax. Quote or escape special chars when needed.
   - `path` defaults to the project root; pass a subdir to narrow the search.
-  - `include` is passed as `--include=<glob>` so you can scope by file type without two grep calls (e.g. `include="*.py"` ignores non-Python files).
-  - Output capped at 50 matches and 10s timeout. For massive codebases, narrow the path or include first.
+  - Use `glob` or legacy `include` to scope by file pattern (e.g. `glob="*.py"` or `glob="*.{js,ts}"`).
+  - `output_mode="content"` returns matching lines; `files_with_matches` returns only file paths; `count` returns per-file counts.
+  - Use `context`, `before`, or `after` to include neighboring lines in content mode.
+  - Use `head_limit` and `offset` to page through large results. Default cap is 250 results.
 
   Examples:
-  - `grep(pattern="def authenticate", include="*.py")` — find Python defs of authenticate
-  - `grep(pattern="TODO|FIXME", path="src/")` — find every TODO in src/
+  - `grep(pattern="def authenticate", glob="*.py", output_mode="content")` — find Python defs of authenticate
+  - `grep(pattern="TODO|FIXME", path="src/", output_mode="files_with_matches")` — find files with TODOs in src/
+  - `grep(pattern="class User", type="py", context=2)` — show matches with two lines of context
 parameters:
   pattern:
     type: string
-    description: Regex pattern (grep-style; basic regex by default, no need to escape `[]`).
+    description: Regex pattern to search for.
   path:
     type: string
     description: Directory to search in, relative to project root.
     default: "."
   include:
     type: string
-    description: Optional grep `--include=<glob>` filter (e.g. "*.py", "*.{js,ts}").
+    description: Legacy file glob filter. Prefer `glob` for new calls.
     default: ""
+  glob:
+    type: string
+    description: File glob filter (e.g. "*.py", "*.{js,ts}").
+    default: ""
+  output_mode:
+    type: string
+    description: One of content, files_with_matches, count.
+    default: content
+  type:
+    type: string
+    description: Ripgrep file type filter such as py, js, rust, go. Ignored by grep fallback.
+    default: ""
+  context:
+    type: integer
+    description: Lines before and after each match in content mode.
+    default: 0
+  before:
+    type: integer
+    description: Lines before each match in content mode.
+    default: 0
+  after:
+    type: integer
+    description: Lines after each match in content mode.
+    default: 0
+  case_insensitive:
+    type: boolean
+    description: Case-insensitive search.
+    default: false
+  head_limit:
+    type: integer
+    description: Maximum result lines/items to return. Use 0 for unlimited.
+    default: 250
+  offset:
+    type: integer
+    description: Number of result lines/items to skip before applying head_limit.
+    default: 0
+  multiline:
+    type: boolean
+    description: Enable ripgrep multiline mode when rg is available.
+    default: false
+  max_count:
+    type: integer
+    description: Stop after this many matches per file when rg is available. 0 means no per-file cap.
+    default: 0
 concurrent_safe: true
 requires:
   - workspace_config

--- a/examples/coder.workspace/tools/notebook_edit/execute.py
+++ b/examples/coder.workspace/tools/notebook_edit/execute.py
@@ -1,0 +1,130 @@
+"""notebook_edit tool — structural JSON edits for .ipynb files."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from coder_lib_tools import _resolve_safe_path, atomic_write_text
+
+from looplet.types import ToolContext
+
+
+def _as_source(value: str, like: Any | None = None) -> str | list[str]:
+    if isinstance(like, list):
+        if not value:
+            return []
+        return value.splitlines(keepends=True)
+    return value
+
+
+def _make_cell(cell_type: str, source: str) -> dict[str, Any]:
+    cell_id = uuid.uuid4().hex[:8]
+    cell: dict[str, Any] = {
+        "cell_type": cell_type,
+        "id": cell_id,
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+    }
+    if cell_type == "code":
+        cell["execution_count"] = None
+        cell["outputs"] = []
+    return cell
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    notebook_path: str,
+    cell_id: str = "",
+    new_source: str = "",
+    cell_type: str = "",
+    edit_mode: str = "replace",
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, notebook_path)
+    if p is None:
+        return {"error": f"Path '{notebook_path}' is outside the project directory."}
+    if p.suffix != ".ipynb":
+        return {"error": "notebook_edit only edits .ipynb files"}
+    if not p.exists():
+        return {"error": f"Notebook not found: {notebook_path}"}
+    if cache is not None:
+        if not cache.was_read(notebook_path):
+            return {
+                "error": f"Cannot edit {notebook_path!r}: notebook has not been read in this session.",
+                "missing": "prior_read",
+                "recovery": f"read_file(file_path={notebook_path!r})",
+            }
+        if not cache.is_unchanged(notebook_path):
+            return {
+                "error": f"Cannot edit {notebook_path!r}: notebook changed since last read.",
+                "stale": True,
+                "recovery": f"read_file(file_path={notebook_path!r})",
+            }
+    try:
+        notebook = json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        return {"error": f"Notebook is not valid JSON: {exc}"}
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        return {"error": "Notebook JSON missing cells list"}
+    mode = edit_mode.strip().lower() or "replace"
+    if mode not in {"replace", "insert", "delete"}:
+        return {
+            "error": f"unknown edit_mode {edit_mode!r}",
+            "valid_modes": ["replace", "insert", "delete"],
+        }
+    normalized_type = cell_type.strip().lower()
+    if normalized_type and normalized_type not in {"code", "markdown"}:
+        return {"error": "cell_type must be code or markdown"}
+
+    target_index = next(
+        (i for i, cell in enumerate(cells) if isinstance(cell, dict) and cell.get("id") == cell_id),
+        None,
+    )
+    if mode in {"replace", "delete"} and target_index is None:
+        return {
+            "error": f"cell_id {cell_id!r} not found",
+            "available_cell_ids": [cell.get("id") for cell in cells if isinstance(cell, dict)],
+        }
+
+    original_cell_count = len(cells)
+    if mode == "replace":
+        cell = cells[target_index]
+        if not isinstance(cell, dict):
+            return {"error": f"cell_id {cell_id!r} is not an object cell"}
+        final_type = normalized_type or str(cell.get("cell_type", "code"))
+        cell["cell_type"] = final_type
+        cell["source"] = _as_source(new_source, cell.get("source"))
+        if final_type == "code":
+            cell.setdefault("execution_count", None)
+            cell.setdefault("outputs", [])
+        else:
+            cell.pop("execution_count", None)
+            cell.pop("outputs", None)
+        changed_cell_id = cell.get("id")
+    elif mode == "insert":
+        final_type = normalized_type or "code"
+        new_cell = _make_cell(final_type, new_source)
+        insert_at = len(cells) if target_index is None else target_index + 1
+        cells.insert(insert_at, new_cell)
+        changed_cell_id = new_cell["id"]
+    else:
+        removed = cells.pop(target_index)
+        changed_cell_id = removed.get("id") if isinstance(removed, dict) else cell_id
+
+    atomic_write_text(p, json.dumps(notebook, indent=1, ensure_ascii=False) + "\n")
+    if cache is not None:
+        cache.invalidate(notebook_path)
+    return {
+        "notebook_path": notebook_path,
+        "edit_mode": mode,
+        "cell_id": changed_cell_id,
+        "cell_type": normalized_type or ("" if mode == "delete" else "code"),
+        "old_cell_count": original_cell_count,
+        "new_cell_count": len(cells),
+    }

--- a/examples/coder.workspace/tools/notebook_edit/tool.yaml
+++ b/examples/coder.workspace/tools/notebook_edit/tool.yaml
@@ -1,0 +1,38 @@
+name: notebook_edit
+description: |-
+  Structurally edit Jupyter notebook cells in `.ipynb` files.
+
+  Usage:
+  - Use this instead of `edit_file` for notebooks so cell JSON stays valid.
+  - Requires `read_file` on the notebook first, and refuses if the notebook changed since that read.
+  - `edit_mode="replace"` replaces an existing cell's source by `cell_id`.
+  - `edit_mode="insert"` inserts a new cell after `cell_id`, or appends when `cell_id` is empty.
+  - `edit_mode="delete"` deletes an existing cell by `cell_id`.
+  - `cell_type` is `code` or `markdown`; for replace it defaults to the current cell type.
+
+  Examples:
+  - `notebook_edit(notebook_path="analysis.ipynb", cell_id="abc123", new_source="print(result)", edit_mode="replace")`
+  - `notebook_edit(notebook_path="analysis.ipynb", new_source="# Notes", cell_type="markdown", edit_mode="insert")`
+parameters:
+  notebook_path:
+    type: string
+    description: Notebook path relative to the project root.
+  cell_id:
+    type: string
+    description: Target cell id. Required for replace/delete; optional insertion anchor for insert.
+    default: ""
+  new_source:
+    type: string
+    description: New source text for replace/insert. Ignored for delete.
+    default: ""
+  cell_type:
+    type: string
+    description: code or markdown. Required for insert; optional for replace.
+    default: ""
+  edit_mode:
+    type: string
+    description: replace, insert, or delete.
+    default: replace
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder.workspace/tools/subagent/execute.py
+++ b/examples/coder.workspace/tools/subagent/execute.py
@@ -1,0 +1,38 @@
+"""subagent tool — workspace wrapper around looplet.subagent.run_sub_loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet import workspace_to_preset
+from looplet.subagent import run_sub_loop
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, prompt: str, max_steps: int = 5, system_prompt: str = "") -> dict:
+    if ctx.llm is None:
+        return {
+            "error": "subagent requires an active ctx.llm from composable_loop; direct dispatch cannot run it.",
+            "recovery": "Call subagent from inside a running looplet loop, or run run_sub_loop directly in Python.",
+        }
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    coder_workspace = Path(__file__).resolve().parents[2]
+    preset = workspace_to_preset(str(coder_workspace), runtime={"workspace": workspace})
+    result = run_sub_loop(
+        llm=ctx.llm,
+        task={"goal": prompt},
+        tools=preset.tools,
+        max_steps=max(1, int(max_steps or 5)),
+        system_prompt=system_prompt
+        or "You are a focused coding sub-agent. Investigate the requested task and return concise findings.",
+        state_mutating_tools=["done", "subagent"],
+    )
+    return {
+        "summary": result.get("summary", ""),
+        "findings": result.get("findings", []),
+        "highlights": result.get("highlights", []),
+        "step_count": len(result.get("steps", [])),
+        "llm_calls": result.get("llm_calls", 0),
+        "subagent_id": result.get("subagent_id"),
+    }

--- a/examples/coder.workspace/tools/subagent/tool.yaml
+++ b/examples/coder.workspace/tools/subagent/tool.yaml
@@ -1,0 +1,27 @@
+name: subagent
+description: |-
+  Run a focused looplet coder sub-agent with isolated context and return its concise result.
+
+  Usage:
+  - Use this for bounded investigations, code review passes, or parallelizable research where raw intermediate output would distract the parent agent.
+  - Requires the host loop to provide `ctx.llm`; direct tool dispatch without an active LLM returns an actionable error.
+  - The sub-agent loads this same coder workspace against the current project root and excludes `done` and `subagent` from its cloned tool set.
+  - Keep prompts narrow and concrete. The sub-agent has its own max step budget.
+
+  Examples:
+  - `subagent(prompt="Review src/auth.py for missing tests and summarize findings", max_steps=4)`
+  - `subagent(prompt="Find where config is loaded and return the key files", system_prompt="You are a codebase cartographer.")`
+parameters:
+  prompt:
+    type: string
+    description: Focused task for the sub-agent.
+  max_steps:
+    type: integer
+    description: Maximum tool calls available to the sub-agent.
+    default: 5
+  system_prompt:
+    type: string
+    description: Optional system prompt override for the sub-agent.
+    default: ""
+requires:
+  - workspace_config

--- a/examples/coder.workspace/tools/todo/execute.py
+++ b/examples/coder.workspace/tools/todo/execute.py
@@ -1,0 +1,149 @@
+"""todo tool — persistent checklist for coder.workspace sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from looplet.types import ToolContext
+
+_VALID_STATUSES = {"not-started", "in-progress", "completed", "blocked"}
+
+
+def _todo_path(workspace: str) -> Path:
+    scratch = Path(workspace) / ".coder_scratch"
+    scratch.mkdir(parents=True, exist_ok=True)
+    return scratch / "todos.json"
+
+
+def _load(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _save(path: Path, todos: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(todos, indent=2) + "\n")
+
+
+def _normalize_items(items: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(items, start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"todo item #{index} must be an object")
+        title = str(raw.get("title", "")).strip()
+        if not title:
+            raise ValueError(f"todo item #{index} missing non-empty title")
+        status = str(raw.get("status", "not-started")).strip() or "not-started"
+        if status not in _VALID_STATUSES:
+            raise ValueError(f"todo item #{index} has invalid status {status!r}")
+        item: dict[str, Any] = {
+            "id": int(raw.get("id") or index),
+            "title": title,
+            "status": status,
+        }
+        notes = str(raw.get("notes", "")).strip()
+        if notes:
+            item["notes"] = notes
+        normalized.append(item)
+    # Reassign ids so list state stays compact and deterministic.
+    for index, item in enumerate(normalized, start=1):
+        item["id"] = index
+    return normalized
+
+
+def _status_counts(todos: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        status: sum(1 for item in todos if item.get("status") == status)
+        for status in sorted(_VALID_STATUSES)
+    }
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    operation: str = "list",
+    todos: list | None = None,
+    id: int = 0,
+    title: str = "",
+    status: str = "",
+    notes: str = "",
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    path = _todo_path(workspace)
+    op = operation.strip().lower()
+    current = _load(path)
+
+    try:
+        if op == "list":
+            updated = current
+        elif op == "replace":
+            updated = _normalize_items(list(todos or []))
+            _save(path, updated)
+        elif op == "add":
+            item_title = title.strip()
+            if not item_title:
+                return {"error": "operation=add requires a non-empty title"}
+            item_status = status.strip() or "not-started"
+            if item_status not in _VALID_STATUSES:
+                return {
+                    "error": f"invalid status {item_status!r}",
+                    "valid_statuses": sorted(_VALID_STATUSES),
+                }
+            updated = list(current)
+            item: dict[str, Any] = {
+                "id": len(updated) + 1,
+                "title": item_title,
+                "status": item_status,
+            }
+            item_notes = notes.strip()
+            if item_notes:
+                item["notes"] = item_notes
+            updated.append(item)
+            _save(path, updated)
+        elif op == "update":
+            if id <= 0:
+                return {"error": "operation=update requires id > 0"}
+            updated = list(current)
+            target = next((item for item in updated if item.get("id") == id), None)
+            if target is None:
+                return {"error": f"todo id {id} not found", "todos": current}
+            if title.strip():
+                target["title"] = title.strip()
+            if status.strip():
+                item_status = status.strip()
+                if item_status not in _VALID_STATUSES:
+                    return {
+                        "error": f"invalid status {item_status!r}",
+                        "valid_statuses": sorted(_VALID_STATUSES),
+                    }
+                target["status"] = item_status
+            if notes.strip():
+                target["notes"] = notes.strip()
+            _save(path, updated)
+        elif op == "clear":
+            updated = []
+            _save(path, updated)
+        else:
+            return {
+                "error": f"unknown operation {operation!r}",
+                "valid_operations": ["list", "replace", "add", "update", "clear"],
+            }
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return {
+        "operation": op,
+        "todos": updated,
+        "count": len(updated),
+        "status_counts": _status_counts(updated),
+        "path": ".coder_scratch/todos.json",
+    }

--- a/examples/coder.workspace/tools/todo/tool.yaml
+++ b/examples/coder.workspace/tools/todo/tool.yaml
@@ -1,0 +1,43 @@
+name: todo
+description: |-
+  Manage a session task checklist for coding work. Stores the list in `.coder_scratch/todos.json` inside the project workspace.
+
+  Usage:
+  - Use this at the start of non-trivial tasks to create a short checklist, then update items as work progresses.
+  - `operation="replace"` replaces the whole list with `todos=[{"title": ..., "status": ...}]` items.
+  - `operation="add"` appends one item from `title` (status defaults to `not-started`).
+  - `operation="update"` changes one item by `id`; pass `title`, `status`, and/or `notes`.
+  - `operation="list"` returns the current list without changing it.
+  - `operation="clear"` removes all items after the task is complete.
+  - Status values: `not-started`, `in-progress`, `completed`, `blocked`.
+
+  Examples:
+  - `todo(operation="replace", todos=[{"title": "Add tests", "status": "not-started"}, {"title": "Implement fix", "status": "not-started"}])`
+  - `todo(operation="update", id=2, status="in-progress")`
+parameters:
+  operation:
+    type: string
+    description: One of list, replace, add, update, clear.
+    default: list
+  todos:
+    type: array
+    description: Full replacement list for operation=replace. Each item may include id, title, status, notes.
+    default: []
+  id:
+    type: integer
+    description: Item id for operation=update.
+    default: 0
+  title:
+    type: string
+    description: Item title for operation=add or optional replacement title for operation=update.
+    default: ""
+  status:
+    type: string
+    description: New item status. Use not-started, in-progress, completed, or blocked.
+    default: ""
+  notes:
+    type: string
+    description: Optional notes for operation=add or operation=update.
+    default: ""
+requires:
+  - workspace_config

--- a/examples/coder.workspace/tools/web_fetch/execute.py
+++ b/examples/coder.workspace/tools/web_fetch/execute.py
@@ -1,0 +1,109 @@
+"""web_fetch tool — dependency-free HTTP(S) fetch with HTML text extraction."""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+from looplet.types import ToolContext
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip = 0
+        self.parts: list[str] = []
+        self.title = ""
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "noscript", "svg"}:
+            self._skip += 1
+        if tag == "title":
+            self._in_title = True
+        if tag in {"p", "div", "section", "article", "li", "br", "h1", "h2", "h3", "h4"}:
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "noscript", "svg"} and self._skip:
+            self._skip -= 1
+        if tag == "title":
+            self._in_title = False
+        if tag in {"p", "div", "section", "article", "li", "h1", "h2", "h3", "h4"}:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_title:
+            self.title = (self.title + " " + text).strip()
+        self.parts.append(text)
+
+
+def _html_to_text(raw: str) -> tuple[str, str]:
+    parser = _TextExtractor()
+    parser.feed(raw)
+    text = " ".join(parser.parts)
+    text = re.sub(r"[ \t\r\f\v]+", " ", text)
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+    text = "\n".join(line.strip() for line in text.splitlines() if line.strip())
+    return parser.title, text.strip()
+
+
+def execute(ctx: ToolContext | None, *, url: str, prompt: str = "", max_chars: int = 12000) -> dict:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return {"error": "web_fetch only allows http and https URLs", "url": url}
+    limit = max(1000, int(max_chars or 12000))
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "looplet-coder/0.1 (+https://github.com)"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            status = getattr(response, "status", 200)
+            content_type = response.headers.get("content-type", "")
+            body = response.read(limit * 4 + 1)
+    except urllib.error.HTTPError as exc:
+        return {"error": f"HTTP {exc.code}: {exc.reason}", "url": url, "status": exc.code}
+    except urllib.error.URLError as exc:
+        return {"error": f"Fetch failed: {exc.reason}", "url": url}
+
+    encoding = "utf-8"
+    match = re.search(r"charset=([^;]+)", content_type, flags=re.I)
+    if match:
+        encoding = match.group(1).strip()
+    raw = body.decode(encoding, errors="replace")
+    if "html" in content_type.lower() or "<html" in raw[:500].lower():
+        title, text = _html_to_text(raw)
+    else:
+        title, text = "", raw.strip()
+    truncated = len(text) > limit
+    text = text[:limit]
+    result: dict = {
+        "url": url,
+        "status": status,
+        "content_type": content_type,
+        "title": title,
+        "text": text,
+        "chars": len(text),
+        "truncated": truncated,
+    }
+    if prompt.strip():
+        if ctx is None or ctx.llm is None:
+            result["prompt_note"] = "No ctx.llm was supplied, so prompt was not run."
+        else:
+            answer = ctx.llm.generate(
+                "Answer the prompt using only the fetched content.\n\n"
+                f"URL: {url}\n\nPROMPT:\n{prompt.strip()}\n\nCONTENT:\n{text}",
+                max_tokens=1000,
+                temperature=0.0,
+            )
+            result["answer"] = answer
+    return result

--- a/examples/coder.workspace/tools/web_fetch/tool.yaml
+++ b/examples/coder.workspace/tools/web_fetch/tool.yaml
@@ -1,0 +1,27 @@
+name: web_fetch
+description: |-
+  Fetch an HTTP(S) URL and return readable text. Optionally ask the active LLM to answer a prompt using the fetched content.
+
+  Usage:
+  - Use this for public documentation, changelogs, issue pages, specs, or other web pages that inform a coding task.
+  - Only `http` and `https` URLs are allowed.
+  - HTML is converted to plain readable text; non-HTML text is returned as-is.
+  - Large pages are truncated to `max_chars` to avoid filling the context.
+  - If `prompt` is provided and the host loop supplies `ctx.llm`, the tool returns `answer` generated from the fetched text.
+
+  Examples:
+  - `web_fetch(url="https://docs.python.org/3/library/pathlib.html")`
+  - `web_fetch(url="https://example.com/release-notes", prompt="Summarize breaking API changes relevant to this repo")`
+parameters:
+  url:
+    type: string
+    description: HTTP or HTTPS URL to fetch.
+  prompt:
+    type: string
+    description: Optional question or extraction prompt to run against the fetched text using ctx.llm.
+    default: ""
+  max_chars:
+    type: integer
+    description: Maximum characters of extracted text to return or pass to the prompt.
+    default: 12000
+concurrent_safe: true

--- a/examples/coder.workspace/tools/worktree/execute.py
+++ b/examples/coder.workspace/tools/worktree/execute.py
@@ -1,0 +1,83 @@
+"""worktree tool — managed git worktree helper."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from looplet.types import ToolContext
+
+
+def _run(workspace: str, args: list[str]) -> dict:
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, capture_output=True, text=True, timeout=60
+    )
+    return {
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _safe_name(name: str) -> str | None:
+    cleaned = name.strip()
+    if not cleaned or cleaned in {".", ".."}:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", cleaned):
+        return None
+    return cleaned
+
+
+def _managed_root(workspace: str) -> Path:
+    root = Path(workspace).resolve()
+    return root.parent / f"{root.name}.worktrees"
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    operation: str = "list",
+    name: str = "",
+    base_ref: str = "HEAD",
+    confirm: bool = False,
+    force: bool = False,
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    probe = _run(workspace, ["rev-parse", "--is-inside-work-tree"])
+    if probe["exit_code"] != 0:
+        return {"error": "Not inside a git worktree", "stderr": probe["stderr"]}
+    op = operation.strip().lower() or "list"
+    managed = _managed_root(workspace)
+    if op == "list":
+        result = _run(workspace, ["worktree", "list", "--porcelain"])
+        result.update({"operation": op, "managed_root": str(managed)})
+        return result
+    safe = _safe_name(name)
+    if safe is None:
+        return {"error": "name must contain only letters, numbers, dot, dash, and underscore"}
+    target = (managed / safe).resolve()
+    if managed.resolve() not in target.parents:
+        return {"error": "resolved worktree path escapes managed root"}
+    if op == "create":
+        if target.exists():
+            return {"error": f"managed worktree already exists: {target}"}
+        managed.mkdir(parents=True, exist_ok=True)
+        result = _run(workspace, ["worktree", "add", str(target), base_ref or "HEAD"])
+        result.update({"operation": op, "path": str(target), "managed_root": str(managed)})
+        return result
+    if op == "remove":
+        if not confirm:
+            return {"error": "operation=remove requires confirm=true", "path": str(target)}
+        args = ["worktree", "remove"]
+        if force:
+            args.append("--force")
+        args.append(str(target))
+        result = _run(workspace, args)
+        result.update({"operation": op, "path": str(target), "managed_root": str(managed)})
+        return result
+    return {
+        "error": f"unknown operation {operation!r}",
+        "valid_operations": ["list", "create", "remove"],
+    }

--- a/examples/coder.workspace/tools/worktree/tool.yaml
+++ b/examples/coder.workspace/tools/worktree/tool.yaml
@@ -1,0 +1,38 @@
+name: worktree
+description: |-
+  Manage git worktrees for isolated coding attempts.
+
+  Usage:
+  - `operation="list"` shows current worktrees.
+  - `operation="create"` creates a sibling managed worktree under `<repo>.worktrees/<name>` from `base_ref`.
+  - `operation="remove"` removes a managed worktree and requires `confirm=true`.
+  - Worktree names are sanitized to letters, numbers, dot, dash, and underscore.
+  - This tool only removes paths inside the managed sibling worktree directory.
+
+  Examples:
+  - `worktree(operation="create", name="experiment-auth", base_ref="HEAD")`
+  - `worktree(operation="list")`
+  - `worktree(operation="remove", name="experiment-auth", confirm=true)`
+parameters:
+  operation:
+    type: string
+    description: list, create, or remove.
+    default: list
+  name:
+    type: string
+    description: Managed worktree name for create/remove.
+    default: ""
+  base_ref:
+    type: string
+    description: Git ref to create the worktree from.
+    default: HEAD
+  confirm:
+    type: boolean
+    description: Required true for remove.
+    default: false
+  force:
+    type: boolean
+    description: Pass --force to git worktree remove.
+    default: false
+requires:
+  - workspace_config

--- a/examples/coder.workspace/tools/write_file/execute.py
+++ b/examples/coder.workspace/tools/write_file/execute.py
@@ -29,10 +29,11 @@ def execute(
         return {
             "error": f"{file_path!r} is a directory, not a file.",
         }
+    exists = p.exists()
     # Safer-overwrite: refuse to clobber an existing file unless
     # the caller explicitly opts in. This prevents the model from
     # accidentally wiping a file it should have edited instead.
-    if p.exists() and not overwrite:
+    if exists and not overwrite:
         return {
             "error": (
                 f"Refused: {file_path!r} already exists. write_file "
@@ -46,11 +47,31 @@ def execute(
                 f"edit_file(file_path={file_path!r}, ...)  OR  write_file(..., overwrite=True)"
             ),
         }
+    if exists and overwrite and cache is not None:
+        if not cache.was_read(file_path):
+            return {
+                "error": (
+                    f"Cannot overwrite {file_path!r}: this file has not been read "
+                    "in the current session. Call read_file first so the full-file "
+                    "replacement is based on current content."
+                ),
+                "missing": "prior_read",
+                "recovery": f"read_file(file_path={file_path!r})",
+            }
+        if not cache.is_unchanged(file_path):
+            return {
+                "error": (
+                    f"Cannot overwrite {file_path!r}: file was modified since "
+                    "the last read. Re-read it before replacing the full file."
+                ),
+                "stale": True,
+                "recovery": f"read_file(file_path={file_path!r})",
+            }
     atomic_write_text(p, content)
     if cache is not None:
         cache.invalidate(file_path)
     return {
         "written": file_path,
         "lines": content.count("\n") + (0 if content.endswith("\n") or not content else 1),
-        "overwritten": p.exists() and overwrite,
+        "overwritten": exists and overwrite,
     }

--- a/examples/coder.workspace/tools/write_file/tool.yaml
+++ b/examples/coder.workspace/tools/write_file/tool.yaml
@@ -5,6 +5,7 @@ description: |-
   Usage:
   - Use this for **NEW** files only by default. To modify an existing file, use `edit_file` (preserves the rest of the file and produces a reviewable diff).
   - **Refuses to clobber an existing file** unless you pass `overwrite=true`. This prevents accidental wipes when the model meant `edit_file`.
+  - When overwriting an existing file, the file must have been read in this session and must still match the last read content. If another command, linter, or user changed it, re-read before overwriting.
   - Writes are **atomic** (tmp file + os.replace) so a crash mid-write can't leave a half-written file.
   - Parent directories are created automatically.
   - The path is relative to the project root and must stay inside it (paths escaping via `..` are refused).
@@ -12,11 +13,12 @@ description: |-
 
   Examples:
   - `write_file(file_path="src/utils.py", content="def foo(): ...")` — new file
-  - `write_file(file_path="src/utils.py", content=..., overwrite=True)` — explicit replace of an existing file
+  - `write_file(file_path="src/utils.py", content=..., overwrite=True)` — explicit replace of an existing file after `read_file`
   - DO NOT use this to "update" a file you already read — that's `edit_file`.
 
   Recovery:
-  - "already exists" → use `edit_file` (preferred) or pass `overwrite=True`
+  - "already exists" → use `edit_file` (preferred) or read the file and pass `overwrite=True`
+  - "modified since last read" → call `read_file` again, then retry if replacement is still intentional
 parameters:
   file_path:
     type: string

--- a/tests/test_coder_tool_improvements_smoke.py
+++ b/tests/test_coder_tool_improvements_smoke.py
@@ -11,8 +11,13 @@ Covers:
 
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 import sys
 import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -181,6 +186,12 @@ def test_bash_tool_runs_safe_command(preset):
         ("list_dir", "tree"),
         ("glob", "pattern"),
         ("grep", "regex"),
+        ("todo", "checklist"),
+        ("web_fetch", "HTTP"),
+        ("subagent", "focused"),
+        ("notebook_edit", "Jupyter"),
+        ("git_inspect", "read-only"),
+        ("worktree", "worktree"),
     ],
 )
 def test_tool_descriptions_are_rich(preset, tool_name, marker):
@@ -232,6 +243,7 @@ def test_write_file_refuses_existing_without_overwrite(preset):
 
 def test_write_file_overwrite_works(preset):
     Path(_workspace(preset), "x.py").write_text("old\n")
+    preset.tools.dispatch(ToolCall(tool="read_file", args={"file_path": "x.py"}))
     r = preset.tools.dispatch(
         ToolCall(
             tool="write_file",
@@ -240,6 +252,33 @@ def test_write_file_overwrite_works(preset):
     )
     assert r.data.get("written") == "x.py"
     assert Path(_workspace(preset), "x.py").read_text() == "new"
+
+
+def test_write_file_overwrite_requires_prior_read(preset):
+    Path(_workspace(preset), "x.py").write_text("old\n")
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="write_file",
+            args={"file_path": "x.py", "content": "new", "overwrite": True},
+        )
+    )
+    assert r.data.get("missing") == "prior_read"
+    assert "read_file" in r.data.get("recovery", "")
+
+
+def test_write_file_overwrite_refuses_stale_read(preset):
+    target = Path(_workspace(preset), "x.py")
+    target.write_text("old\n")
+    preset.tools.dispatch(ToolCall(tool="read_file", args={"file_path": "x.py"}))
+    target.write_text("user changed\n")
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="write_file",
+            args={"file_path": "x.py", "content": "new", "overwrite": True},
+        )
+    )
+    assert r.data.get("stale") is True
+    assert target.read_text() == "user changed\n"
 
 
 def test_write_file_creates_parent_dirs(preset):
@@ -363,3 +402,199 @@ def test_bash_repeat_window_only_holds_recent_4(preset):
         preset.tools.dispatch(ToolCall(tool="bash", args={"command": cmd}))
     r = preset.tools.dispatch(ToolCall(tool="bash", args={"command": "echo a"}))
     assert "a" in r.data.get("stdout", "")
+
+
+def test_todo_replace_update_and_persist(preset):
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="todo",
+            args={
+                "operation": "replace",
+                "todos": [
+                    {"title": "Explore", "status": "completed"},
+                    {"title": "Implement", "status": "in-progress"},
+                ],
+            },
+        )
+    )
+    assert r.data.get("count") == 2
+    assert r.data["todos"][1]["id"] == 2
+    r = preset.tools.dispatch(
+        ToolCall(tool="todo", args={"operation": "update", "id": 2, "status": "completed"})
+    )
+    assert r.data["status_counts"]["completed"] == 2
+    list_result = preset.tools.dispatch(ToolCall(tool="todo", args={"operation": "list"}))
+    assert [item["title"] for item in list_result.data["todos"]] == ["Explore", "Implement"]
+
+
+def test_grep_supports_modes_filters_and_pagination(preset):
+    workspace = Path(_workspace(preset))
+    (workspace / "a.py").write_text("needle one\nneedle two\n")
+    (workspace / "b.txt").write_text("needle text\n")
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="grep",
+            args={
+                "pattern": "needle",
+                "glob": "*.py",
+                "output_mode": "content",
+                "head_limit": 1,
+            },
+        )
+    )
+    assert r.data.get("count") == 2
+    assert r.data.get("truncated") is True
+    assert r.data.get("matches") == ["a.py:1:needle one"]
+    files = preset.tools.dispatch(
+        ToolCall(
+            tool="grep",
+            args={"pattern": "needle", "glob": "*.py", "output_mode": "files_with_matches"},
+        )
+    )
+    assert files.data.get("filenames") == ["a.py"]
+
+
+def test_web_fetch_extracts_local_html(preset):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"<html><head><title>Docs</title></head><body><h1>Needle Docs</h1><p>Hello from docs.</p></body></html>"
+            self.send_response(200)
+            self.send_header("content-type", "text/html; charset=utf-8")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/docs"
+        r = preset.tools.dispatch(ToolCall(tool="web_fetch", args={"url": url}))
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert r.data.get("status") == 200
+    assert r.data.get("title") == "Docs"
+    assert "Hello from docs" in r.data.get("text", "")
+
+
+def test_notebook_edit_replaces_cell_after_read(preset):
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "id": "abc123",
+                "metadata": {},
+                "outputs": [],
+                "source": ["print('old')\n"],
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path = Path(_workspace(preset), "analysis.ipynb")
+    path.write_text(json.dumps(notebook) + "\n")
+    preset.tools.dispatch(ToolCall(tool="read_file", args={"file_path": "analysis.ipynb"}))
+    r = preset.tools.dispatch(
+        ToolCall(
+            tool="notebook_edit",
+            args={
+                "notebook_path": "analysis.ipynb",
+                "cell_id": "abc123",
+                "new_source": "print('new')\n",
+            },
+        )
+    )
+    assert r.data.get("cell_id") == "abc123"
+    updated = json.loads(path.read_text())
+    assert updated["cells"][0]["source"] == ["print('new')"]
+
+
+def test_notebook_edit_requires_prior_read(preset):
+    path = Path(_workspace(preset), "analysis.ipynb")
+    path.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}))
+    r = preset.tools.dispatch(
+        ToolCall(tool="notebook_edit", args={"notebook_path": "analysis.ipynb", "cell_id": "x"})
+    )
+    assert r.data.get("missing") == "prior_read"
+
+
+def test_git_inspect_status(preset):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    workspace = Path(_workspace(preset))
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True, text=True)
+    (workspace / "tracked.txt").write_text("hi\n")
+    r = preset.tools.dispatch(ToolCall(tool="git_inspect", args={"operation": "status"}))
+    assert r.data.get("exit_code") == 0
+    assert "tracked.txt" in r.data.get("stdout", "")
+
+
+def test_worktree_create_list_remove_managed_path(preset):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    workspace = Path(_workspace(preset))
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=workspace, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=workspace, check=True)
+    (workspace / "tracked.txt").write_text("hi\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=workspace, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=workspace, check=True, capture_output=True, text=True
+    )
+    created = preset.tools.dispatch(
+        ToolCall(
+            tool="worktree", args={"operation": "create", "name": "experiment", "base_ref": "HEAD"}
+        )
+    )
+    assert created.data.get("exit_code") == 0, created.data
+    worktree_path = Path(created.data["path"])
+    assert worktree_path.exists()
+    listed = preset.tools.dispatch(ToolCall(tool="worktree", args={"operation": "list"}))
+    assert str(worktree_path) in listed.data.get("stdout", "")
+    refused = preset.tools.dispatch(
+        ToolCall(tool="worktree", args={"operation": "remove", "name": "experiment"})
+    )
+    assert "confirm=true" in refused.data.get("error", "")
+    removed = preset.tools.dispatch(
+        ToolCall(
+            tool="worktree", args={"operation": "remove", "name": "experiment", "confirm": True}
+        )
+    )
+    assert removed.data.get("exit_code") == 0, removed.data
+    assert not worktree_path.exists()
+
+
+def test_subagent_direct_dispatch_explains_missing_llm(preset):
+    r = preset.tools.dispatch(ToolCall(tool="subagent", args={"prompt": "Inspect the repo"}))
+    assert "ctx.llm" in r.data.get("error", "")
+
+
+def test_subagent_runs_inside_loop(preset):
+    from looplet import composable_loop
+    from looplet.testing import MockLLMBackend
+
+    llm = MockLLMBackend(
+        responses=[
+            json.dumps({"tool": "subagent", "args": {"prompt": "Think once", "max_steps": 1}}),
+            json.dumps({"tool": "think", "args": {"thought": "sub thought"}}),
+            json.dumps({"tool": "done", "args": {"summary": "subagent complete"}}),
+        ]
+    )
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=preset.state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"q": "run subagent"},
+        )
+    )
+    assert [step.tool_call.tool for step in steps] == ["subagent", "done"]
+    assert steps[0].tool_result.data["step_count"] == 1

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -483,7 +483,7 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
         FileCache, StaleFile, Stagnation, ThresholdCompact, PerToolLimit
         from YAML; LinterHook + EvalHook appended by setup.py to match
         looplet.examples coder reference feature-for-feature)
-      * 9 tools (bash/list_dir/read/write/edit/glob/grep/think/done) load
+    * Coder tools (bash/list_dir/read/write/edit/glob/grep/think/done plus optional helpers) load
       * FileCacheHook and StaleFileHook share the SAME FileCache instance
         via @file_cache (proves the shared-resource registry under load)
       * setup.py wires WORKSPACE_CONFIG + FILE_CACHE module globals into
@@ -522,12 +522,18 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
         "bash",
         "done",
         "edit_file",
+        "git_inspect",
         "glob",
         "grep",
         "list_dir",
         "multi_edit",
+        "notebook_edit",
         "read_file",
+        "subagent",
         "think",
+        "todo",
+        "web_fetch",
+        "worktree",
         "write_file",
     ]
 
@@ -798,12 +804,18 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
         "bash",
         "done",
         "edit_file",
+        "git_inspect",
         "glob",
         "grep",
         "list_dir",
         "multi_edit",
+        "notebook_edit",
         "read_file",
+        "subagent",
         "think",
+        "todo",
+        "web_fetch",
+        "worktree",
         "write_file",
     ]
 


### PR DESCRIPTION
## Summary
- expand coder workspace guidance and safer write/search behavior
- add workspace-only tools for todos, web fetch, subagents, notebooks, git inspection, and managed worktrees
- add smoke coverage for the new coder tool behavior and workspace loading

## Validation
- uv run pytest tests/test_coder_tool_improvements_smoke.py tests/test_workspace.py -q --tb=short
- pre-push full suite: 1694 passed in 73.49s