### PR TITLE
fix(compact): avoid growing repeated compactions

### DIFF
--- a/src/looplet/compact.py
+++ b/src/looplet/compact.py
@@ -199,6 +199,28 @@ def _render_transcript(session_log: Any | None, conversation: Any | None) -> tup
     return "", "empty"
 
 
+def _compact_conversation_if_smaller(
+    conversation: Any | None,
+    *,
+    keep_recent: int,
+    summarizer: Callable[[list[Any]], str] | None = None,
+) -> int | None:
+    """Compact a conversation only when the message count shrinks."""
+    if conversation is None or not hasattr(conversation, "compact"):
+        return _message_count(conversation)
+    before = _message_count(conversation)
+    original_messages = list(getattr(conversation, "messages", []))
+    if summarizer is None:
+        conversation.compact(keep_recent=keep_recent)
+    else:
+        conversation.compact(summarizer=summarizer, keep_recent=keep_recent)
+    after = _message_count(conversation)
+    if before is not None and after is not None and after >= before:
+        conversation.messages = original_messages
+        return before
+    return after
+
+
 def _stage_report(name: str, outcome: CompactOutcome) -> dict[str, Any]:
     return {
         "name": name,
@@ -291,9 +313,10 @@ class TruncateCompact:
         compacted_step_range = candidate_step_range if session_was_compacted else None
 
         # Conversation side (optional — most domains don't thread one).
-        if conversation is not None and hasattr(conversation, "compact"):
-            conversation.compact(keep_recent=self.keep_recent)
-        messages_after = _message_count(conversation)
+        messages_after = _compact_conversation_if_smaller(
+            conversation,
+            keep_recent=self.keep_recent,
+        )
 
         return CompactOutcome(
             reason=reason,
@@ -525,12 +548,14 @@ class SummarizeCompact:
                 entries_after=session_entries_after,
             )
             compacted_step_range = candidate_step_range if session_was_compacted else None
-            if conversation is not None and hasattr(conversation, "compact"):
-                conversation.compact(keep_recent=self.keep_recent)
+            messages_after = _compact_conversation_if_smaller(
+                conversation,
+                keep_recent=self.keep_recent,
+            )
             return CompactOutcome(
                 reason=reason,
                 messages_before=messages_before,
-                messages_after=_message_count(conversation),
+                messages_after=messages_after,
                 session_entries_before=session_entries_before,
                 session_entries_after=session_entries_after,
                 compacted_step_range=compacted_step_range,
@@ -610,16 +635,11 @@ class SummarizeCompact:
                 # a splice failure break the loop.
                 pass
 
-        if conversation is not None and hasattr(conversation, "compact"):
-            if summary_text:
-                conversation.compact(
-                    summarizer=lambda _messages: summary_text,
-                    keep_recent=self.keep_recent,
-                )
-            else:
-                conversation.compact(keep_recent=self.keep_recent)
-
-        messages_after = _message_count(conversation)
+        messages_after = _compact_conversation_if_smaller(
+            conversation,
+            keep_recent=self.keep_recent,
+            summarizer=(lambda _messages: summary_text) if summary_text else None,
+        )
         final_summary = summary_text or fallback_summary
         return CompactOutcome(
             reason=reason,

--- a/tests/test_compact_strategies_smoke.py
+++ b/tests/test_compact_strategies_smoke.py
@@ -433,3 +433,43 @@ class TestDefaultCompactService:
         assert out.llm_calls_spent == 0
         assert out.session_entries_after < out.session_entries_before
         assert out.extra["use_llm_summary"] is False
+
+    def test_repeat_compaction_does_not_expand_conversation(self):
+        conv = Conversation()
+        for step in range(1, 8):
+            conv.append(Message(role=MessageRole.USER, content=f"user {step}"))
+            conv.append(Message(role=MessageRole.ASSISTANT, content=f"assistant {step}"))
+            conv.append(
+                Message(
+                    role=MessageRole.TOOL,
+                    content="large result" * 200,
+                    tool_result=ToolResult(tool="tool", args_summary="", data={"step": step}),
+                )
+            )
+        log = _log(7)
+        service = DefaultCompactService(keep_recent=2, keep_recent_tool_results=2)
+
+        first = service.compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=_SummaryLLM("first summary"),
+            conversation=conv,
+            step_num=8,
+            reason="first",
+        )
+        messages_after_first = len(conv.messages)
+        entries_after_first = len(log.entries)
+        second = service.compact(
+            state=type("S", (), {"steps": []})(),
+            session_log=log,
+            llm=_SummaryLLM("second summary"),
+            conversation=conv,
+            step_num=9,
+            reason="second",
+        )
+
+        assert first.compacted is True
+        assert len(conv.messages) <= messages_after_first
+        assert len(log.entries) <= entries_after_first
+        assert second.messages_after <= second.messages_before
+        assert second.session_entries_after <= second.session_entries_before


### PR DESCRIPTION
## Summary
- prevent conversation compaction from applying when it would not reduce message count
- keep repeated DefaultCompactService calls from expanding already compacted conversations
- add regression coverage for repeat compaction on boundary-preserving conversations

## Dogfood
- ran deterministic hello_world, data_agent, coding_agent, and scripted_demo examples
- exercised bundled workspace compact_service resources for coder, dep_doctor, git_detective, and threat_intel
- forced repeated proactive compactions in a live composable_loop
- forced prompt-too-long reactive recovery through DefaultCompactService
- exercised LLM summary failure fallback, no-summary offline mode, conversation-only compaction, and outcome JSON serialization

## Validation
- uv run ruff check src/looplet/compact.py tests/test_compact_strategies_smoke.py
- uv run ruff format --check src/looplet/compact.py tests/test_compact_strategies_smoke.py
- uv run pytest tests/test_compact_smoke.py tests/test_compact_strategies_smoke.py tests/test_llm_compact_smoke.py tests/test_proactive_compact_smoke.py tests/test_compaction_boundary.py tests/test_multimodal_compaction.py -q --tb=short
- uv run pyright src/looplet/
- uv run pytest -q --tb=short: 1702 passed
- pre-push hook full suite: 1702 passed