### PR TITLE
feat(compact): add production default service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ composable_loop(llm, tools, state, config, hooks)
 | `tools` | Tool schema inference, registry & dispatch | `@tool`, `tools_from`, `BaseToolRegistry`, `ToolSpec` |
 | `backends` | LLM adapters | `OpenAIBackend`, `AnthropicBackend`, `AsyncOpenAIBackend` |
 | `permissions` | Declarative permission engine | `PermissionEngine`, `PermissionHook`, `PermissionRule` |
-| `compact` | Context management | `compact_chain`, `PruneToolResults`, `SummarizeCompact`, `TruncateCompact` |
+| `compact` | Context management | `DefaultCompactService`, `compact_chain`, `PruneToolResults`, `SummarizeCompact`, `TruncateCompact` |
 | `checkpoint` | Crash-resume | `FileCheckpointStore`, `resume_loop_state` |
 | `hooks` | Hook decisions | `HookDecision`, `InjectContext`, `Allow`, `Deny`, `Block`, `Stop` |
 | `skills` | Composable bundles | `Skill` |
@@ -270,7 +270,7 @@ for step in composable_loop(
 from looplet import (
     composable_loop, LoopConfig, DefaultState, tool, tools_from,
     HookDecision, InjectContext, StaticMemorySource,
-    compact_chain, PruneToolResults, SummarizeCompact, TruncateCompact,
+    DefaultCompactService,
     ContextBudget, ThresholdCompactHook, EvalHook,
 )
 
@@ -310,11 +310,7 @@ class MyHook:
 config = LoopConfig(
     max_steps=20,
     system_prompt="You are a Python developer. Use bash for tests.",
-    compact_service=compact_chain(
-        PruneToolResults(keep_recent=5),
-        SummarizeCompact(keep_recent=2),
-        TruncateCompact(keep_recent=1),
-    ),
+    compact_service=DefaultCompactService(keep_recent=2, keep_recent_tool_results=5),
     memory_sources=[StaticMemorySource("Always write tests first.")],
 )
 
@@ -583,7 +579,7 @@ def check_done(self, state, session_log, context, step_num):
 ```python
 config = LoopConfig(
     memory_sources=[StaticMemorySource("Always use type hints. Write tests first.")],
-    compact_service=compact_chain(...),
+    compact_service=DefaultCompactService(),
 )
 ```
 
@@ -857,6 +853,7 @@ symbols live in `looplet.<module>`.
 | `ContextBudget` | `budget` | Context window thresholds |
 | `Continue` | `hook_decision` | Factory: explicit no-op |
 | `Conversation` | `conversation` | Message thread container |
+| `DefaultCompactService` | `compact` | Recommended production compaction service |
 | `DefaultState` | `types` | Built-in `AgentState` impl |
 | `Deny` | `hook_decision` | Factory: deny permission |
 | `DomainAdapter` | `loop` | Bundle domain callables |
@@ -905,6 +902,7 @@ symbols live in `looplet.<module>`.
 | `coding_agent_preset` | `presets` | Pre-built coding agent |
 | `compact_chain` | `compact` | Chain compaction strategies |
 | `composable_loop` | `loop` | **The loop generator** |
+| `default_compact_service` | `compact` | Factory for the recommended compaction service |
 | `emit_event` | `loop` | Fire a `LifecycleEvent` to hooks |
 | `eval_cli` | `evals` | CLI entry for evals |
 | `eval_discover` | `evals` | Find eval scenarios |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,23 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   framing trimmed from public docstrings and comments now that the
   migration to the workspace format is complete. No behavioural
   change. ROADMAP entries that have shipped are dropped.
+- **Coding and research presets now use `DefaultCompactService`.** The
+  preset path gets the same production compaction policy users can
+  import directly: prune old tool payloads, summarize older context,
+  keep recent steps verbatim, and report stage-level outcomes.
+- **Docs and shipped examples now teach `DefaultCompactService` first.**
+  README, tutorial, AGENTS guide, packaged examples, and bundled
+  workspace `compact_service.py` resources now point to the coherent
+  default service, leaving `compact_chain(...)` as the custom-policy
+  escape hatch.
 
 ### Added
+- **`DefaultCompactService` and `default_compact_service(...)`.** A
+  clear production default for context compaction that composes
+  `PruneToolResults`, `SummarizeCompact`, and deterministic truncate
+  fallback into one inspectable service. `CompactOutcome` now reports
+  session-log entry counts, compacted step ranges, summaries, and a
+  JSON-able `to_dict()` used in `POST_COMPACT` event payloads.
 - **`extends:` workspace composition.** A workspace's `config.yaml` may
   now declare `extends: <path>`. At load time the parent workspace is
   recursively materialized and overlaid with the child via a tempdir;

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ for step in composable_loop(..., hooks=[RedactPII(), RetryFlakyTool()]):
     ...
 ```
 
-Ship-ready hooks already wired in: `ApprovalHook`, `PermissionHook`, `CheckpointHook`, `ContextPressureHook`, `ThresholdCompactHook`, `ProvenanceSink`, `TracingHook`, `MetricsHook`, `EvalHook`, plus the `compact_chain(Prune, Summarize, Truncate)` context strategy. [Drop in your own](docs/hooks.md) in 10 lines.
+Ship-ready hooks already wired in: `ApprovalHook`, `PermissionHook`, `CheckpointHook`, `ContextPressureHook`, `ThresholdCompactHook`, `ProvenanceSink`, `TracingHook`, `MetricsHook`, `EvalHook`, plus `DefaultCompactService` for production context management. [Drop in your own](docs/hooks.md) in 10 lines.
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -68,25 +68,30 @@ See [hooks.md](hooks.md) for the full walkthrough.
 
 ## Step 4 — Add context management
 
-For long sessions, add a compaction chain so the agent doesn't run out
-of context:
+For long sessions, add the default compaction service so the agent can
+keep working under context pressure:
 
 ```python
 from looplet import (
-    compact_chain, PruneToolResults, SummarizeCompact, TruncateCompact,
+    DefaultCompactService,
     ContextBudget, ThresholdCompactHook,
 )
 
 config = LoopConfig(
     max_steps=50,
-    compact_service=compact_chain(
-        PruneToolResults(keep_recent=5),   # free: clear old tool output
-        SummarizeCompact(keep_recent=2),   # 1 LLM call: summarise middle
-        TruncateCompact(keep_recent=1),    # free: drop everything old
+    compact_service=DefaultCompactService(
+        keep_recent=2,
+        keep_recent_tool_results=5,
     ),
 )
 hooks = [ThresholdCompactHook(ContextBudget(context_window=128_000))]
 ```
+
+`DefaultCompactService` prunes old bulky tool results, summarizes older
+working context, keeps recent steps verbatim, and reports what changed
+through compaction lifecycle events. Use `compact_chain(...)` with
+`PruneToolResults`, `SummarizeCompact`, and `TruncateCompact` when you
+want a custom policy.
 
 ## Step 5 — Add crash-resume and approval
 

--- a/examples/coder.workspace/resources/compact_service.py
+++ b/examples/coder.workspace/resources/compact_service.py
@@ -1,18 +1,15 @@
 """Compaction service for the coder workspace.
 
-Two-stage chain: prune old tool results first, then truncate any
-remaining historical turns. Mirrors the pattern the looplet.examples coder reference
-used; lifts it out of ``setup.py`` so the entire workspace is
-declarative.
+Uses looplet's production default: prune old tool payloads, summarize
+older working context, keep recent steps verbatim, and truncate only as
+a fallback. Kept as a declarative resource so ``config.yaml`` can refer
+to it with ``compact_service: "@compact_service"``.
 """
 
 from __future__ import annotations
 
-from looplet.compact import PruneToolResults, TruncateCompact, compact_chain
+from looplet.compact import default_compact_service
 
 
 def build(runtime=None):
-    return compact_chain(
-        PruneToolResults(keep_recent=10),
-        TruncateCompact(keep_recent=5),
-    )
+    return default_compact_service(keep_recent=5, keep_recent_tool_results=10)

--- a/examples/dep_doctor.workspace/resources/compact_service.py
+++ b/examples/dep_doctor.workspace/resources/compact_service.py
@@ -1,16 +1,12 @@
 """Compaction service for the dep_doctor workspace.
 
-PruneToolResults(keep_recent=8) + TruncateCompact(keep_recent=3).
-Lifted out of setup.py so the workspace is fully declarative.
+Uses looplet's production default as a declarative resource.
 """
 
 from __future__ import annotations
 
-from looplet.compact import PruneToolResults, TruncateCompact, compact_chain
+from looplet.compact import default_compact_service
 
 
 def build(runtime=None):
-    return compact_chain(
-        PruneToolResults(keep_recent=8),
-        TruncateCompact(keep_recent=3),
-    )
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=8)

--- a/examples/git_detective.workspace/resources/compact_service.py
+++ b/examples/git_detective.workspace/resources/compact_service.py
@@ -1,16 +1,12 @@
 """Compaction service for the git_detective workspace.
 
-PruneToolResults(keep_recent=6) + TruncateCompact(keep_recent=3).
-Lifted out of setup.py so the workspace is fully declarative.
+Uses looplet's production default as a declarative resource.
 """
 
 from __future__ import annotations
 
-from looplet.compact import PruneToolResults, TruncateCompact, compact_chain
+from looplet.compact import default_compact_service
 
 
 def build(runtime=None):
-    return compact_chain(
-        PruneToolResults(keep_recent=6),
-        TruncateCompact(keep_recent=3),
-    )
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=6)

--- a/examples/threat_intel.workspace/resources/compact_service.py
+++ b/examples/threat_intel.workspace/resources/compact_service.py
@@ -1,16 +1,12 @@
 """Compaction service for the threat_intel workspace.
 
-PruneToolResults(keep_recent=6) + TruncateCompact(keep_recent=3).
-Lifted out of setup.py so the workspace is fully declarative.
+Uses looplet's production default as a declarative resource.
 """
 
 from __future__ import annotations
 
-from looplet.compact import PruneToolResults, TruncateCompact, compact_chain
+from looplet.compact import default_compact_service
 
 
 def build(runtime=None):
-    return compact_chain(
-        PruneToolResults(keep_recent=6),
-        TruncateCompact(keep_recent=3),
-    )
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=6)

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -49,10 +49,12 @@ from looplet.checkpoint import FileCheckpointStore
 from looplet.compact import (
     CompactOutcome,
     CompactService,
+    DefaultCompactService,
     PruneToolResults,
     SummarizeCompact,
     TruncateCompact,
     compact_chain,
+    default_compact_service,
     run_compact,
 )
 from looplet.conversation import Conversation, Message
@@ -230,10 +232,12 @@ __all__ = [
     # ── CONTEXT MANAGEMENT ──────────────────────────────────────
     "CompactService",
     "CompactOutcome",
+    "DefaultCompactService",
     "TruncateCompact",
     "SummarizeCompact",
     "PruneToolResults",
     "compact_chain",
+    "default_compact_service",
     "run_compact",
     "ContextBudget",
     "ThresholdCompactHook",

--- a/src/looplet/compact.py
+++ b/src/looplet/compact.py
@@ -12,10 +12,10 @@ this module exposes it as a **service** so users can:
 * Trigger compaction manually from a hook at any time by calling
   :func:`run_compact`.
 
-The default service :class:`DefaultCompactService` preserves the
-existing three-strategy chain (aggressive budget → reactive compact →
-clear old results) so existing behavior is unchanged when no service
-is configured.
+The default service :class:`DefaultCompactService` is the recommended
+production starting point: it prunes old bulky tool payloads, preserves
+the older working session in a compact summary, and falls back to
+deterministic truncation when the summariser cannot help.
 """
 
 from __future__ import annotations
@@ -30,10 +30,12 @@ if TYPE_CHECKING:
 __all__ = [
     "CompactService",
     "CompactOutcome",
+    "DefaultCompactService",
     "TruncateCompact",
     "SummarizeCompact",
     "PruneToolResults",
     "compact_chain",
+    "default_compact_service",
     "run_compact",
 ]
 
@@ -50,6 +52,10 @@ class CompactOutcome:
     reason: str = ""
     messages_before: int | None = None
     messages_after: int | None = None
+    session_entries_before: int | None = None
+    session_entries_after: int | None = None
+    compacted_step_range: tuple[int, int] | None = None
+    summary: str = ""
     llm_calls_spent: int = 0
     extra: dict[str, Any] | None = None
     cleanup: "Callable[[], None] | None" = None
@@ -63,9 +69,10 @@ class CompactOutcome:
     def compacted(self) -> bool:
         """True when the compaction actually reduced context size.
 
-        Checks ``messages_before`` vs ``messages_after`` when both are
-        set; also returns True when ``extra`` contains a positive
-        ``"cleared"`` count (from :class:`PruneToolResults`).
+        Checks conversation message counts, session-log entry counts,
+        explicit compacted step ranges, and tool-result pruning counts.
+        This keeps chained services honest when a stage mutates only
+        one history surface.
         """
         if (
             self.messages_before is not None
@@ -73,9 +80,32 @@ class CompactOutcome:
             and self.messages_after < self.messages_before
         ):
             return True
+        if (
+            self.session_entries_before is not None
+            and self.session_entries_after is not None
+            and self.session_entries_after < self.session_entries_before
+        ):
+            return True
+        if self.compacted_step_range is not None:
+            return True
         if self.extra and self.extra.get("cleared", 0) > 0:
             return True
         return False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a small JSON-able summary for lifecycle events and tests."""
+        return {
+            "reason": self.reason,
+            "messages_before": self.messages_before,
+            "messages_after": self.messages_after,
+            "session_entries_before": self.session_entries_before,
+            "session_entries_after": self.session_entries_after,
+            "compacted_step_range": self.compacted_step_range,
+            "summary": self.summary,
+            "llm_calls_spent": self.llm_calls_spent,
+            "compacted": self.compacted,
+            "extra": dict(self.extra or {}),
+        }
 
 
 @runtime_checkable
@@ -99,6 +129,124 @@ class CompactService(Protocol):
         step_num: int,
         reason: str,
     ) -> CompactOutcome: ...
+
+
+def _message_count(conversation: Any | None) -> int | None:
+    if conversation is None or not hasattr(conversation, "messages"):
+        return None
+    return len(conversation.messages)
+
+
+def _session_entry_count(session_log: Any | None) -> int | None:
+    if session_log is None or not hasattr(session_log, "entries"):
+        return None
+    return len(session_log.entries)
+
+
+def _older_entries(entries: list[Any], keep_recent: int) -> list[Any]:
+    if keep_recent <= 0:
+        return list(entries)
+    return list(entries[:-keep_recent])
+
+
+def _compacted_step_range(session_log: Any | None, keep_recent: int) -> tuple[int, int] | None:
+    if session_log is None or not hasattr(session_log, "entries"):
+        return None
+    entries = _older_entries(list(session_log.entries), keep_recent)
+    compactable = [
+        entry
+        for entry in entries
+        if getattr(entry, "tool", "") not in {"__summary__", "__compact_summary__"}
+        and isinstance(getattr(entry, "step", None), int)
+        and getattr(entry, "step") > 0
+    ]
+    if not compactable:
+        return None
+    return (compactable[0].step, compactable[-1].step)
+
+
+def _session_log_was_compacted(
+    *,
+    summary: str,
+    entries_before: int | None,
+    entries_after: int | None,
+) -> bool:
+    return bool(
+        summary
+        or (
+            entries_before is not None
+            and entries_after is not None
+            and entries_after < entries_before
+        )
+    )
+
+
+def _render_transcript(session_log: Any | None, conversation: Any | None) -> tuple[str, str]:
+    if session_log is not None and hasattr(session_log, "render"):
+        try:
+            rendered = session_log.render() or ""
+        except Exception:  # noqa: BLE001
+            rendered = ""
+        if rendered.strip():
+            return rendered, "session_log"
+    if conversation is not None and hasattr(conversation, "render"):
+        try:
+            rendered = conversation.render() or ""
+        except Exception:  # noqa: BLE001
+            rendered = ""
+        if rendered.strip():
+            return rendered, "conversation"
+    return "", "empty"
+
+
+def _stage_report(name: str, outcome: CompactOutcome) -> dict[str, Any]:
+    return {
+        "name": name,
+        "compacted": outcome.compacted,
+        "messages_before": outcome.messages_before,
+        "messages_after": outcome.messages_after,
+        "session_entries_before": outcome.session_entries_before,
+        "session_entries_after": outcome.session_entries_after,
+        "compacted_step_range": outcome.compacted_step_range,
+        "llm_calls_spent": outcome.llm_calls_spent,
+        "mode": (outcome.extra or {}).get("mode"),
+        "cleared": (outcome.extra or {}).get("cleared", 0),
+    }
+
+
+def _merge_outcomes(reason: str, outcomes: list[tuple[str, CompactOutcome]]) -> CompactOutcome:
+    """Combine several stage outcomes into one production-facing report."""
+    if not outcomes:
+        return CompactOutcome(reason=reason)
+    first = outcomes[0][1]
+    last = outcomes[-1][1]
+    step_ranges = [out.compacted_step_range for _, out in outcomes if out.compacted_step_range]
+    compacted_step_range = None
+    if step_ranges:
+        compacted_step_range = (min(r[0] for r in step_ranges), max(r[1] for r in step_ranges))
+    summary = next((out.summary for _, out in outcomes if out.summary), "")
+    stages = [_stage_report(name, out) for name, out in outcomes]
+    extra: dict[str, Any] = {
+        "mode": "default",
+        "stages": stages,
+        "stage_count": len(outcomes),
+    }
+    for _, out in outcomes:
+        if out.extra:
+            for key in ("cleared",):
+                if key in out.extra:
+                    extra[key] = extra.get(key, 0) + out.extra[key]
+    return CompactOutcome(
+        reason=reason,
+        messages_before=first.messages_before,
+        messages_after=last.messages_after,
+        session_entries_before=first.session_entries_before,
+        session_entries_after=last.session_entries_after,
+        compacted_step_range=compacted_step_range,
+        summary=summary,
+        llm_calls_spent=sum(out.llm_calls_spent for _, out in outcomes),
+        extra=extra,
+    )
 
 
 class TruncateCompact:
@@ -130,19 +278,33 @@ class TruncateCompact:
         # Session-log side.
         from looplet.scaffolding import emergency_truncate  # noqa: PLC0415
 
-        messages_before = len(conversation.messages) if conversation is not None else None
-        emergency_truncate(state, session_log, keep_recent=self.keep_recent)
+        messages_before = _message_count(conversation)
+        session_entries_before = _session_entry_count(session_log)
+        candidate_step_range = _compacted_step_range(session_log, self.keep_recent)
+        summary = emergency_truncate(state, session_log, keep_recent=self.keep_recent) or ""
+        session_entries_after = _session_entry_count(session_log)
+        session_was_compacted = _session_log_was_compacted(
+            summary=summary,
+            entries_before=session_entries_before,
+            entries_after=session_entries_after,
+        )
+        compacted_step_range = candidate_step_range if session_was_compacted else None
 
         # Conversation side (optional — most domains don't thread one).
         if conversation is not None and hasattr(conversation, "compact"):
             conversation.compact(keep_recent=self.keep_recent)
-        messages_after = len(conversation.messages) if conversation is not None else None
+        messages_after = _message_count(conversation)
 
         return CompactOutcome(
             reason=reason,
             messages_before=messages_before,
             messages_after=messages_after,
+            session_entries_before=session_entries_before,
+            session_entries_after=session_entries_after,
+            compacted_step_range=compacted_step_range,
+            summary=summary,
             llm_calls_spent=0,
+            extra={"mode": "truncate", "keep_recent": self.keep_recent},
         )
 
 
@@ -202,6 +364,7 @@ def run_compact(
         messages_before=outcome.messages_before,
         messages_after=outcome.messages_after,
         reason=reason,
+        outcome=outcome,
     )
 
     # Post-compact cleanup callback — domain-specific state resets.
@@ -228,6 +391,7 @@ def _emit_compact_event(
     messages_before: int | None,
     messages_after: int | None = None,
     reason: str,
+    outcome: CompactOutcome | None = None,
 ) -> list[Any]:
     """Dispatch a compact lifecycle event via ``on_event``.
 
@@ -244,7 +408,7 @@ def _emit_compact_event(
         session_log=session_log,
         messages_before=messages_before,
         messages_after=messages_after,
-        extra={"reason": reason},
+        extra={"reason": reason, **({"outcome": outcome.to_dict()} if outcome else {})},
     )
     decisions: list[HookDecision] = []
     for hook in hooks:
@@ -301,9 +465,10 @@ class SummarizeCompact:
     """Ask the LLM to summarise the session, then keep N recent entries.
 
     Spends one LLM call to produce a dense 4-section summary (goal,
-    findings, open questions, recent decisions), spliced into the
-    session log before the recent entries. Falls back to deterministic
-    keep-recent on any summariser error — compaction always succeeds.
+    findings, open questions, recent decisions). When the session log
+    is long enough to shorten, the summary is spliced in before the
+    recent entries. Falls back to deterministic keep-recent on any
+    summariser error — compaction always succeeds.
 
     Prefer for long-running autonomous sessions where reasoning-chain
     preservation matters. Avoid for sub-second latency budgets or
@@ -340,28 +505,38 @@ class SummarizeCompact:
             llm_call_with_retry,
         )
 
-        messages_before = len(conversation.messages) if conversation is not None else None
+        messages_before = _message_count(conversation)
+        session_entries_before = _session_entry_count(session_log)
+        candidate_step_range = _compacted_step_range(session_log, self.keep_recent)
 
         # 1. Build transcript text: session_log.render() is the
-        #    single source of truth for what the agent has seen.
-        transcript = ""
-        if hasattr(session_log, "render"):
-            try:
-                transcript = session_log.render() or ""
-            except Exception:  # noqa: BLE001
-                transcript = ""
+        #    preferred source of truth for what the agent has seen;
+        #    conversation.render() is the fallback for loops that do
+        #    not thread a SessionLog.
+        transcript, transcript_source = _render_transcript(session_log, conversation)
 
         # Short-circuit: nothing to compact.
         if not transcript.strip():
-            emergency_truncate(state, session_log, keep_recent=self.keep_recent)
+            summary = emergency_truncate(state, session_log, keep_recent=self.keep_recent) or ""
+            session_entries_after = _session_entry_count(session_log)
+            session_was_compacted = _session_log_was_compacted(
+                summary=summary,
+                entries_before=session_entries_before,
+                entries_after=session_entries_after,
+            )
+            compacted_step_range = candidate_step_range if session_was_compacted else None
             if conversation is not None and hasattr(conversation, "compact"):
                 conversation.compact(keep_recent=self.keep_recent)
             return CompactOutcome(
                 reason=reason,
                 messages_before=messages_before,
-                messages_after=(len(conversation.messages) if conversation is not None else None),
+                messages_after=_message_count(conversation),
+                session_entries_before=session_entries_before,
+                session_entries_after=session_entries_after,
+                compacted_step_range=compacted_step_range,
+                summary=summary,
                 llm_calls_spent=0,
-                extra={"mode": "empty_fallback"},
+                extra={"mode": "empty_fallback", "transcript_source": transcript_source},
             )
 
         # Escape curly braces in transcript before str.format() — tool
@@ -394,15 +569,24 @@ class SummarizeCompact:
             import logging  # noqa: PLC0415
 
             logging.getLogger(__name__).exception(
-                "LLMCompactService summary call raised; falling back",
+                "SummarizeCompact summary call raised; falling back",
             )
 
         # 3. Apply compaction. Deterministic keep-recent runs either
         #    way (so the log is actually shorter); the summary is
         #    spliced in as a synthetic entry.
-        emergency_truncate(state, session_log, keep_recent=self.keep_recent)
+        fallback_summary = (
+            emergency_truncate(state, session_log, keep_recent=self.keep_recent) or ""
+        )
+        session_entries_after_truncate = _session_entry_count(session_log)
+        session_was_compacted = _session_log_was_compacted(
+            summary=fallback_summary,
+            entries_before=session_entries_before,
+            entries_after=session_entries_after_truncate,
+        )
+        compacted_step_range = candidate_step_range if session_was_compacted else None
 
-        if summary_text and hasattr(session_log, "entries"):
+        if summary_text and session_was_compacted and hasattr(session_log, "entries"):
             try:
                 from looplet.session import LogEntry  # noqa: PLC0415
 
@@ -427,17 +611,29 @@ class SummarizeCompact:
                 pass
 
         if conversation is not None and hasattr(conversation, "compact"):
-            conversation.compact(keep_recent=self.keep_recent)
+            if summary_text:
+                conversation.compact(
+                    summarizer=lambda _messages: summary_text,
+                    keep_recent=self.keep_recent,
+                )
+            else:
+                conversation.compact(keep_recent=self.keep_recent)
 
-        messages_after = len(conversation.messages) if conversation is not None else None
+        messages_after = _message_count(conversation)
+        final_summary = summary_text or fallback_summary
         return CompactOutcome(
             reason=reason,
             messages_before=messages_before,
             messages_after=messages_after,
+            session_entries_before=session_entries_before,
+            session_entries_after=_session_entry_count(session_log),
+            compacted_step_range=compacted_step_range,
+            summary=final_summary,
             llm_calls_spent=llm_calls_spent,
             extra={
                 "mode": "llm_summary" if summary_text else "llm_fallback",
                 "summary_chars": len(summary_text) if summary_text else 0,
+                "transcript_source": transcript_source,
             },
         )
 
@@ -492,8 +688,14 @@ class PruneToolResults:
         step_num: int,
         reason: str,
     ) -> CompactOutcome:
+        session_entries_before = _session_entry_count(session_log)
         if conversation is None or not hasattr(conversation, "messages"):
-            return CompactOutcome(reason=reason, extra={"mode": "no_conversation"})
+            return CompactOutcome(
+                reason=reason,
+                session_entries_before=session_entries_before,
+                session_entries_after=_session_entry_count(session_log),
+                extra={"mode": "no_conversation"},
+            )
 
         from looplet.conversation import MessageRole  # noqa: PLC0415
 
@@ -527,9 +729,134 @@ class PruneToolResults:
             reason=reason,
             messages_before=messages_before,
             messages_after=messages_before,  # structure unchanged
+            session_entries_before=session_entries_before,
+            session_entries_after=_session_entry_count(session_log),
             llm_calls_spent=0,
             extra={"mode": "prune", "cleared": cleared},
         )
+
+
+# ── Production default ───────────────────────────────────────────
+
+
+class DefaultCompactService:
+    """Recommended production compaction service.
+
+    The service keeps looplet's core simple by composing ordinary
+    compaction stages:
+
+    1. :class:`PruneToolResults` clears old bulky tool payloads while
+       keeping conversation structure intact.
+    2. :class:`SummarizeCompact` preserves older working context in a
+       concise summary and keeps recent entries verbatim.
+    3. :class:`TruncateCompact` runs only if the first two stages had
+       no effect, providing a deterministic last-resort fallback.
+
+    Use this when you want the normal, production-ready behaviour and
+    do not need to choose individual stages yourself. Use
+    :func:`compact_chain` or your own :class:`CompactService` when you
+    want a different policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        keep_recent: int = 2,
+        keep_recent_tool_results: int = 5,
+        use_llm_summary: bool = True,
+        summary_max_chars: int = 4000,
+        summary_max_tokens: int = 1200,
+        compactable_tools: frozenset[str] | None = None,
+    ) -> None:
+        self.keep_recent = keep_recent
+        self.keep_recent_tool_results = keep_recent_tool_results
+        self.use_llm_summary = use_llm_summary
+        self.prune = PruneToolResults(
+            keep_recent=keep_recent_tool_results,
+            compactable_tools=compactable_tools,
+        )
+        self.summarize: CompactService
+        if use_llm_summary:
+            self.summarize = SummarizeCompact(
+                keep_recent=keep_recent,
+                summary_max_chars=summary_max_chars,
+                summary_max_tokens=summary_max_tokens,
+            )
+        else:
+            self.summarize = TruncateCompact(keep_recent=keep_recent)
+        self.fallback = TruncateCompact(keep_recent=max(1, keep_recent))
+
+    def compact(
+        self,
+        *,
+        state: AgentState,
+        session_log: SessionLog,
+        llm: LLMBackend,
+        conversation: Any | None,
+        step_num: int,
+        reason: str,
+    ) -> CompactOutcome:
+        outcomes: list[tuple[str, CompactOutcome]] = []
+
+        prune_outcome = self.prune.compact(
+            state=state,
+            session_log=session_log,
+            llm=llm,
+            conversation=conversation,
+            step_num=step_num,
+            reason=reason,
+        )
+        outcomes.append(("prune_tool_results", prune_outcome))
+
+        summarize_outcome = self.summarize.compact(
+            state=state,
+            session_log=session_log,
+            llm=llm,
+            conversation=conversation,
+            step_num=step_num,
+            reason=reason,
+        )
+        outcomes.append(
+            ("summarize_context" if self.use_llm_summary else "truncate_context", summarize_outcome)
+        )
+
+        if not any(outcome.compacted for _, outcome in outcomes):
+            fallback_outcome = self.fallback.compact(
+                state=state,
+                session_log=session_log,
+                llm=llm,
+                conversation=conversation,
+                step_num=step_num,
+                reason=reason,
+            )
+            outcomes.append(("fallback_truncate", fallback_outcome))
+
+        merged = _merge_outcomes(reason, outcomes)
+        if merged.extra is None:
+            merged.extra = {}
+        merged.extra.update(
+            {
+                "mode": "default",
+                "keep_recent": self.keep_recent,
+                "keep_recent_tool_results": self.keep_recent_tool_results,
+                "use_llm_summary": self.use_llm_summary,
+            }
+        )
+        return merged
+
+
+def default_compact_service(**kwargs: Any) -> DefaultCompactService:
+    """Return the recommended production compaction service.
+
+    This small factory is convenient in workspace resource builders::
+
+        from looplet import default_compact_service
+
+        def build(runtime=None):
+            return default_compact_service(keep_recent=3)
+    """
+
+    return DefaultCompactService(**kwargs)
 
 
 # ── Chained compaction ───────────────────────────────────────────
@@ -594,13 +921,7 @@ class _CompactChain:
             total_llm += outcome.llm_calls_spent
 
             # Did this stage have an effect?
-            _shrank = (
-                outcome.messages_before is not None
-                and outcome.messages_after is not None
-                and outcome.messages_after < outcome.messages_before
-            )
-            _pruned = outcome.extra is not None and outcome.extra.get("cleared", 0) > 0
-            if _shrank or _pruned or i == len(self._stages) - 1:
+            if outcome.compacted or i == len(self._stages) - 1:
                 outcome.llm_calls_spent = total_llm
                 if outcome.extra is None:
                     outcome.extra = {}

--- a/src/looplet/examples/coding_agent.py
+++ b/src/looplet/examples/coding_agent.py
@@ -13,16 +13,16 @@ Demonstrates how a well-structured agent harness works:
    remediation steps, so the agent self-corrects without human input.
 5. **Persistent standards** — coding standards are injected via
    ``StaticMemorySource`` and survive all compactions.
-6. **Compaction chain** — for long sessions: prune old tool results
-   first (free), then LLM-summarize (one call), then truncate (last resort).
+6. **Default compaction** — for long sessions: prune old tool results,
+   summarize older context, then truncate only as a last resort.
 
 This agent:
   - Receives a task ("implement a fibonacci function with tests")
   - Uses the same tools as Claude Code: bash, read, write, edit, glob, grep, think
   - Gets just-in-time review feedback via a ``post_dispatch`` hook
   - Keeps running until tests pass (``check_done`` quality gate)
-  - Has persistent memory (coding standards survive compaction)
-  - Uses ``compact_chain`` for context management in long sessions
+    - Has persistent memory (coding standards survive compaction)
+    - Uses ``DefaultCompactService`` for context management in long sessions
 
 Run::
 
@@ -44,6 +44,7 @@ from typing import Any
 
 from looplet import (
     ContextBudget,
+    DefaultCompactService,
     DefaultState,
     DomainAdapter,
     EvalContext,
@@ -52,12 +53,8 @@ from looplet import (
     InjectContext,
     LoopConfig,
     MockLLMBackend,
-    PruneToolResults,
     StaticMemorySource,
-    SummarizeCompact,
     ThresholdCompactHook,
-    TruncateCompact,
-    compact_chain,
     composable_loop,
     probe_native_tool_support,
     tool,
@@ -378,20 +375,14 @@ CODING_STANDARDS = StaticMemorySource("""\
 """)
 
 # ═══════════════════════════════════════════════════════════════════
-# 4. COMPACTION CHAIN — cheap first, then LLM, then truncate
+# 4. DEFAULT COMPACTION — prune, summarize, then truncate fallback
 #
-# Long sessions need context management. The chain tries the
-# cheapest strategy first:
-#   1. PruneToolResults — clear old tool output (free)
-#   2. SummarizeCompact — LLM summary of middle (one call)
-#   3. TruncateCompact — drop everything except last 2 (free, last resort)
+# Long sessions need context management. DefaultCompactService keeps
+# recent steps verbatim, prunes old bulky tool results, summarizes the
+# older working session, and falls back to deterministic truncation.
 # ═══════════════════════════════════════════════════════════════════
 
-COMPACT_SERVICE = compact_chain(
-    PruneToolResults(keep_recent=5),
-    SummarizeCompact(keep_recent=2),
-    TruncateCompact(keep_recent=1),
-)
+COMPACT_SERVICE = DefaultCompactService(keep_recent=2, keep_recent_tool_results=5)
 
 # ═══════════════════════════════════════════════════════════════════
 # 5. DOMAIN ADAPTER — Bundle domain callables in one object

--- a/src/looplet/examples/data_agent.py
+++ b/src/looplet/examples/data_agent.py
@@ -7,9 +7,10 @@ frameworks, shown as one agent that actually needs them:
   freely, but calling ``delete_rows`` must get human sign-off. The
   sync handler blocks on ``input()`` until you approve / deny.
 
-* **Compact** — ``compact_chain(PruneToolResults, TruncateCompact)``
-  fires whenever the session grows past a tiny 4 000-token budget,
-  so you'll actually watch it happen on a normal-sized run.
+* **Compact** — ``DefaultCompactService`` fires whenever the session
+    grows past a tiny 4 000-token budget, so you'll actually watch it
+    happen on a normal-sized run. This example disables the summary LLM
+    call so scripted/offline runs stay deterministic.
 
 * **Checkpoints** — every step is serialised to
   ``./checkpoints/data_agent/``. Kill the script (Ctrl-C) mid-run
@@ -46,13 +47,11 @@ from pathlib import Path
 from looplet import (
     ApprovalHook,
     ContextBudget,
+    DefaultCompactService,
     DefaultState,
     LoopConfig,
     MockLLMBackend,
-    PruneToolResults,
     ThresholdCompactHook,
-    TruncateCompact,
-    compact_chain,
     composable_loop,
     probe_native_tool_support,
     tool,
@@ -238,10 +237,11 @@ def main(argv: list[str] | None = None) -> int:
 
     tools = build_tools()
 
-    # ── Compact: two-stage chain, tiny budget so it fires on a short run.
-    compact_service = compact_chain(
-        PruneToolResults(keep_recent=3),
-        TruncateCompact(keep_recent=4),
+    # ── Compact: default service, tiny budget so it fires on a short run.
+    compact_service = DefaultCompactService(
+        keep_recent=4,
+        keep_recent_tool_results=3,
+        use_llm_summary=False,
     )
     budget = ContextBudget(
         context_window=4_000,

--- a/src/looplet/presets.py
+++ b/src/looplet/presets.py
@@ -28,12 +28,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from looplet.budget import ContextBudget, ThresholdCompactHook
-from looplet.compact import (
-    PruneToolResults,
-    SummarizeCompact,
-    TruncateCompact,
-    compact_chain,
-)
+from looplet.compact import DefaultCompactService
 from looplet.loop import LoopConfig
 from looplet.memory import StaticMemorySource
 from looplet.tools import BaseToolRegistry, ToolSpec, register_done_tool, tool, tools_from
@@ -443,11 +438,7 @@ def coding_agent_preset(
             "install packages, and execute commands. Use edit for targeted "
             "fixes, write for new files. Run tests before calling done."
         ),
-        compact_service=compact_chain(
-            PruneToolResults(keep_recent=5),
-            SummarizeCompact(keep_recent=2),
-            TruncateCompact(keep_recent=1),
-        ),
+        compact_service=DefaultCompactService(keep_recent=2, keep_recent_tool_results=5),
         memory_sources=[
             StaticMemorySource(
                 "## Coding Standards (persistent)\n"
@@ -517,11 +508,7 @@ def research_agent_preset(
             "to understand the codebase. Produce clear, structured findings. "
             "Call done with a comprehensive summary when finished."
         ),
-        compact_service=compact_chain(
-            PruneToolResults(keep_recent=8),
-            SummarizeCompact(keep_recent=3),
-            TruncateCompact(keep_recent=2),
-        ),
+        compact_service=DefaultCompactService(keep_recent=3, keep_recent_tool_results=8),
         context_window=context_window,
     )
 

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -78,9 +78,9 @@ mechanism hook kwargs use. Example::
     tracer: "@tracer"
 
     # resources/compact_service.py
-    from looplet.compact import PruneToolResults, TruncateCompact, compact_chain
+    from looplet.compact import default_compact_service
     def build(runtime=None):
-        return compact_chain(PruneToolResults(), TruncateCompact())
+        return default_compact_service(keep_recent=2)
 
 This eliminates the ``setup.py`` detour for the common case of
 attaching callable LoopConfig services. Tool dependency injection

--- a/tests/test_compact_smoke.py
+++ b/tests/test_compact_smoke.py
@@ -7,6 +7,7 @@ import pytest
 from looplet import (
     CompactOutcome,
     CompactService,
+    DefaultCompactService,
     EventPayload,
     LifecycleEvent,
     TruncateCompact,
@@ -17,8 +18,11 @@ pytestmark = pytest.mark.smoke
 
 
 class TestDefaultCompactService:
-    def test_default_service_is_compact_service(self):
+    def test_truncate_service_is_compact_service(self):
         assert isinstance(TruncateCompact(), CompactService)
+
+    def test_default_service_is_compact_service(self):
+        assert isinstance(DefaultCompactService(), CompactService)
 
     def test_default_service_returns_outcome(self):
         svc = TruncateCompact()
@@ -38,14 +42,34 @@ class TestDefaultCompactService:
         assert isinstance(outcome, CompactOutcome)
         assert outcome.reason == "test"
 
+    def test_outcome_reports_session_log_compaction(self):
+        from looplet.session import SessionLog
+
+        log = SessionLog()
+        for step in range(1, 7):
+            log.record(step=step, theory="", tool="read", reasoning=f"step {step}")
+        outcome = TruncateCompact(keep_recent=2).compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=None,
+            conversation=None,
+            step_num=6,
+            reason="test",
+        )
+        assert outcome.session_entries_before == 6
+        assert outcome.session_entries_after < 6
+        assert outcome.compacted_step_range == (1, 4)
+        assert outcome.compacted is True
+        assert outcome.to_dict()["compacted"] is True
+
 
 class TestRunCompactEvents:
     def test_pre_and_post_compact_events_fire(self):
-        seen: list[LifecycleEvent] = []
+        seen: list[EventPayload] = []
 
         class Observer:
             def on_event(self, payload: EventPayload):
-                seen.append(payload.event)
+                seen.append(payload)
                 return None
 
         state = type("S", (), {"steps": []})()
@@ -62,8 +86,10 @@ class TestRunCompactEvents:
             step_num=0,
             reason="test",
         )
-        assert LifecycleEvent.PRE_COMPACT in seen
-        assert LifecycleEvent.POST_COMPACT in seen
+        assert LifecycleEvent.PRE_COMPACT in [payload.event for payload in seen]
+        assert LifecycleEvent.POST_COMPACT in [payload.event for payload in seen]
+        post = next(payload for payload in seen if payload.event == LifecycleEvent.POST_COMPACT)
+        assert post.extra["outcome"]["reason"] == "test"
         assert outcome.reason == "test"
 
     def test_pre_compact_can_abort(self):

--- a/tests/test_compact_strategies_smoke.py
+++ b/tests/test_compact_strategies_smoke.py
@@ -13,6 +13,7 @@ from looplet import (
 )
 from looplet.compact import (
     CompactOutcome,
+    DefaultCompactService,
     PruneToolResults,
     SummarizeCompact,
     TruncateCompact,
@@ -227,6 +228,32 @@ class TestCompactChain:
         )
         assert out.extra["chain_stage"] == 0
 
+    def test_session_log_only_compaction_counts_as_effective(self):
+        class SessionOnlyCompact:
+            def compact(self, *, session_log, reason, **kwargs):
+                before = len(session_log.entries)
+                del session_log.entries[:-1]
+                return CompactOutcome(
+                    reason=reason,
+                    session_entries_before=before,
+                    session_entries_after=len(session_log.entries),
+                    compacted_step_range=(1, before - 1),
+                    extra={"mode": "session_only"},
+                )
+
+        chain = compact_chain(SessionOnlyCompact(), TruncateCompact(keep_recent=1))
+        log = _log(5)
+        out = chain.compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=None,
+            conversation=None,
+            step_num=5,
+            reason="test",
+        )
+        assert out.extra["chain_stage"] == 0
+        assert len(log.entries) == 1
+
 
 # ── CompactOutcome.cleanup ───────────────────────────────────────
 
@@ -324,3 +351,85 @@ class TestLoopIntegration:
             )
         )
         assert len(steps) == 2
+
+
+class _SummaryLLM:
+    def __init__(self, text: str = "LLM summary kept") -> None:
+        self.text = text
+        self.calls = 0
+
+    def generate(self, prompt, *, max_tokens=2000, system_prompt="", temperature=0.2):
+        self.calls += 1
+        return self.text
+
+
+class TestSummarizeCompact:
+    def test_reuses_llm_summary_for_conversation_boundary(self):
+        conv = _conv_with_tool_results(5)
+        log = _log(5)
+        llm = _SummaryLLM("TASK: preserve this summary")
+        out = SummarizeCompact(keep_recent=2).compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=llm,
+            conversation=conv,
+            step_num=5,
+            reason="test",
+        )
+        assert out.summary == "TASK: preserve this summary"
+        boundaries = conv.find_compaction_boundaries()
+        assert boundaries
+        assert boundaries[-1].metadata["summary"] == "TASK: preserve this summary"
+        assert out.session_entries_after < out.session_entries_before
+
+    def test_short_session_log_does_not_grow(self):
+        conv = _conv_with_tool_results(4)
+        log = _log(2)
+        llm = _SummaryLLM("summary for conversation only")
+        out = SummarizeCompact(keep_recent=1).compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=llm,
+            conversation=conv,
+            step_num=4,
+            reason="test",
+        )
+        assert out.summary == "summary for conversation only"
+        assert out.session_entries_after == out.session_entries_before
+        assert out.compacted_step_range is None
+
+
+class TestDefaultCompactService:
+    def test_prunes_and_summarizes_in_one_service(self):
+        conv = _conv_with_tool_results(8)
+        log = _log(8)
+        llm = _SummaryLLM("default summary")
+        out = DefaultCompactService(keep_recent=2, keep_recent_tool_results=3).compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=llm,
+            conversation=conv,
+            step_num=8,
+            reason="proactive",
+        )
+        assert out.compacted is True
+        assert out.llm_calls_spent == 1
+        assert out.summary == "default summary"
+        assert out.extra["mode"] == "default"
+        stage_names = [stage["name"] for stage in out.extra["stages"]]
+        assert stage_names == ["prune_tool_results", "summarize_context"]
+        assert out.extra["cleared"] > 0
+
+    def test_can_run_without_llm_summary(self):
+        log = _log(6)
+        out = DefaultCompactService(keep_recent=2, use_llm_summary=False).compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=None,
+            conversation=None,
+            step_num=6,
+            reason="offline",
+        )
+        assert out.llm_calls_spent == 0
+        assert out.session_entries_after < out.session_entries_before
+        assert out.extra["use_llm_summary"] is False


### PR DESCRIPTION
## Summary
- add DefaultCompactService and default_compact_service as the recommended production compaction path
- enrich CompactOutcome reporting and POST_COMPACT event payloads
- update presets, docs, packaged examples, and workspace compact_service resources to use the new default
- add regression coverage for session-log compaction accounting, summary reuse, and default-service behavior

## Validation
- uv run ruff check src/looplet/compact.py src/looplet/workspace.py src/looplet/examples/coding_agent.py src/looplet/examples/data_agent.py src/looplet/presets.py tests/test_compact_smoke.py tests/test_compact_strategies_smoke.py examples/coder.workspace/resources/compact_service.py examples/dep_doctor.workspace/resources/compact_service.py examples/git_detective.workspace/resources/compact_service.py examples/threat_intel.workspace/resources/compact_service.py
- uv run ruff format --check src/looplet/compact.py src/looplet/workspace.py src/looplet/examples/coding_agent.py src/looplet/examples/data_agent.py src/looplet/presets.py tests/test_compact_smoke.py tests/test_compact_strategies_smoke.py examples/coder.workspace/resources/compact_service.py examples/dep_doctor.workspace/resources/compact_service.py examples/git_detective.workspace/resources/compact_service.py examples/threat_intel.workspace/resources/compact_service.py
- uv run pytest tests/test_examples.py tests/test_packaged_coding_agent_smoke.py tests/test_data_agent_example_smoke.py tests/test_workspace.py tests/test_workspace_extends_smoke.py tests/test_compact_smoke.py tests/test_compact_strategies_smoke.py -q --tb=short
- uv run pyright src/looplet/
- git push pre-push hook: full suite passed, 1701 passed

## Notes
- Tried docs build separately, but mkdocs is not installed in the current uv dev environment and there is no docs extra in pyproject.toml.