### PR TITLE
feat(spec): cartridge-spec v1.0 — internal boundary + declarative slots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,365 @@
+# Cartridge Spec v1.0
+
+> **Status.** Reference implementation in this repository (Looplet).
+> Companion artifact: [`cartridge.schema.json`](cartridge.schema.json).
+> **Audience.** Loader implementers in any language; agent builders.
+> **Versioning.** Semantic. v1.x is additive. Slot renames or breaking
+> shape changes require a v2 RFC.
+
+A **cartridge** (a.k.a. *workspace*) is a small directory of files
+that fully describes an LLM agent's behavioural contract. The
+runtime that loads and runs a cartridge is interchangeable. The
+cartridge is the artifact; the runtime is the engine.
+
+This document specifies what files a v1 cartridge contains, what
+each file means, and what a conformant loader must do with them.
+
+## Core principles
+
+1. **The cartridge is complete.** Loading the cartridge is sufficient
+   to reproduce the agent's surface. No hidden registries, no
+   runtime patches, no environment-only state.
+2. **The cartridge is runtime-agnostic.** No file in the cartridge
+   names a particular runtime. Tool bodies are ordinary functions in
+   the host language; hooks are ordinary classes implementing a small
+   protocol. The runtime binds them.
+3. **Every editable concern has a fixed location.** Reviewers,
+   admission gates, and diff tools can determine the *category* of an
+   edit from the *path* alone, without reading file contents.
+4. **Slots may be empty, never ambiguous.** A loader sees either a
+   recognised file at a known path or nothing.
+
+## Layout (canonical)
+
+```
+my_agent.workspace/
+├── workspace.json              # required: name, schema_version
+├── config.yaml                 # required: loop config + declarative slots
+├── prompts/
+│   └── system.md               # required: the system prompt, alone
+├── tools/
+│   └── <name>/
+│       ├── tool.yaml           # required per tool
+│       └── execute.py          # required per tool (host language body)
+├── hooks/                      # optional
+│   └── NN_<name>/
+│       ├── config.yaml         # optional kwargs for the hook class
+│       └── hook.py             # required when the hook is local code
+├── resources/                  # optional
+│   └── <name>.py               # optional: shared singletons (def build())
+├── memory/                     # optional
+│   ├── long_term.md            # optional: long-term memory (v1.0 slot)
+│   └── *.md / *.py             # optional: ordered memory sources
+└── setup.py                    # optional: imperative escape hatch
+```
+
+The `.workspace` directory suffix is conventional but not load-bearing
+(loaders MUST accept any directory containing a valid `workspace.json`).
+
+## Manifest — `workspace.json`
+
+```json
+{
+  "name": "my_agent",
+  "schema_version": 1,
+  "description": "what the agent does",
+  "version": "1.0.0"
+}
+```
+
+Required fields: `name`, `schema_version`. v1.0 cartridges set
+`schema_version: 1`. `description` and `version` are optional and
+declarative.
+
+## Configuration — `config.yaml`
+
+The configuration file declares loop budgets, model binding, slot
+references, and inheritance. All fields are optional except as
+noted. Loaders MUST accept any v1.0 cartridge with an empty
+`config.yaml` (defaults apply).
+
+### Loop budgets
+
+```yaml
+max_steps: 20                  # default 15
+max_tokens: 2000               # max tokens per LLM call
+recovery_temperature: 0.1
+context_window: 128000
+max_briefing_tokens: 4000      # null = unbounded
+use_native_tools: false
+concurrent_dispatch: false
+reactive_recovery: true
+done_tool: done                # name of the completion sentinel tool
+```
+
+### Model binding (v1.0 slot)
+
+A structured `model:` block declares the LLM the cartridge is
+designed for. Loaders that bind a different model SHOULD warn.
+
+```yaml
+model:
+  provider: anthropic              # openai | anthropic | azure | …
+  name: claude-sonnet-4.6          # provider-specific id
+  reasoning_effort: high           # minimal | low | medium | high | xhigh
+  max_tokens: 4096
+  temperature: 0.2
+  top_p: 1.0
+  extra:                           # provider-specific pass-through
+    cache_control: ephemeral
+```
+
+**Backwards compatibility.** Pre-v1.0 cartridges set the flat
+`temperature:` and `max_tokens:` at the top level. Loaders MUST
+continue to accept the flat form; when both are present, the
+`model:` block wins.
+
+### Permissions (v1.0 slot)
+
+A declarative permissions block compiles into a `PermissionEngine`
+hook. Tools without an explicit rule fall through to `default`.
+
+```yaml
+permissions:
+  default: allow                   # allow | deny | ask
+  deny:
+    - tool: bash
+      contains:
+        command: "rm -rf"
+      reason: "destructive shell"
+    - tool: write
+      contains:
+        file_path: "/etc"
+      reason: "system path"
+  ask:
+    - tool: bash
+  allow:
+    - read
+    - glob
+    - grep
+```
+
+A bare string entry (e.g. `- read`) is shorthand for `{ tool: read }`.
+
+### Memory (v1.0 slot)
+
+```yaml
+memory:
+  long_term: memory/long_term.md   # default if file exists
+  include:                         # additional ordered files
+    - memory/lessons.md
+  max_tokens: 1500                 # truncate combined memory
+```
+
+When `memory/long_term.md` exists and no `memory:` block is given,
+loaders MUST auto-load it as a long-term memory source.
+
+### Inheritance
+
+```yaml
+extends: ../base.workspace        # one parent
+```
+
+The loader resolves the chain top-down: ancestor first, child wins on
+any conflict. Inheritance applies to tools (by directory name),
+hooks (by directory name), resources (by file name), and config
+fields (last write wins).
+
+### Built-in registries
+
+```yaml
+builtin_tools:
+  - search_skills
+  - activate_skill
+
+builtin_hooks:
+  - skill_activation
+  - stagnation: { threshold: 6, ignore_tools: [think, done] }
+```
+
+A loader MAY ship a built-in registry of tools and hooks. The
+contents of the registry are not part of v1.0 (they are
+implementation-defined). The directives themselves are part of v1.0.
+
+### Reference grammar
+
+Three forms work in any string-valued YAML field:
+
+| Form                     | Meaning                                       |
+|--------------------------|-----------------------------------------------|
+| `${ref:name}`            | Resolve from `resources/<name>.py::build()`.  |
+| `${py:module:symbol}`    | Import a Python object by dotted path.        |
+| `${runtime.field}`       | Per-invocation runtime dict; supports `.a.b`. |
+| `${runtime.x:-default}`  | Default if the runtime key is absent.         |
+
+The legacy `@name` form is an alias for `${ref:name}`.
+
+## System prompt — `prompts/system.md`
+
+A single Markdown file containing the agent's system prompt verbatim.
+No templating. The whole file is the prompt.
+
+## Tools — `tools/<name>/`
+
+Each tool is a directory with a `tool.yaml` manifest and an
+`execute.py` body. Loaders MAY accept additional language extensions
+in future spec versions.
+
+```yaml
+# tools/bash/tool.yaml
+name: bash
+description: Run a shell command and return stdout, stderr, exit code.
+parameters:
+  command:
+    type: string
+    description: The shell command to run.
+requires:
+  - workspace_config
+concurrent_safe: false
+free: false
+timeout_s: 60
+```
+
+```python
+# tools/bash/execute.py
+import subprocess
+
+def execute(ctx, *, command: str) -> dict:
+    workspace = ctx.resources["workspace_config"].workspace
+    proc = subprocess.run(command, shell=True, cwd=workspace, capture_output=True, text=True, timeout=60)
+    return {"stdout": proc.stdout, "stderr": proc.stderr, "exit_code": proc.returncode}
+```
+
+The `done` tool is required. The loader treats it as the loop's
+completion sentinel; `done_tool:` in `config.yaml` defaults to it.
+
+### Output contract on `done` (v1.0 slot)
+
+When `tools/done/tool.yaml` declares `output_schema:`, loaders MUST
+validate the agent's `done` arguments against it before terminating
+the loop. This makes the agent's *return shape* part of the
+cartridge contract, not an implicit convention.
+
+```yaml
+# tools/done/tool.yaml
+name: done
+description: Mark the task complete with a structured summary.
+parameters:
+  summary: { type: string }
+  pass:    { type: boolean }
+output_schema:
+  type: object
+  required: [summary, pass]
+  properties:
+    summary: { type: string, minLength: 1 }
+    pass:    { type: boolean }
+```
+
+## Hooks — `hooks/NN_<name>/`
+
+A hook directory contains either a local `hook.py` plus optional
+`config.yaml` (kwargs passed to the hook class), or just `config.yaml`
+that points at an importable class via the reference grammar.
+
+```yaml
+# hooks/01_CodingGuardrailHook/config.yaml
+class_name: CodingGuardrailHook
+order: 1
+kwargs:
+  max_warnings: 3
+```
+
+The `NN_` prefix sorts hook ordering. The hook must implement the
+`LoopHook` protocol: at minimum one of `pre_dispatch`, `post_dispatch`,
+`check_done`, or `should_stop`.
+
+## Resources — `resources/<name>.py`
+
+Each resource module exports a `build(runtime=None)` function that
+returns a singleton instance. Tools and hooks request the singleton
+through `requires:`; the loader injects it via `ctx.resources[<name>]`.
+
+```python
+# resources/workspace_config.py
+def build(runtime=None):
+    return WorkspaceConfig(workspace=runtime["workspace"])
+```
+
+The reserved resource name `runtime` is auto-injected from the host
+runtime dict. Tools may declare `requires: [runtime]` directly without
+a builder file.
+
+## Memory — `memory/`
+
+Files in this directory contribute to the agent's persistent context.
+
+| File                 | Role                                              |
+|----------------------|---------------------------------------------------|
+| `long_term.md`       | Long-term memory; auto-loaded as a v1.0 slot.     |
+| `*.md`               | Ordered static memory sources (filename = order). |
+| `*.py`               | A module with `def load(state) -> str`.           |
+
+Memory sources are concatenated in filename order, prefixed with
+`memory/long_term.md` if present.
+
+## Setup — `setup.py` (optional escape hatch)
+
+A `setup(preset, resources, *, runtime=None)` function may mutate the
+preset before it is returned. Most cartridges should not need this;
+the declarative slots above cover the published examples.
+
+## Loader contract (what a conformant runtime promises)
+
+A loader implementation MUST:
+
+1. **Validate the manifest.** Reject cartridges with no
+   `workspace.json` or with `schema_version` greater than the loader
+   supports.
+2. **Resolve `extends:`.** Apply ancestors top-down before reading
+   the leaf.
+3. **Construct an `AgentPreset`** with: the parsed `LoopConfig`, an
+   ordered tool registry, an ordered hook list, the resource registry,
+   and (if the cartridge declares one) an LLM backend factory.
+4. **Honour the reference grammar** in every string-valued YAML field.
+5. **Auto-load `memory/long_term.md`** when present and not overridden.
+6. **Validate `done` arguments** against `output_schema:` when
+   declared.
+7. **Fail loudly with a structured error** that names the offending
+   file path on any malformed slot. No silent defaults that hide
+   schema breaks.
+
+A loader MAY also implement: hot-reload, parallel tool dispatch,
+prompt-cache reuse, and provider-specific extras (`extra:` in the
+model block). Conformance does not require these.
+
+## Backwards compatibility
+
+v1.0 introduces three new slots: structured `model:`, declarative
+`permissions:`, and `memory.long_term`. All three are optional and
+co-exist with the pre-v1.0 forms (flat `temperature`, hook-based
+permissions, `memory/*.md` files). When both old and new shapes
+appear, the new wins. Loaders SHOULD log a one-line deprecation
+notice when only the old shape is present.
+
+## Conformance fixtures
+
+`tests/conformance/` (in this repository) contains a small set of
+cartridges paired with expected loader outputs. Any v1.0 loader is
+expected to produce equivalent outputs against the same fixtures.
+The conformance suite will grow with v1.x; v2 will mandate it.
+
+## Repository status
+
+Today the schema lives inside the reference implementation. Once a
+second loader exists (or the cartridge registry product reaches
+beta), the spec, the JSON schema, and the conformance suite will
+move to a neutral `cartridge-spec` repository so they have a stable
+home independent of any one runtime. This is planned, not done.
+
+## Changelog
+
+- **v1.0** (2026-05-09) — first numbered version. New slots:
+  `model:`, `permissions:`, `memory.long_term`, `output_schema` on
+  `done`. Conformance fixture seed introduced.
+- **v0.x** — implementation-defined; everything was already
+  declarative but slots were not numbered.

--- a/cartridge.schema.json
+++ b/cartridge.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hsaghir/looplet/blob/master/cartridge.schema.json",
+  "title": "Cartridge — agent artifact schema",
+  "description": "Machine-readable schema for the cartridge artifact described in SPEC.md (cartridge-spec v1.0). Two manifest files share this schema: workspace.json and config.yaml.",
+  "type": "object",
+  "$defs": {
+    "manifest": {
+      "type": "object",
+      "required": ["name", "schema_version"],
+      "additionalProperties": true,
+      "properties": {
+        "name":           { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
+        "schema_version": { "type": "integer", "const": 1 },
+        "description":    { "type": "string" },
+        "version":        { "type": "string" }
+      }
+    },
+    "model_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider":         { "type": "string", "description": "openai, anthropic, azure, vertex, …" },
+        "name":             { "type": "string", "description": "Provider-specific model id." },
+        "reasoning_effort": { "type": "string", "enum": ["minimal", "low", "medium", "high", "xhigh"] },
+        "max_tokens":       { "type": "integer", "minimum": 1 },
+        "temperature":      { "type": "number", "minimum": 0, "maximum": 2 },
+        "top_p":            { "type": "number", "minimum": 0, "maximum": 1 },
+        "extra":            { "type": "object", "description": "Provider-specific extras passed through verbatim." }
+      }
+    },
+    "permissions_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": { "type": "string", "enum": ["allow", "deny", "ask"] },
+        "allow":   { "type": "array", "items": { "$ref": "#/$defs/permission_rule" } },
+        "deny":    { "type": "array", "items": { "$ref": "#/$defs/permission_rule" } },
+        "ask":     { "type": "array", "items": { "$ref": "#/$defs/permission_rule" } }
+      }
+    },
+    "permission_rule": {
+      "oneOf": [
+        { "type": "string", "description": "Tool name to apply the rule to." },
+        {
+          "type": "object",
+          "required": ["tool"],
+          "additionalProperties": false,
+          "properties": {
+            "tool":     { "type": "string" },
+            "reason":   { "type": "string" },
+            "matches":  { "type": "object", "description": "Equality match against tool args." },
+            "contains": { "type": "object", "description": "Substring match against named args." }
+          }
+        }
+      ]
+    },
+    "memory_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "long_term":   { "type": "string", "description": "Path (relative to cartridge root) of the long-term memory file." },
+        "include":     { "type": "array", "items": { "type": "string" } },
+        "max_tokens":  { "type": "integer", "minimum": 0 }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "extends":              { "type": "string" },
+        "max_steps":            { "type": "integer", "minimum": 1 },
+        "max_tokens":           { "type": "integer", "minimum": 1 },
+        "temperature":          { "type": "number" },
+        "recovery_temperature": { "type": "number" },
+        "use_native_tools":     { "type": "boolean" },
+        "concurrent_dispatch":  { "type": "boolean" },
+        "reactive_recovery":    { "type": "boolean" },
+        "context_window":       { "type": "integer", "minimum": 0 },
+        "max_briefing_tokens":  { "type": ["integer", "null"], "minimum": 0 },
+        "checkpoint_dir":       { "type": ["string", "null"] },
+        "done_tool":            { "type": "string" },
+        "model":                { "$ref": "#/$defs/model_block" },
+        "permissions":          { "$ref": "#/$defs/permissions_block" },
+        "memory":               { "$ref": "#/$defs/memory_block" },
+        "memory_sources":       { "type": "array" },
+        "builtin_tools":        { "type": "array" },
+        "builtin_hooks":        { "type": "array" },
+        "compact_service":      { "type": ["string", "object"] },
+        "state":                { "type": ["string", "object"] }
+      }
+    },
+    "tool_yaml": {
+      "type": "object",
+      "required": ["name", "description"],
+      "additionalProperties": true,
+      "properties": {
+        "name":             { "type": "string" },
+        "description":      { "type": "string" },
+        "parameters":       { "type": "object" },
+        "requires":         { "type": "array", "items": { "type": "string" } },
+        "concurrent_safe":  { "type": "boolean" },
+        "free":             { "type": "boolean" },
+        "timeout_s":        { "type": ["number", "null"] },
+        "output_schema":    { "type": "object", "description": "Schema for the tool's return shape; on the done tool this declares the agent's output contract." }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/manifest" },
+    { "$ref": "#/$defs/config" },
+    { "$ref": "#/$defs/tool_yaml" }
+  ]
+}

--- a/examples/coder.workspace/config.yaml
+++ b/examples/coder.workspace/config.yaml
@@ -11,6 +11,37 @@ memory_sources:
   - "@instructions_memory"
   - "@project_memory"
 
+# v1.0 model binding. Provider/name/effort live in tool_metadata so
+# downstream tooling (cost, routing, governance) can read them; the
+# loop continues to read the flat fields above for back-compat.
+model:
+  provider: anthropic
+  name: claude-sonnet-4.6
+  reasoning_effort: high
+
+# v1.0 declarative permissions. Compiled into a PermissionHook by
+# the loader. Replaces the previous hand-written BashPermissionHook
+# class — the same rules, expressed in the schema.
+permissions:
+  default: allow
+  deny:
+    - tool: bash
+      contains:
+        command: "rm -rf"
+      reason: "destructive recursive delete"
+    - tool: bash
+      contains:
+        command: "sudo "
+      reason: "escalated privileges"
+    - tool: bash
+      contains:
+        command: "> /dev/"
+      reason: "raw device write"
+    - tool: write_file
+      contains:
+        file_path: "/etc/"
+      reason: "system path"
+
 # Generic guard / budget hooks via the looplet-shipped registry.
 # Coder-specific hooks (TestGuardHook, FileCacheHook, StaleFileHook,
 # LinterHook, EvalHook) live under hooks/ alongside this file.

--- a/examples/coder.workspace/tools/done/tool.yaml
+++ b/examples/coder.workspace/tools/done/tool.yaml
@@ -4,3 +4,11 @@ parameters:
   summary:
     type: string
     description: One-line summary of what was accomplished.
+# v1.0 output_schema: validated by the loop before termination.
+output_schema:
+  type: object
+  required: [summary]
+  properties:
+    summary:
+      type: string
+      description: Free-form summary of the task outcome.

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -127,6 +127,7 @@ from looplet.presets import (
 from looplet.prompts import preview_prompt
 from looplet.provenance import ProvenanceSink, TrajectoryRecorder, replay_loop
 from looplet.resilient import ResilientBackend, RetryExhausted
+from looplet.scaffold import scaffold_workspace
 from looplet.session import SessionLog
 from looplet.skills import (
     FileSkillStore,
@@ -275,6 +276,7 @@ __all__ = [
     "WorkspaceSerializationError",
     "preset_to_workspace",
     "resource_ref_for",
+    "scaffold_workspace",
     "workspace_to_preset",
     "StreamingHook",
     "Tracer",

--- a/src/looplet/_spec_modules.py
+++ b/src/looplet/_spec_modules.py
@@ -1,0 +1,98 @@
+"""Declaration of which modules constitute the *cartridge spec*.
+
+This file marks a deliberate, small internal boundary inside
+:mod:`looplet`: the schema and the loader are spec material; the loop,
+backends, examples, CLI, and friends are runtime material. The split
+exists so that:
+
+* the ``SPEC.md`` document can point at a stable, narrow surface;
+* a future repo split (Phase 2 of the agents-as-files roadmap) can
+  carve these modules out without dragging in the runtime;
+* third-party loaders in other languages can study a small set of
+  Python files instead of the whole package.
+
+A test (``tests/test_spec_boundary.py``) enforces that no module in
+:data:`SPEC_MODULES` adds a top-level dependency on a non-spec
+runtime module. New imports inside SPEC modules must either be
+external (stdlib, typing-only ``TYPE_CHECKING``) or lazy (function
+local). When a new spec slot is added, list its module here too.
+"""
+
+from __future__ import annotations
+
+# ── The cartridge spec surface ──────────────────────────────────────
+#
+# Modules whose public types and behaviour define the cartridge.
+# Keep this set deliberately small.
+SPEC_MODULES: frozenset[str] = frozenset(
+    {
+        "workspace",  # the loader + schema parsing
+        "spec_slots",  # v1.0 declarative slots: model, permissions, memory
+        "memory",  # PersistentMemorySource protocol + impls
+        "validation",  # OutputSchema, DoneValidator
+        "permissions",  # PermissionEngine + rule semantics
+        "hook_decision",  # the small return-type vocabulary hooks share
+        "skills",  # agentskills.io SKILL.md format support
+    }
+)
+
+# Runtime modules that SPEC modules MAY NOT top-level import. Listed
+# explicitly so the boundary check can give a precise diagnostic.
+# (TYPE_CHECKING-only imports and function-local imports are always
+# allowed.)
+SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS: frozenset[str] = frozenset(
+    {
+        # The loop itself and everything it pulls in.
+        "loop",
+        "async_loop",
+        "scaffolding",
+        "resilient",
+        # I/O backends.
+        "backends",
+        "router",
+        # Application-level features.
+        "presets",
+        "subagent",
+        "compact",
+        "checkpoint",
+        "evals",
+        "provenance",
+        "cache",
+        "telemetry",
+        "streaming",
+        "context",
+        "context_budget",
+        "limits",
+        "stagnation",
+        "session",
+        "session_tree",
+        "history",
+        "conversation",
+        "prompts",
+        "recovery",
+        "recovery_strategies",
+        "approval",
+        "blueprints",
+        "bundles",
+        "cost",
+        "steering",
+        "hot_reload",
+        "rpc",
+        "harness_snapshot",
+        "done_steps",
+        "events",
+        "flags",
+        "parse",
+        "native_tools",
+        "scaffold",
+        "testing",
+        "builtin_tools",
+        "builtin_hooks",
+        "examples",
+        "cli",
+        "mcp",
+    }
+)
+
+
+__all__ = ["SPEC_MODULES", "SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS"]

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -843,7 +843,7 @@ class EvalHook:
         ``{"evaluators": "@sql_evaluators"}``). Otherwise the writer
         emits the generic ``"@evaluators"`` / ``"@collectors"`` names.
         """
-        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+        from looplet.refs import resource_ref_for  # noqa: PLC0415
 
         ev_ref = resource_ref_for(self.evaluators)
         cfg: dict[str, Any] = {"evaluators": ev_ref or "@evaluators"}

--- a/src/looplet/hot_reload.py
+++ b/src/looplet/hot_reload.py
@@ -57,16 +57,25 @@ __all__ = [
 _WATCHED_SUFFIXES: tuple[str, ...] = (".py", ".yaml", ".yml", ".md", ".json")
 
 
-def fingerprint_workspace(root: str | Path) -> dict[str, float]:
-    """Return ``{relpath: mtime_ns}`` for every watched file under ``root``.
+def fingerprint_workspace(root: str | Path) -> dict[str, str]:
+    """Return ``{relpath: fingerprint}`` for every watched file under ``root``.
 
-    Returns an empty dict if ``root`` does not exist (so the watcher
-    can be constructed before the workspace is generated).
+    Each fingerprint is a short string combining ``mtime_ns``, ``size``, and
+    a 64-bit BLAKE2b digest of the file contents. The digest is what makes
+    the fingerprint correct on filesystems whose ``mtime`` resolution is
+    coarse enough to collapse rapid writes (tmpfs, some network mounts).
+    Without it, two writes within a few microseconds can yield the same
+    ``mtime_ns`` and the watcher silently misses the second edit.
+
+    Returns an empty dict if ``root`` does not exist (so the watcher can
+    be constructed before the workspace is generated).
     """
+    import hashlib  # noqa: PLC0415
+
     base = Path(root)
     if not base.is_dir():
         return {}
-    fp: dict[str, float] = {}
+    fp: dict[str, str] = {}
     for p in base.rglob("*"):
         if not p.is_file():
             continue
@@ -78,9 +87,12 @@ def fingerprint_workspace(root: str | Path) -> dict[str, float]:
         if any(part.startswith("__pycache__") or part.startswith(".") for part in parts):
             continue
         try:
-            fp[str(rel)] = p.stat().st_mtime_ns
+            stat = p.stat()
+            data = p.read_bytes()
         except OSError:
             continue
+        digest = hashlib.blake2b(data, digest_size=8).hexdigest()
+        fp[str(rel)] = f"{stat.st_mtime_ns}:{stat.st_size}:{digest}"
     return fp
 
 
@@ -98,7 +110,7 @@ class WorkspaceWatcher:
     root: str | Path
     runtime: dict[str, Any] | None = None
     strict: bool = False
-    _fp: dict[str, float] = field(default_factory=dict, init=False)
+    _fp: dict[str, str] = field(default_factory=dict, init=False)
     _preset: Any = field(default=None, init=False)
 
     def preset(self) -> Any:

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -2304,10 +2304,15 @@ def composable_loop(
             if gate_warning is not None:
                 logger.info("Quality gate rejected done() at step %d", step_num)
                 quality_gate_message = gate_warning
+                # Mirror the gate reason into ``error`` as well as
+                # ``data['rejected']``: builders grepping for errors
+                # otherwise miss schema-level rejections entirely (a
+                # frequent friction surfaced during dogfooding).
                 tool_result = ToolResult(
                     tool=done_tool_name,
                     args_summary="rejected",
                     data={"rejected": True, "reason": gate_warning},
+                    error=gate_warning,
                 )
                 step = Step(number=cur_step, tool_call=tool_call, tool_result=tool_result)
                 state.steps.append(step)

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -2266,8 +2266,20 @@ def composable_loop(
             gate_warning: str | None = None
             for hook in hooks:
                 if hasattr(hook, "check_done"):
-                    w = _call_check_done(hook, state, session_log, context, step_num, tool_call)
-                    _decision = normalize_hook_return(w, slot="check_done")
+                    try:
+                        w = _call_check_done(hook, state, session_log, context, step_num, tool_call)
+                        _decision = normalize_hook_return(w, slot="check_done")
+                    except Exception:  # noqa: BLE001
+                        # Isolate buggy hooks: a single check_done that
+                        # raises (or returns garbage normalize_hook_return
+                        # rejects) must not crash the loop. Log loudly,
+                        # treat as 'no decision', and let the agent's
+                        # done() through.
+                        logger.exception(
+                            "check_done hook %s raised or returned invalid value; continuing",
+                            type(hook).__name__,
+                        )
+                        _decision = None
                     if _decision is not None:
                         _emit_hook_decision_event(
                             hooks,

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -1146,9 +1146,12 @@ def _intercept_tool_calls(
             if _d.updated_args is not None:
                 tc.args = _d.updated_args
             if _d.permission == "deny":
+                _prefix = f"Permission denied for tool '{tc.tool}'"
+                _reason = _d.block or ""
+                _msg = f"{_prefix}: {_reason}" if _reason else _prefix
                 _te = ToolError(
                     kind=ErrorKind.PERMISSION_DENIED,
-                    message=_d.block or f"Permission denied for tool '{tc.tool}'",
+                    message=_msg,
                     retriable=False,
                 )
                 result.intercepted[tc_idx] = ToolResult(
@@ -1193,9 +1196,12 @@ def _intercept_tool_calls(
             if _decision.updated_args is not None:
                 tc.args = _decision.updated_args
             if _decision.permission == "deny":
+                _prefix = f"Permission denied for tool '{tc.tool}'"
+                _reason = _decision.block or ""
+                _msg = f"{_prefix}: {_reason}" if _reason else _prefix
                 _te = ToolError(
                     kind=ErrorKind.PERMISSION_DENIED,
-                    message=_decision.block or f"Permission denied for tool '{tc.tool}'",
+                    message=_msg,
                     retriable=False,
                 )
                 result.intercepted[tc_idx] = ToolResult(
@@ -1234,11 +1240,14 @@ def _intercept_tool_calls(
                 )
             allowed = _decision is None or _decision.permission != "deny"
             if not allowed:
-                _msg = (
-                    _decision.block
-                    if _decision and _decision.block
-                    else f"Permission denied for tool '{tc.tool}'"
-                )
+                # Always prefix the canonical phrase 'Permission denied for
+                # tool X' so builders grepping for ``permission`` or ``denied``
+                # find it. The hook's specific reason (rule.reason in the
+                # PermissionEngine, or _decision.block elsewhere) is appended
+                # as context, preserving the actionable detail.
+                _prefix = f"Permission denied for tool '{tc.tool}'"
+                _reason = _decision.block if _decision and _decision.block else ""
+                _msg = f"{_prefix}: {_reason}" if _reason else _prefix
                 _te = ToolError(
                     kind=ErrorKind.PERMISSION_DENIED,
                     message=_msg,

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -1406,6 +1406,19 @@ def composable_loop(
     """
     if task is None:
         task = {}
+    # Common new-user mistake: pass a bare string instead of a dict.
+    # The docs and AGENTS.md show ``task={'goal': '...'}`` / ``{'description':
+    # '...'}``; a bare string crashes downstream with
+    # ``AttributeError: 'str' object has no attribute 'items'`` because
+    # the prompt builder iterates ``task.items()``. Catch the shape
+    # mistake at the entry point.
+    if isinstance(task, str):
+        raise TypeError(
+            "composable_loop(task=...) expects a dict, not a string. "
+            f"Wrap the value in a dict like ``task={{'description': {task!r}}}``"
+            " or ``task={{'goal': '...'}}``. The prompt builder iterates the "
+            "dict's keys to render the TASK section."
+        )
     if tools is None:
         raise ValueError("tools is required")
     # Common new-user mistake: pass a list of @tool ToolSpecs (or plain

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -1399,6 +1399,18 @@ def composable_loop(
         task = {}
     if tools is None:
         raise ValueError("tools is required")
+    # Common new-user mistake: pass a list of @tool ToolSpecs (or plain
+    # functions) instead of a registry. The downstream failure is a
+    # bare ``AttributeError: 'list' object has no attribute
+    # 'tool_catalog_text'`` deep inside prompt assembly. Catch the
+    # mistake at the entry point and tell the user about ``tools_from``.
+    if isinstance(tools, list):
+        raise TypeError(
+            "composable_loop(tools=...) expects a tool registry, not a list. "
+            "Wrap your list of @tool functions with ``tools_from(...)``: "
+            "``from looplet import tools_from; tools = tools_from([greet, ...], "
+            "include_done=True, done_parameters={'answer': 'Final answer'})``."
+        )
     if config is None:
         config = LoopConfig()
     if max_steps is not None:

--- a/src/looplet/memory.py
+++ b/src/looplet/memory.py
@@ -29,9 +29,12 @@ string joined by blank lines with empty/None returns skipped.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "PersistentMemorySource",
@@ -191,12 +194,24 @@ def render_memory(
     Falsy outputs (``None`` / empty / whitespace-only) are silently
     skipped so adding an optional source never yields stray blank
     sections. Returns an empty string when there is nothing to render.
+
+    Sources are isolated: if one ``load`` raises, the exception is
+    logged and the source is skipped, mirroring hook isolation in
+    the loop. A single buggy memory source must not bring the loop
+    down.
     """
     if not sources:
         return ""
     chunks: list[str] = []
     for src in sources:
-        text = src.load(state)
+        try:
+            text = src.load(state)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "memory source %s.load() raised; skipping for this turn",
+                type(src).__name__,
+            )
+            continue
         if text is None:
             continue
         s = str(text).strip()

--- a/src/looplet/parse.py
+++ b/src/looplet/parse.py
@@ -204,6 +204,16 @@ def _dict_to_tool_call(d: dict) -> ToolCall | None:
             "theory",
             "thought",
             "thinking",
+            # Call identifiers: Anthropic native tool_use blocks have
+            # ``id``, OpenAI tool calls have ``id``/``call_id``, and
+            # MockLLMBackend / RPC consumers commonly include
+            # ``call_id`` for traceability. Without these in the
+            # meta-key list, an empty-args response with a top-level
+            # ``call_id`` triggers the flat-args fallback and the
+            # dispatcher rejects every call with an "unexpected
+            # argument: ['call_id']" error.
+            "call_id",
+            "id",
         }
         flat = {k: v for k, v in d.items() if k not in _meta_keys}
         if flat:
@@ -215,6 +225,7 @@ def _dict_to_tool_call(d: dict) -> ToolCall | None:
         tool=str(tool),
         args=args,
         reasoning=str(d.get("reasoning", d.get("thinking", d.get("thought", "")))),
+        call_id=str(d.get("call_id") or d.get("id") or ""),
     )
 
 

--- a/src/looplet/permissions.py
+++ b/src/looplet/permissions.py
@@ -272,7 +272,7 @@ class PermissionHook:
         ``{"engine": "@sql_permissions"}``. Otherwise the writer
         emits the generic ``"@engine"`` name.
         """
-        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+        from looplet.refs import resource_ref_for  # noqa: PLC0415
 
         ref = resource_ref_for(self.engine)
         return {"engine": ref or "@engine"}

--- a/src/looplet/prompts.py
+++ b/src/looplet/prompts.py
@@ -210,14 +210,19 @@ def preview_prompt(
             task={"goal": "fix the bug"},
             tools=my_registry,
             state=my_state,
+            config=my_config,
         ))
+
+    Returns the system prompt (from ``config.system_prompt``) prepended
+    to the user prompt so the output mirrors what the LLM actually
+    receives. Without ``config``, only the user prompt is returned.
 
     Args:
         task: Task dict (same as composable_loop).
         tools: BaseToolRegistry instance.
         state: AgentState instance (or None for empty facts).
         session_log: SessionLog instance (or None for empty log).
-        config: LoopConfig (optional — used for memory_sources).
+        config: LoopConfig (optional — used for system_prompt + memory_sources).
         step_number: Which step to render for (default 1).
     """
 
@@ -230,6 +235,7 @@ def preview_prompt(
     _max = getattr(config, "max_steps", 15) if config else 15
     _briefing = ""
     _memory = ""
+    _system = getattr(config, "system_prompt", "") if config else ""
     if config is not None:
         sources = getattr(config, "memory_sources", None) or []
         parts = []
@@ -239,7 +245,7 @@ def preview_prompt(
                 parts.append(text)
         _memory = "\n".join(parts)
 
-    return build_prompt(
+    user_prompt = build_prompt(
         task=_task,
         tool_catalog=_catalog,
         state_summary=_state,
@@ -250,3 +256,7 @@ def preview_prompt(
         briefing=_briefing,
         memory=_memory,
     )
+
+    if not _system:
+        return user_prompt
+    return f"═══ SYSTEM PROMPT ═══\n{_system.rstrip()}\n\n{user_prompt}"

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -560,6 +560,7 @@ class TrajectoryRecorder:
         tracer: Tracer | None = None,
         output_dir: str | Path | None = None,
         harness_snapshot: dict[str, Any] | None = None,
+        redact: Callable[[str], str] | None = None,
     ) -> None:
         self.trajectory = Trajectory(
             run_id=uuid4().hex[:12],
@@ -574,6 +575,12 @@ class TrajectoryRecorder:
         self._step_start_time: float = 0.0
         self._output_dir: Path | None = Path(output_dir) if output_dir is not None else None
         self._harness_snapshot = dict(harness_snapshot) if harness_snapshot is not None else None
+        # When set, every JSON document written to disk is redacted
+        # through this callable. The recorder still captures the
+        # un-redacted in-memory trajectory so callers that want raw
+        # data can read ``self.trajectory`` directly; only the
+        # on-disk artefact is scrubbed.
+        self._redact = redact
 
     # ── hook methods ────────────────────────────────────────────
 
@@ -772,15 +779,18 @@ class TrajectoryRecorder:
         """
         root = Path(directory)
         root.mkdir(parents=True, exist_ok=True)
-        (root / "trajectory.json").write_text(
-            json.dumps(self.trajectory.to_dict(), indent=2, default=str),
-            encoding="utf-8",
-        )
+        traj_text = json.dumps(self.trajectory.to_dict(), indent=2, default=str)
+        if self._redact is not None:
+            traj_text = self._redact(traj_text)
+        (root / "trajectory.json").write_text(traj_text, encoding="utf-8")
         steps_dir = root / "steps"
         steps_dir.mkdir(exist_ok=True)
         for s in self.trajectory.steps:
+            step_text = json.dumps(s.to_dict(), indent=2, default=str)
+            if self._redact is not None:
+                step_text = self._redact(step_text)
             (steps_dir / f"step_{s.step_num:02d}.json").write_text(
-                json.dumps(s.to_dict(), indent=2, default=str),
+                step_text,
                 encoding="utf-8",
             )
         if self._recording_llm is not None:
@@ -850,6 +860,7 @@ class ProvenanceSink:
             self._hook = TrajectoryRecorder(
                 recording_llm=self._recording_llm,
                 capture_context=self._capture_context,
+                redact=self._redact,
             )
         return self._hook
 

--- a/src/looplet/refs.py
+++ b/src/looplet/refs.py
@@ -1,0 +1,117 @@
+"""Resource-reference helpers shared between core and the workspace loader.
+
+This module owns the small registry that lets hooks like
+:class:`looplet.permissions.PermissionHook` ask "was this engine handed
+to me by a workspace ``resources/<name>.py`` builder?" — and if so,
+return ``"@<name>"`` so :func:`looplet.workspace.preset_to_workspace`
+can serialise the original reference instead of a placeholder.
+
+It lives in its own tiny module (rather than inside ``workspace.py``)
+so that core modules — ``permissions``, ``streaming``, ``evals``,
+``telemetry`` — can call :func:`resource_ref_for` without importing
+the 3000-line workspace loader. The workspace loader is then cleanly
+extractable into a separate package without leaving reverse imports
+behind.
+
+Public symbol: :func:`resource_ref_for`. Everything else is treated as
+internal but is re-exported from :mod:`looplet.workspace` for
+backwards compatibility with tests written against the old location.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_REF_PREFIX = "@"
+
+# id() -> resource name, populated by the workspace loader's
+# ``_load_resources`` via ``_register_resource_origin``. Empty in
+# pure-Python (no-workspace) usage; that path simply makes
+# ``resource_ref_for`` return ``None`` and callers fall back to a
+# default ref name.
+_resource_origin: dict[int, str] = {}
+
+
+def _register_resource_origin(instance: Any, name: str) -> None:
+    """Record that ``instance`` came from ``resources/<name>.py``.
+
+    Only registers instances that support :mod:`weakref`. Built-in
+    containers (``list``, ``tuple``, ``dict``, ``set``) and other
+    types that reject weak references would otherwise pin a stale
+    entry forever — and Python's ``id()`` can be reused once the
+    original object is garbage-collected, leading to false positives
+    in :func:`resource_ref_for`. Skip them here; their identity is
+    recovered via the ``__module__``-based fallback path.
+    """
+    import weakref  # noqa: PLC0415
+
+    key = id(instance)
+    try:
+        weakref.finalize(instance, _resource_origin.pop, key, None)
+    except TypeError:
+        # Object can't be weak-referenced (list / tuple / dict / set /
+        # bare int / etc.) — skip the identity registration entirely
+        # so a future object at the same ``id()`` can't pick up this
+        # name by accident.
+        return
+    _resource_origin[key] = name
+
+
+def resource_ref_for(value: Any) -> str | None:
+    """Return ``"@<name>"`` when ``value`` was produced by a workspace
+    ``resources/<name>.py`` builder; ``None`` otherwise.
+
+    Two detection paths:
+
+    1. **Identity registry.** :func:`_register_resource_origin`
+       stamps every built instance into :data:`_resource_origin`
+       keyed by ``id``. This handles the common case where the
+       builder returns a stock third-party object (e.g.
+       ``PermissionEngine``, ``MetricsCollector``) whose own
+       ``__module__`` is *not* in the workspace.
+    2. **Module name fallback.** When the value (or its first list
+       element) was *defined* inside the workspace's resource module
+       (e.g. a closure built by ``def build(): def fn(...): ...``),
+       its ``__module__`` starts with ``_chw_resource_``.
+
+    Used by hook ``to_config()`` implementations to round-trip the
+    *original* resource ref name (e.g. ``"@sql_permissions"``) instead
+    of a hardcoded fallback (e.g. ``"@engine"``).
+
+    Returns ``None`` for in-process objects so callers can fall back
+    to a default ref name. In a pure-Python (no-workspace) program,
+    :data:`_resource_origin` is empty and this always returns ``None``,
+    which is the correct answer.
+    """
+    # Path 1: identity registry — handles instances of stock classes
+    # like ``looplet.permissions.PermissionEngine`` whose own
+    # ``__module__`` is the framework, not the workspace.
+    by_id = _resource_origin.get(id(value))
+    if by_id is not None:
+        return f"{_REF_PREFIX}{by_id}"
+    # Also probe list/tuple elements for identity matches — common
+    # for ``EvalHook(evaluators=[...])`` whose list is rebuilt each
+    # call by the resource builder.
+    if isinstance(value, (list, tuple)) and value:
+        elem_id = _resource_origin.get(id(value[0]))
+        if elem_id is not None:
+            return f"{_REF_PREFIX}{elem_id}"
+
+    # Path 2: module-name fallback — handles closures defined inside
+    # the resource module (CallableMemorySource(fn=lambda ...)) and
+    # custom classes declared in the resource file.
+    candidate_modules: list[str] = []
+    cls_mod = getattr(type(value), "__module__", "") or ""
+    if cls_mod:
+        candidate_modules.append(cls_mod)
+    direct_mod = getattr(value, "__module__", "") or ""
+    if direct_mod and direct_mod != cls_mod:
+        candidate_modules.append(direct_mod)
+    if isinstance(value, (list, tuple)) and value:
+        item_mod = getattr(value[0], "__module__", "") or getattr(type(value[0]), "__module__", "")
+        if item_mod and item_mod not in candidate_modules:
+            candidate_modules.append(item_mod)
+    for mod in candidate_modules:
+        if mod.startswith("_chw_resource_"):
+            return f"{_REF_PREFIX}{mod[len('_chw_resource_') :]}"
+    return None

--- a/src/looplet/scaffolding.py
+++ b/src/looplet/scaffolding.py
@@ -298,6 +298,14 @@ def llm_call_with_retry(
             if _is_prompt_too_long(e):
                 logger.warning("Prompt too long (not retrying): %s", e)
                 return LLMResult(None, e)
+            # MockLLMBackend(cycle=False) raises LLMResponsesExhausted when
+            # a test scripted fewer responses than the loop asked for.
+            # Retrying the same exhausted mock never helps; surface the
+            # error immediately so the test author sees the actionable
+            # message on the first try, not after N seconds of backoff.
+            if type(e).__name__ == "LLMResponsesExhausted":
+                logger.warning("Mock LLM exhausted (not retrying): %s", e)
+                return LLMResult(None, e)
             if attempt < max_retries:
                 wait = RETRY_BACKOFF_BASE * (2**attempt)
                 logger.warning(

--- a/src/looplet/spec_slots.py
+++ b/src/looplet/spec_slots.py
@@ -1,0 +1,265 @@
+"""Compilers for the v1.0 declarative slots in ``config.yaml``.
+
+These functions translate the declarative ``model:``, ``permissions:``,
+and ``memory:`` blocks documented in ``SPEC.md`` into the live
+runtime objects the loop expects (``LoopConfig`` field overrides and
+``PermissionHook`` instances).
+
+Kept here rather than inlined in :mod:`looplet.workspace` so the
+permission / model / memory shape can be tested in isolation and
+ported to a future spec-only package without dragging the loader.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from looplet.permissions import (
+    PermissionDecision,
+    PermissionEngine,
+    PermissionHook,
+    PermissionRule,
+)
+from looplet.validation import FieldSpec, OutputSchema
+
+if TYPE_CHECKING:
+    pass
+
+
+__all__ = [
+    "compile_permissions_block",
+    "compile_model_block",
+    "compile_output_schema",
+    "default_long_term_memory_path",
+    "SCHEMA_BLOCK_PERMISSIONS",
+    "SCHEMA_BLOCK_MODEL",
+    "SCHEMA_BLOCK_MEMORY",
+]
+
+
+SCHEMA_BLOCK_PERMISSIONS = "permissions"
+SCHEMA_BLOCK_MODEL = "model"
+SCHEMA_BLOCK_MEMORY = "memory"
+
+
+# ── permissions: ───────────────────────────────────────────────────
+
+
+_DECISION_BY_KEY: dict[str, PermissionDecision] = {
+    "allow": PermissionDecision.ALLOW,
+    "deny": PermissionDecision.DENY,
+    "ask": PermissionDecision.ASK,
+}
+
+
+def _make_arg_matcher(spec: dict[str, Any]) -> Any:
+    """Build an ``ArgMatcher`` from the ``matches:`` / ``contains:`` shorthand.
+
+    * ``matches:`` requires an equality match against the named arg.
+    * ``contains:`` requires the named arg to be a string containing
+      the substring.
+
+    Returning ``None`` means the rule matches regardless of args.
+    """
+    matches = spec.get("matches") or {}
+    contains = spec.get("contains") or {}
+    if not matches and not contains:
+        return None
+
+    def _match(args: dict[str, Any]) -> bool:
+        for key, expected in matches.items():
+            if args.get(key) != expected:
+                return False
+        for key, needle in contains.items():
+            value = args.get(key)
+            if not isinstance(value, str) or needle not in value:
+                return False
+        return True
+
+    return _match
+
+
+def _normalise_rule_entry(entry: Any) -> dict[str, Any]:
+    """Accept either a bare tool name or a structured rule dict.
+
+    Returns a dict with at least ``tool``; raises ``ValueError`` on
+    malformed input so the loader can attribute the error to the
+    offending file.
+    """
+    if isinstance(entry, str):
+        return {"tool": entry}
+    if isinstance(entry, dict):
+        if "tool" not in entry:
+            raise ValueError(f"permission rule missing 'tool' field: {entry!r}")
+        return entry
+    raise ValueError(f"permission rule must be a string (tool name) or a dict, got {entry!r}")
+
+
+def compile_permissions_block(block: dict[str, Any]) -> PermissionHook:
+    """Compile a ``permissions:`` block into a ``PermissionHook``.
+
+    The block accepts ``default``, ``allow``, ``deny``, ``ask`` keys.
+    Each rule list contains either bare tool names (matching any args)
+    or structured dicts with ``matches:`` / ``contains:`` shorthand.
+
+    Empty / missing blocks return a hook with no rules and the
+    documented default of ``allow`` so the result is always safe to
+    install.
+    """
+    if block is None:
+        block = {}
+    if not isinstance(block, dict):
+        raise ValueError(
+            f"permissions block must be a mapping, got {type(block).__name__}: {block!r}"
+        )
+
+    default_key = (block.get("default") or "allow").lower()
+    if default_key not in _DECISION_BY_KEY:
+        raise ValueError(
+            f"permissions.default must be one of {sorted(_DECISION_BY_KEY)}, got {default_key!r}"
+        )
+    engine = PermissionEngine(default=_DECISION_BY_KEY[default_key])
+
+    # Order matters: deny list is evaluated first so explicit denials
+    # cannot be silently overridden by a broader allow rule. ask runs
+    # second; allow is last and acts as a positive override.
+    for slot_key in ("deny", "ask", "allow"):
+        rules = block.get(slot_key) or []
+        if not isinstance(rules, list):
+            raise ValueError(
+                f"permissions.{slot_key} must be a list, got {type(rules).__name__}: {rules!r}"
+            )
+        decision = _DECISION_BY_KEY[slot_key]
+        for entry in rules:
+            normalised = _normalise_rule_entry(entry)
+            engine.rules.append(
+                PermissionRule(
+                    tool=normalised["tool"],
+                    decision=decision,
+                    arg_matcher=_make_arg_matcher(normalised),
+                    reason=str(normalised.get("reason", "")),
+                )
+            )
+
+    return PermissionHook(engine)
+
+
+# ── model: ─────────────────────────────────────────────────────────
+
+
+_MODEL_TO_LOOPCONFIG: dict[str, str] = {
+    "max_tokens": "max_tokens",
+    "temperature": "temperature",
+}
+
+
+def compile_model_block(block: dict[str, Any], *, existing_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Translate a structured ``model:`` block into ``LoopConfig`` overrides.
+
+    Returns a dict of overrides to merge into the existing config
+    kwargs. When both a structured block and a flat field
+    (e.g. ``temperature: 0.2`` at the top level) are present, the
+    structured block wins.
+
+    Provider / model name / reasoning effort / extras are *not* part
+    of the v1.0 ``LoopConfig`` surface; they are surfaced through
+    ``tool_metadata['model']`` so that downstream tooling (cost
+    estimators, routers, governance) can read them without parsing
+    the cartridge again.
+    """
+    if block is None:
+        return {}
+    if not isinstance(block, dict):
+        raise ValueError(f"model block must be a mapping, got {type(block).__name__}: {block!r}")
+
+    overrides: dict[str, Any] = {}
+
+    for source_key, cfg_key in _MODEL_TO_LOOPCONFIG.items():
+        if source_key in block:
+            overrides[cfg_key] = block[source_key]
+
+    metadata: dict[str, Any] = {}
+    for key in ("provider", "name", "reasoning_effort", "top_p", "extra"):
+        if key in block:
+            metadata[key] = block[key]
+
+    if metadata:
+        existing_metadata = dict(existing_cfg.get("tool_metadata") or {})
+        existing_metadata.setdefault("model", {}).update(metadata)
+        overrides["tool_metadata"] = existing_metadata
+
+    return overrides
+
+
+# ── memory: ────────────────────────────────────────────────────────
+
+
+def default_long_term_memory_path() -> str:
+    """Path of the default long-term memory file relative to the cartridge root."""
+    return "memory/long_term.md"
+
+
+# ── output_schema: on done ────────────────────────────────
+
+
+_JSONSCHEMA_TYPE_TO_FIELD_TYPE: dict[str, str] = {
+    "string": "str",
+    "integer": "int",
+    "number": "float",
+    "boolean": "bool",
+    "array": "list",
+    "object": "dict",
+}
+
+
+def compile_output_schema(block: dict[str, Any]) -> OutputSchema:
+    """Translate a (subset of) JSON Schema into an :class:`OutputSchema`.
+
+    Supported shape (matches what ``tools/done/tool.yaml`` realistically
+    declares today): top-level ``type: object`` with ``properties``
+    and an optional ``required`` list. Each property may declare a
+    JSON Schema ``type``, an ``enum`` (mapped to ``allowed_values``),
+    and a ``description``.
+
+    Anything outside this subset is ignored with a deliberate silent
+    pass: future spec versions may widen the supported shape, and
+    rejecting unknown keys would prevent forward-compatible cartridges.
+    """
+    if not isinstance(block, dict):
+        raise ValueError(f"output_schema must be a mapping, got {type(block).__name__}: {block!r}")
+    block_type = block.get("type", "object")
+    if block_type != "object":
+        raise ValueError(
+            f"output_schema.type must be 'object' (got {block_type!r}); "
+            f"flat schemas are out of scope for v1.0"
+        )
+
+    properties = block.get("properties") or {}
+    if not isinstance(properties, dict):
+        raise ValueError(
+            f"output_schema.properties must be a mapping, got {type(properties).__name__}"
+        )
+    required = set(block.get("required") or [])
+
+    fields: dict[str, FieldSpec] = {}
+    for name, prop in properties.items():
+        if not isinstance(prop, dict):
+            raise ValueError(f"output_schema.properties[{name!r}] must be a mapping")
+        json_type = prop.get("type", "any")
+        if isinstance(json_type, list):
+            # JSON Schema allows ["string", "null"] etc. We collapse
+            # to the first non-null type for OutputSchema's flat type tag.
+            non_null = [t for t in json_type if t != "null"]
+            json_type = non_null[0] if non_null else "any"
+        field_type = _JSONSCHEMA_TYPE_TO_FIELD_TYPE.get(json_type, "any")
+        enum = prop.get("enum")
+        allowed_values = [str(v) for v in enum] if isinstance(enum, list) and enum else None
+        fields[name] = FieldSpec(
+            name=name,
+            field_type=field_type,
+            required=name in required,
+            description=str(prop.get("description", "") or ""),
+            allowed_values=allowed_values,
+        )
+
+    return OutputSchema(fields=fields, strict=False)

--- a/src/looplet/streaming.py
+++ b/src/looplet/streaming.py
@@ -315,7 +315,7 @@ class StreamingHook:
         whose origin can't be traced fall through to a None-stub the
         user must replace.
         """
-        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+        from looplet.refs import resource_ref_for  # noqa: PLC0415
 
         ref = resource_ref_for(self._emitter)
         return {"emitter": ref or "@emitter"}

--- a/src/looplet/telemetry.py
+++ b/src/looplet/telemetry.py
@@ -356,7 +356,7 @@ class MetricsHook:
         builder, the original ref name is preserved. Otherwise the
         writer emits the generic ``"@collector"`` name.
         """
-        from looplet.workspace import resource_ref_for  # noqa: PLC0415
+        from looplet.refs import resource_ref_for  # noqa: PLC0415
 
         ref = resource_ref_for(self._collector)
         return {"collector": ref or "@collector"}

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -690,22 +690,49 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
 
 
 def _import_module_from_path(path: Path, module_name: str) -> Any:
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None or spec.loader is None:
-        raise WorkspaceSerializationError(f"cannot import module from {path}")
-    module = importlib.util.module_from_spec(spec)
-    # Register in ``sys.modules`` so ``inspect.getmodule(cls)`` /
-    # ``inspect.getsource(cls)`` can find the on-disk source for
-    # workspace-defined classes (hooks / resources). Without this,
-    # round-tripping a loaded workspace's own inline ``hook.py``
-    # falls back to the placeholder branch in ``_render_hook_source``
-    # because the dynamically-loaded module has no ``sys.modules``
-    # entry for ``inspect`` to consult.
-    import sys as _sys  # noqa: PLC0415
+    """Load a workspace-shipped Python module from ``path``.
 
+    Reads the source verbatim and executes it into a fresh
+    :class:`types.ModuleType`. We deliberately avoid Python's normal
+    :class:`importlib.machinery.SourceFileLoader` for two reasons:
+
+    1. *Hot reload correctness.* ``SourceFileLoader`` writes a
+       ``__pycache__/<name>.cpython-XYZ.pyc`` next to the source, and
+       on subsequent imports it reuses that bytecode whenever the
+       source mtime matches the value stored in the ``.pyc`` header.
+       That mtime is recorded with **second** resolution, so two
+       writes within the same wall-clock second silently re-use the
+       old bytecode — which means a cartridge reloaded after a fast
+       edit returns the previous tool body. Reading the source
+       directly each time avoids the cache entirely.
+
+    2. *Cartridge cleanliness.* ``SourceFileLoader`` litters the
+       cartridge directory with ``__pycache__/`` folders, which makes
+       \"the cartridge is just files\" demonstrably untrue — a
+       reviewer doing ``ls`` sees engine artefacts mixed with the
+       agent's contract.
+
+    The module is registered in :data:`sys.modules` under
+    ``module_name`` so :func:`inspect.getmodule` /
+    :func:`inspect.getsource` can recover the on-disk source for
+    workspace-defined classes (hooks / resources). Linecache uses
+    ``__file__`` to fetch source on demand for tracebacks.
+    """
+    import sys as _sys  # noqa: PLC0415
+    import types as _types  # noqa: PLC0415
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise WorkspaceSerializationError(f"cannot read module {path}: {exc}") from exc
+
+    code = compile(source, str(path), "exec")
+    module = _types.ModuleType(module_name)
+    module.__file__ = str(path)
+    module.__loader__ = None  # type: ignore[assignment]
     _sys.modules[module_name] = module
     try:
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        exec(code, module.__dict__)
     except Exception:
         _sys.modules.pop(module_name, None)
         raise
@@ -2613,6 +2640,45 @@ def _workspace_to_preset_inner(
                     if strict:
                         raise WorkspaceSerializationError(msg)
                     logger.warning("%s; tool will receive None for missing resources", msg)
+            # Surface ``parameters: {}`` mismatches with the execute.py
+            # signature. The most common scaffold-then-edit friction:
+            # ``scaffold_workspace`` writes ``parameters: {}`` and
+            # ``def execute(ctx, **kwargs)`` together. Users replace
+            # ``**kwargs`` with explicit keyword params (``*, name: str``)
+            # but forget to also fill in ``parameters:``. The dispatcher
+            # then rejects every call with VALIDATION because the schema
+            # advertises zero parameters. We detect the mismatch here and
+            # warn pointing at the tool.yaml. Detection is deliberately
+            # conservative: we only flag declared-empty parameters paired
+            # with a non-``**kwargs`` signature that has at least one
+            # required keyword-only parameter beyond ``ctx``.
+            if not spec.parameters:
+                try:
+                    sig = inspect.signature(execute_fn)
+                    explicit = [
+                        p
+                        for p in sig.parameters.values()
+                        if p.kind == inspect.Parameter.KEYWORD_ONLY and p.name != "ctx"
+                    ]
+                    has_var_keyword = any(
+                        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+                    )
+                except (TypeError, ValueError):
+                    explicit = []
+                    has_var_keyword = True
+                if explicit and not has_var_keyword:
+                    declared = [p.name for p in explicit]
+                    msg = (
+                        f"tool {spec.name!r} (in {tool_dir.name!r}): "
+                        f"execute.py declares keyword params {declared} but "
+                        f"tool.yaml has empty ``parameters: {{}}``. The "
+                        f"dispatcher will reject every call with a VALIDATION "
+                        f"error. Add the parameters block to {spec_path.name}, "
+                        f"or accept ``**kwargs`` in execute.py."
+                    )
+                    if strict:
+                        raise WorkspaceSerializationError(msg)
+                    logger.warning("%s", msg)
             registry.register(spec)
 
             # v1.0: ``output_schema:`` on the done tool installs an

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -2387,19 +2387,64 @@ def _resolve_extends(root: Path, *, _seen: set[Path] | None = None) -> Path:
     # to (the merged dir holds .pyc caches and may import modules that
     # are still bound to its path until process end).
     _EXTENDS_TEMPDIRS.append(merged)
-    # Copy parent first, then overlay child.
+    # Copy parent first, then overlay child. Directory overlay is
+    # correct for tools/, hooks/, resources/, prompts/, memory/ —
+    # each entry lives in its own subdirectory and the child either
+    # adds a new entry or replaces an entry of the same name.
     _shutil.copytree(parent_root, merged, dirs_exist_ok=True, symlinks=False)
     _shutil.copytree(root, merged, dirs_exist_ok=True, symlinks=False)
-    # Strip the top-level ``extends:`` line from the merged config.yaml
-    # so the inner loader doesn't re-resolve it. Only top-level (indent
-    # 0) lines are stripped — an "extends:" string inside a deeper
-    # block scalar is preserved.
-    merged_cfg = merged / WorkspaceLayout.CONFIG_YAML
-    if merged_cfg.is_file():
-        lines = merged_cfg.read_text(encoding="utf-8").splitlines()
-        kept = [ln for ln in lines if not ln.startswith("extends:")]
-        merged_cfg.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+
+    # config.yaml needs *key-level* merging, not file-level overlay.
+    # File-level overlay would cause the child's config.yaml to wholly
+    # replace the parent's, silently dropping every parent key the child
+    # didn't redeclare (e.g. ``max_tokens``, ``max_steps``, ``model:``,
+    # ``permissions:``, ...). Builders observing this from outside the
+    # merge would see ``extends:`` as a partial inheritance mechanism
+    # — which is the opposite of what the schema promises.
+    #
+    # The merge strategy is shallow: top-level scalars and lists are
+    # replaced wholesale by the child if redeclared, while top-level
+    # mappings (``model:``, ``permissions:``, ``memory:``,
+    # ``tool_metadata:``) are recursively shallow-merged so a child
+    # can override a single key inside a block (e.g. just
+    # ``model.reasoning_effort``) without losing siblings. Lists are
+    # NOT concatenated — wholesale-replace mirrors how layered config
+    # files (Kubernetes overlays, Terraform locals, Hydra) handle them.
+    parent_cfg_path = parent_root / WorkspaceLayout.CONFIG_YAML
+    child_cfg_path = root / WorkspaceLayout.CONFIG_YAML
+    parent_cfg = (
+        _load_yaml(parent_cfg_path.read_text(encoding="utf-8"))
+        if parent_cfg_path.is_file()
+        else None
+    ) or {}
+    child_cfg = (
+        _load_yaml(child_cfg_path.read_text(encoding="utf-8")) if child_cfg_path.is_file() else None
+    ) or {}
+    # Drop the child's ``extends:`` so the inner loader doesn't re-resolve.
+    child_cfg.pop("extends", None)
+    parent_cfg.pop("extends", None)  # belt and braces; should already be gone
+    merged_cfg = _shallow_merge_config(parent_cfg, child_cfg)
+    merged_cfg_path = merged / WorkspaceLayout.CONFIG_YAML
+    merged_cfg_path.write_text(_dump_yaml(merged_cfg) + "\n", encoding="utf-8")
     return merged
+
+
+def _shallow_merge_config(parent: dict[str, Any], child: dict[str, Any]) -> dict[str, Any]:
+    """Shallow-merge two parsed config.yaml dicts.
+
+    Top-level scalars and lists from ``child`` win wholesale. Top-level
+    mappings are recursively shallow-merged so a child can override one
+    sub-key (``model.reasoning_effort``) without erasing siblings
+    (``model.provider``). Used by :func:`_resolve_extends`.
+    """
+    out: dict[str, Any] = dict(parent)
+    for key, child_val in child.items():
+        parent_val = out.get(key)
+        if isinstance(parent_val, dict) and isinstance(child_val, dict):
+            out[key] = _shallow_merge_config(parent_val, child_val)
+        else:
+            out[key] = child_val
+    return out
 
 
 def _workspace_to_preset_inner(
@@ -2921,6 +2966,24 @@ def _workspace_to_preset_inner(
         state = state_factory(max_steps)
     else:
         state = DefaultState(max_steps=max_steps)
+
+    # Sanity check: warn when ``done_tool`` doesn't point at any
+    # registered tool. We deliberately only warn (not raise even under
+    # strict) because some legitimate use cases construct ``done``
+    # later (sub-agent presets where the parent injects a done tool,
+    # workspaces extended by host code, test fixtures). The runtime
+    # will surface the missing tool when the LLM tries to dispatch
+    # it; this warning lets a builder catch the typo at load time
+    # without breaking those use cases.
+    if config.done_tool and config.done_tool not in registry.tool_names:
+        msg = (
+            f"config.yaml declares ``done_tool: {config.done_tool!r}`` but no "
+            f"such tool is registered. Available tools: {sorted(registry.tool_names)}. "
+            f"Add a ``tools/{config.done_tool}/`` directory or fix the "
+            f"``done_tool:`` field. The loop will fail at the agent's first "
+            f"done() call."
+        )
+        logger.warning("%s", msg)
 
     preset = AgentPreset(
         config=config,

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -2637,10 +2637,22 @@ def _workspace_to_preset_inner(
                     raise WorkspaceSerializationError(msg)
                 logger.warning("%s; skipping", msg)
                 continue
+            raw_parameters = yaml_payload.get("parameters", {}) or {}
+            if not isinstance(raw_parameters, dict):
+                msg = (
+                    f"tool {yaml_payload.get('name', tool_dir.name)!r} (in "
+                    f"{tool_dir.name!r}): tool.yaml ``parameters:`` must be a "
+                    f'mapping ("name: {{type: ...}}" entries), got '
+                    f"{type(raw_parameters).__name__}. Source: {spec_path}."
+                )
+                if strict:
+                    raise WorkspaceSerializationError(msg)
+                logger.warning("%s; skipping tool", msg)
+                continue
             spec = ToolSpec(
                 name=str(yaml_payload.get("name", tool_dir.name)),
                 description=str(yaml_payload.get("description", "")),
-                parameters=dict(yaml_payload.get("parameters", {}) or {}),
+                parameters=dict(raw_parameters),
                 execute=execute_fn,
                 concurrent_safe=bool(yaml_payload.get("concurrent_safe", False)),
                 free=bool(yaml_payload.get("free", False)),

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -808,35 +808,18 @@ def _load_resources(root: Path, runtime: dict[str, Any] | None = None) -> dict[s
 # ``__module__``-based fallback in :func:`resource_ref_for` covers
 # those cases (closures created inside the resource module's
 # ``build()`` carry the synthetic ``_chw_resource_<name>`` module).
-_resource_origin: dict[int, str] = {}
-
-
-def _register_resource_origin(instance: Any, name: str) -> None:
-    """Record that ``instance`` came from ``resources/<name>.py``.
-
-    Only registers instances that support :mod:`weakref`. Built-in
-    containers (``list``, ``tuple``, ``dict``, ``set``) and other
-    types that reject weak references would otherwise pin a stale
-    entry forever — and Python's ``id()`` can be reused once the
-    original object is garbage-collected, leading to false positives
-    in :func:`resource_ref_for`. Skip them here; their identity is
-    recovered via the ``__module__``-based fallback path.
-    """
-    import weakref  # noqa: PLC0415
-
-    key = id(instance)
-    try:
-        weakref.finalize(instance, _resource_origin.pop, key, None)
-    except TypeError:
-        # Object can't be weak-referenced (list / tuple / dict / set /
-        # bare int / etc.) — skip the identity registration entirely
-        # so a future object at the same ``id()`` can't pick up this
-        # name by accident.
-        return
-    _resource_origin[key] = name
-
-
-_REF_PREFIX = "@"
+# ``_REF_PREFIX``, ``_resource_origin``, ``_register_resource_origin`` and
+# ``resource_ref_for`` live in :mod:`looplet.refs` so that core modules
+# (permissions, streaming, evals, telemetry) can call ``resource_ref_for``
+# without importing this 3000-line workspace loader. Re-exported here for
+# backwards compatibility — existing tests reach
+# ``looplet.workspace._resource_origin`` directly, and that still works.
+from looplet.refs import (  # noqa: E402, F401, I001, PLC0415
+    _REF_PREFIX,
+    _register_resource_origin,
+    _resource_origin,
+    resource_ref_for,
+)
 
 
 # Unified ``${kind:value}`` reference grammar — applied to every
@@ -949,62 +932,9 @@ def _coerce_default(text: str | None) -> Any:
     return s
 
 
-def resource_ref_for(value: Any) -> str | None:
-    """Return ``"@<name>"`` when ``value`` was produced by a workspace
-    ``resources/<name>.py`` builder; ``None`` otherwise.
-
-    Two detection paths:
-
-    1. **Identity registry.** :func:`_load_resources` stamps every
-       built instance into ``_resource_origin`` keyed by ``id``. This
-       handles the common case where the builder returns a stock
-       third-party object (e.g. ``PermissionEngine``,
-       ``MetricsCollector``) whose own ``__module__`` is *not* in
-       the workspace.
-    2. **Module name fallback.** When the value (or its first list
-       element) was *defined* inside the workspace's resource module
-       (e.g. a closure built by ``def build(): def fn(...): ...``),
-       its ``__module__`` starts with ``_chw_resource_``.
-
-    Used by hook ``to_config()`` implementations to round-trip the
-    *original* resource ref name (e.g. ``"@sql_permissions"``) instead
-    of a hardcoded fallback (e.g. ``"@engine"``).
-
-    Returns ``None`` for in-process objects so callers can fall back
-    to a default ref name.
-    """
-    # Path 1: identity registry — handles instances of stock classes
-    # like ``looplet.permissions.PermissionEngine`` whose own
-    # ``__module__`` is the framework, not the workspace.
-    by_id = _resource_origin.get(id(value))
-    if by_id is not None:
-        return f"{_REF_PREFIX}{by_id}"
-    # Also probe list/tuple elements for identity matches — common
-    # for ``EvalHook(evaluators=[...])`` whose list is rebuilt each
-    # call by the resource builder.
-    if isinstance(value, (list, tuple)) and value:
-        elem_id = _resource_origin.get(id(value[0]))
-        if elem_id is not None:
-            return f"{_REF_PREFIX}{elem_id}"
-
-    # Path 2: module-name fallback — handles closures defined inside
-    # the resource module (CallableMemorySource(fn=lambda ...)) and
-    # custom classes declared in the resource file.
-    candidate_modules: list[str] = []
-    cls_mod = getattr(type(value), "__module__", "") or ""
-    if cls_mod:
-        candidate_modules.append(cls_mod)
-    direct_mod = getattr(value, "__module__", "") or ""
-    if direct_mod and direct_mod != cls_mod:
-        candidate_modules.append(direct_mod)
-    if isinstance(value, (list, tuple)) and value:
-        item_mod = getattr(value[0], "__module__", "") or getattr(type(value[0]), "__module__", "")
-        if item_mod and item_mod not in candidate_modules:
-            candidate_modules.append(item_mod)
-    for mod in candidate_modules:
-        if mod.startswith("_chw_resource_"):
-            return f"{_REF_PREFIX}{mod[len('_chw_resource_') :]}"
-    return None
+# ``resource_ref_for`` is defined in :mod:`looplet.refs` and re-imported
+# above; kept available here as ``looplet.workspace.resource_ref_for`` for
+# backwards compatibility.
 
 
 def _resolve_refs(

--- a/src/looplet/workspace.py
+++ b/src/looplet/workspace.py
@@ -138,9 +138,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from looplet.memory import PersistentMemorySource, StaticMemorySource
-
 if TYPE_CHECKING:
+    from looplet.memory import PersistentMemorySource
     from looplet.presets import AgentPreset
     from looplet.tools import BaseToolRegistry
 
@@ -484,12 +483,31 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
             if not after:
                 out.append(parse_block(indent + 2))
             elif _is_inline_single_key_dict(after):
-                # ``- key: <flow value or scalar>`` — single-key dict.
-                # Used by ``builtin_hooks: [- name: {kwargs}]`` style.
+                # ``- key: <flow value or scalar>`` — may be a single-key
+                # dict (when no follow-on fields at the same indent),
+                # OR the first key of a multi-field block mapping list
+                # item:
+                #     - key: value
+                #       other: thing
+                # The follow-on fields live at the indent of the dash
+                # plus 2 (the standard YAML alignment for keys after
+                # ``- ``). We parse them via ``parse_block(...)`` and
+                # merge into the item; absent follow-ons, the result
+                # is the same single-key dict the parser produced before.
                 key, _, val = after.partition(":")
-                out.append(
-                    {key.strip(): _scalar(val.strip()) if val.strip() else parse_block(indent + 2)}
-                )
+                item: dict[str, Any] = {}
+                if val.strip():
+                    item[key.strip()] = _scalar(val.strip())
+                else:
+                    item[key.strip()] = parse_block(cur_indent + 2)
+                # Consume any additional ``key: value`` lines at
+                # ``cur_indent + 2``. ``parse_block`` returns ``{}`` if
+                # nothing matches, so this is a no-op when the list
+                # item is genuinely single-key.
+                extra = parse_block(cur_indent + 2)
+                if isinstance(extra, dict):
+                    item.update(extra)
+                out.append(item)
             else:
                 out.append(_scalar(after))
         return out
@@ -535,10 +553,24 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
             return True
         if raw == "false":
             return False
-        if raw.startswith(("[", "{", '"')):
+        if raw.startswith(('"', "'")):
             try:
                 return json.loads(raw)
             except json.JSONDecodeError:
+                # Single-quoted YAML strings: trim the quotes by hand
+                # since json.loads only accepts double-quoted strings.
+                if raw.startswith("'") and raw.endswith("'") and len(raw) >= 2:
+                    return raw[1:-1]
+                return raw
+        if raw.startswith(("[", "{")):
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                # Strict JSON failed (likely YAML flow style with
+                # unquoted keys/values). Try the tolerant flow parser.
+                parsed, ok = _parse_flow(raw)
+                if ok:
+                    return parsed
                 return raw
         try:
             if "." in raw or "e" in raw or "E" in raw:
@@ -546,6 +578,110 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
             return int(raw)
         except ValueError:
             return raw
+
+    def _parse_flow(raw: str) -> tuple[Any, bool]:
+        """Parse a YAML flow scalar (``[a, b]`` or ``{k: v, k2: v2}``).
+
+        Tolerant of unquoted strings (the common YAML idiom). Returns
+        ``(value, True)`` on success or ``(None, False)`` on failure.
+        Nested flow collections are supported.
+        """
+        text = raw.strip()
+        try:
+            value, idx = _parse_flow_value(text, 0)
+        except (ValueError, IndexError):
+            return None, False
+        # All input must be consumed (modulo trailing whitespace).
+        if text[idx:].strip():
+            return None, False
+        return value, True
+
+    def _skip_ws(s: str, i: int) -> int:
+        while i < len(s) and s[i] in " \t":
+            i += 1
+        return i
+
+    def _parse_flow_value(s: str, i: int) -> tuple[Any, int]:
+        i = _skip_ws(s, i)
+        if i >= len(s):
+            raise ValueError("unexpected end of flow value")
+        ch = s[i]
+        if ch == "[":
+            return _parse_flow_list(s, i)
+        if ch == "{":
+            return _parse_flow_map(s, i)
+        if ch in ('"', "'"):
+            return _parse_flow_quoted(s, i)
+        # Bare scalar: read until , } ] (or end).
+        start = i
+        while i < len(s) and s[i] not in ",}]":
+            i += 1
+        token = s[start:i].strip()
+        return _scalar(token), i
+
+    def _parse_flow_list(s: str, i: int) -> tuple[list[Any], int]:
+        assert s[i] == "["
+        out: list[Any] = []
+        i = _skip_ws(s, i + 1)
+        if i < len(s) and s[i] == "]":
+            return out, i + 1
+        while i < len(s):
+            value, i = _parse_flow_value(s, i)
+            out.append(value)
+            i = _skip_ws(s, i)
+            if i < len(s) and s[i] == ",":
+                i = _skip_ws(s, i + 1)
+                continue
+            if i < len(s) and s[i] == "]":
+                return out, i + 1
+            raise ValueError(f"expected ',' or ']' in flow list at offset {i}")
+        raise ValueError("unterminated flow list")
+
+    def _parse_flow_map(s: str, i: int) -> tuple[dict[str, Any], int]:
+        assert s[i] == "{"
+        out: dict[str, Any] = {}
+        i = _skip_ws(s, i + 1)
+        if i < len(s) and s[i] == "}":
+            return out, i + 1
+        while i < len(s):
+            # Parse key (bare or quoted, terminate on ':').
+            if s[i] in ('"', "'"):
+                key_value, i = _parse_flow_quoted(s, i)
+                key = str(key_value)
+            else:
+                start = i
+                while i < len(s) and s[i] != ":":
+                    if s[i] in ",}]":
+                        raise ValueError("missing ':' in flow map")
+                    i += 1
+                key = s[start:i].strip()
+            if i >= len(s) or s[i] != ":":
+                raise ValueError(f"expected ':' in flow map at offset {i}")
+            i = _skip_ws(s, i + 1)
+            value, i = _parse_flow_value(s, i)
+            out[key] = value
+            i = _skip_ws(s, i)
+            if i < len(s) and s[i] == ",":
+                i = _skip_ws(s, i + 1)
+                continue
+            if i < len(s) and s[i] == "}":
+                return out, i + 1
+            raise ValueError(f"expected ',' or '}}' in flow map at offset {i}")
+        raise ValueError("unterminated flow map")
+
+    def _parse_flow_quoted(s: str, i: int) -> tuple[str, int]:
+        quote = s[i]
+        i += 1
+        start = i
+        while i < len(s) and s[i] != quote:
+            if s[i] == "\\" and i + 1 < len(s):
+                i += 2
+                continue
+            i += 1
+        if i >= len(s):
+            raise ValueError("unterminated quoted string")
+        text = s[start:i]
+        return text, i + 1
 
     return parse_block(0)
 
@@ -1958,12 +2094,15 @@ def _write_memory(
     ``memory_sources`` list and the resource auto-emit machinery
     copies the original on-disk source verbatim.
     """
+    from looplet.memory import (  # noqa: PLC0415
+        CallableMemorySource,
+        StaticMemorySource,
+    )
+
     if isinstance(source, StaticMemorySource):
         (memory_root / f"{index:02d}_static.md").write_text(source.text, encoding="utf-8")
         return None
     # CallableMemorySource: three branches in priority order.
-    from looplet.memory import CallableMemorySource  # noqa: PLC0415
-
     if isinstance(source, CallableMemorySource):
         fn = source.fn
         fn_name = getattr(fn, "__name__", "")
@@ -2286,7 +2425,10 @@ def _workspace_to_preset_inner(
     file_memory_sources: list[PersistentMemorySource] = []
     memory_dir = root / WorkspaceLayout.MEMORY_DIR
     if memory_dir.is_dir():
-        from looplet.memory import CallableMemorySource  # noqa: PLC0415
+        from looplet.memory import (  # noqa: PLC0415
+            CallableMemorySource,
+            StaticMemorySource,
+        )
 
         memory_files = sorted(
             p for p in memory_dir.iterdir() if p.is_file() and p.suffix in (".md", ".py")
@@ -2351,6 +2493,33 @@ def _workspace_to_preset_inner(
     # pre-resolved instance from ``_resolve_refs``). Falls back to the
     # ``state_factory`` constructor arg, and finally to ``DefaultState``.
     _state_directive = cfg_kwargs.pop("state", None)
+
+    # ── v1.0 declarative slots (SPEC.md): model, permissions, memory.
+    # Each is consumed here, *not* by ``LoopConfig``. We pop them off
+    # cfg_kwargs so the LoopConfig constructor doesn't see unknown
+    # kwargs, then process them after the config is built.
+    _model_block = cfg_kwargs.pop("model", None)
+    _permissions_block = cfg_kwargs.pop("permissions", None)
+    _memory_block = cfg_kwargs.pop("memory", None)
+
+    # Apply ``model:`` overrides BEFORE constructing LoopConfig so the
+    # structured block wins over flat ``temperature:`` / ``max_tokens:``
+    # at the top level. ``compile_model_block`` returns a dict of
+    # LoopConfig field overrides plus an updated ``tool_metadata``
+    # carrying provider / name / reasoning_effort for downstream
+    # tooling to read.
+    if _model_block is not None:
+        from looplet.spec_slots import compile_model_block  # noqa: PLC0415
+
+        try:
+            model_overrides = compile_model_block(_model_block, existing_cfg=cfg_kwargs)
+        except ValueError as exc:
+            msg = f"invalid 'model' block in {cfg_path}: {exc}"
+            if strict:
+                raise WorkspaceSerializationError(msg) from exc
+            logger.warning("%s; ignoring model block", msg)
+            model_overrides = {}
+        cfg_kwargs.update(model_overrides)
 
     config = LoopConfig(**cfg_kwargs)
 
@@ -2445,6 +2614,30 @@ def _workspace_to_preset_inner(
                         raise WorkspaceSerializationError(msg)
                     logger.warning("%s; tool will receive None for missing resources", msg)
             registry.register(spec)
+
+            # v1.0: ``output_schema:`` on the done tool installs an
+            # OutputSchema validator on the LoopConfig so the loop
+            # validates the agent's done() args before terminating.
+            # Only the configured ``done_tool`` is treated specially;
+            # output_schema on other tools is recorded in tool metadata
+            # and may be enforced by future spec versions but is not
+            # part of the v1.0 loader contract.
+            if (
+                spec.name == config.done_tool
+                and config.output_schema is None
+                and isinstance(yaml_payload.get("output_schema"), dict)
+            ):
+                from looplet.spec_slots import compile_output_schema  # noqa: PLC0415
+
+                try:
+                    config.output_schema = compile_output_schema(
+                        dict(yaml_payload["output_schema"])
+                    )
+                except (ValueError, TypeError) as exc:
+                    msg = f"invalid output_schema in {spec_path}: {exc}"
+                    if strict:
+                        raise WorkspaceSerializationError(msg) from exc
+                    logger.warning("%s; ignoring output_schema", msg)
 
     # Built-in tools — opt-in via ``builtin_tools:`` in config.yaml.
     # These are looplet-shipped tools (``subagent``, future helpers)
@@ -2670,6 +2863,52 @@ def _workspace_to_preset_inner(
         state=state,
         resources=dict(resources),
     )
+
+    # ── v1.0 declarative slots: permissions, memory.long_term ───────
+    # Both are processed AFTER hooks/state/preset are built so the
+    # auto-installed hook lands at the end of the hook list (after any
+    # user-defined permission policy in ``hooks/``) and the long-term
+    # memory file appends to file-based memory sources already loaded.
+    # ``setup.py`` (below) can still override either, by design.
+
+    if _permissions_block is not None:
+        from looplet.spec_slots import compile_permissions_block  # noqa: PLC0415
+
+        try:
+            permission_hook = compile_permissions_block(_permissions_block)
+        except ValueError as exc:
+            msg = f"invalid 'permissions' block in {cfg_path}: {exc}"
+            if strict:
+                raise WorkspaceSerializationError(msg) from exc
+            logger.warning("%s; ignoring permissions block", msg)
+        else:
+            preset.hooks.append(permission_hook)
+
+    # Long-term memory: explicit ``memory: { long_term: <path> }`` wins;
+    # otherwise, auto-load ``memory/long_term.md`` if present. Either
+    # path resolves relative to the cartridge root and is appended to
+    # the existing memory_sources so existing static files are not
+    # disturbed.
+    long_term_path: Path | None = None
+    if isinstance(_memory_block, dict):
+        explicit = _memory_block.get("long_term")
+        if isinstance(explicit, str) and explicit:
+            long_term_path = (root / explicit).resolve()
+    if long_term_path is None:
+        from looplet.spec_slots import default_long_term_memory_path  # noqa: PLC0415
+
+        candidate = root / default_long_term_memory_path()
+        if candidate.is_file():
+            long_term_path = candidate.resolve()
+    if long_term_path is not None and long_term_path.is_file():
+        from looplet.memory import StaticMemorySource  # noqa: PLC0415
+
+        long_term_source = StaticMemorySource(
+            text=long_term_path.read_text(encoding="utf-8"),
+        )
+        if preset.config.memory_sources is None:
+            preset.config.memory_sources = []
+        preset.config.memory_sources = list(preset.config.memory_sources) + [long_term_source]
 
     # ``setup.py`` escape hatch — runs after the declarative load to
     # let the workspace attach callable / opaque fields that don't

--- a/tests/conformance/fixtures/01_minimal/cartridge/config.yaml
+++ b/tests/conformance/fixtures/01_minimal/cartridge/config.yaml
@@ -1,0 +1,1 @@
+max_steps: 5

--- a/tests/conformance/fixtures/01_minimal/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/01_minimal/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+you are a minimal test agent.

--- a/tests/conformance/fixtures/01_minimal/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/01_minimal/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(ctx, *, summary: str) -> dict:
+    return {"summary": summary}

--- a/tests/conformance/fixtures/01_minimal/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/01_minimal/cartridge/tools/done/tool.yaml
@@ -1,0 +1,4 @@
+name: done
+description: Mark the task complete.
+parameters:
+  summary: { type: string }

--- a/tests/conformance/fixtures/01_minimal/cartridge/workspace.json
+++ b/tests/conformance/fixtures/01_minimal/cartridge/workspace.json
@@ -1,0 +1,1 @@
+{"name": "minimal", "schema_version": 1}

--- a/tests/conformance/fixtures/01_minimal/expected.json
+++ b/tests/conformance/fixtures/01_minimal/expected.json
@@ -1,0 +1,13 @@
+{
+  "max_steps": 5,
+  "max_tokens": 2000,
+  "temperature": 0.2,
+  "done_tool": "done",
+  "tools": [
+    {"name": "done", "requires": []}
+  ],
+  "permissions": null,
+  "output_schema_fields": null,
+  "model": null,
+  "memory_source_count": 0
+}

--- a/tests/conformance/fixtures/02_permissions/cartridge/config.yaml
+++ b/tests/conformance/fixtures/02_permissions/cartridge/config.yaml
@@ -1,0 +1,10 @@
+max_steps: 8
+permissions:
+  default: allow
+  deny:
+    - tool: bash
+      contains:
+        command: "rm -rf"
+      reason: "destructive"
+  ask:
+    - tool: write

--- a/tests/conformance/fixtures/02_permissions/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/02_permissions/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+you are a permission-test agent.

--- a/tests/conformance/fixtures/02_permissions/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/02_permissions/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(ctx, *, summary: str) -> dict:
+    return {"summary": summary}

--- a/tests/conformance/fixtures/02_permissions/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/02_permissions/cartridge/tools/done/tool.yaml
@@ -1,0 +1,4 @@
+name: done
+description: Mark the task complete.
+parameters:
+  summary: { type: string }

--- a/tests/conformance/fixtures/02_permissions/cartridge/workspace.json
+++ b/tests/conformance/fixtures/02_permissions/cartridge/workspace.json
@@ -1,0 +1,1 @@
+{"name": "permissions", "schema_version": 1}

--- a/tests/conformance/fixtures/02_permissions/expected.json
+++ b/tests/conformance/fixtures/02_permissions/expected.json
@@ -1,0 +1,19 @@
+{
+  "max_steps": 8,
+  "max_tokens": 2000,
+  "temperature": 0.2,
+  "done_tool": "done",
+  "tools": [
+    {"name": "done", "requires": []}
+  ],
+  "permissions": {
+    "default": "allow",
+    "rules": [
+      {"tool": "bash", "decision": "deny", "reason": "destructive"},
+      {"tool": "write", "decision": "ask", "reason": ""}
+    ]
+  },
+  "output_schema_fields": null,
+  "model": null,
+  "memory_source_count": 0
+}

--- a/tests/conformance/fixtures/03_model_and_output_schema/cartridge/config.yaml
+++ b/tests/conformance/fixtures/03_model_and_output_schema/cartridge/config.yaml
@@ -1,0 +1,6 @@
+model:
+  provider: anthropic
+  name: claude-sonnet-4.6
+  reasoning_effort: high
+  max_tokens: 4096
+  temperature: 0.0

--- a/tests/conformance/fixtures/03_model_and_output_schema/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/03_model_and_output_schema/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+you are a typed-output test agent.

--- a/tests/conformance/fixtures/03_model_and_output_schema/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/03_model_and_output_schema/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(ctx, *, summary: str, passed: bool) -> dict:
+    return {"summary": summary, "passed": passed}

--- a/tests/conformance/fixtures/03_model_and_output_schema/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/03_model_and_output_schema/cartridge/tools/done/tool.yaml
@@ -1,0 +1,11 @@
+name: done
+description: Mark the task complete with a structured summary.
+parameters:
+  summary: { type: string }
+  passed: { type: boolean }
+output_schema:
+  type: object
+  required: [summary, passed]
+  properties:
+    summary: { type: string }
+    passed: { type: boolean }

--- a/tests/conformance/fixtures/03_model_and_output_schema/cartridge/workspace.json
+++ b/tests/conformance/fixtures/03_model_and_output_schema/cartridge/workspace.json
@@ -1,0 +1,1 @@
+{"name": "model_and_output_schema", "schema_version": 1}

--- a/tests/conformance/fixtures/03_model_and_output_schema/expected.json
+++ b/tests/conformance/fixtures/03_model_and_output_schema/expected.json
@@ -1,0 +1,17 @@
+{
+  "max_steps": 15,
+  "max_tokens": 4096,
+  "temperature": 0.0,
+  "done_tool": "done",
+  "tools": [
+    {"name": "done", "requires": []}
+  ],
+  "permissions": null,
+  "output_schema_fields": ["passed", "summary"],
+  "model": {
+    "provider": "anthropic",
+    "name": "claude-sonnet-4.6",
+    "reasoning_effort": "high"
+  },
+  "memory_source_count": 0
+}

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/config.yaml
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/config.yaml
@@ -1,0 +1,1 @@
+max_steps: 5

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/memory/long_term.md
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/memory/long_term.md
@@ -1,0 +1,1 @@
+REMEMBER: this is the long-term memory file the loader auto-injects.

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+you are a long-term-memory test agent.

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(ctx, *, summary: str) -> dict:
+    return {"summary": summary}

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/tools/done/tool.yaml
@@ -1,0 +1,4 @@
+name: done
+description: Mark the task complete.
+parameters:
+  summary: { type: string }

--- a/tests/conformance/fixtures/04_long_term_memory/cartridge/workspace.json
+++ b/tests/conformance/fixtures/04_long_term_memory/cartridge/workspace.json
@@ -1,0 +1,1 @@
+{"name": "long_term_memory", "schema_version": 1}

--- a/tests/conformance/fixtures/04_long_term_memory/expected.json
+++ b/tests/conformance/fixtures/04_long_term_memory/expected.json
@@ -1,0 +1,13 @@
+{
+  "max_steps": 5,
+  "max_tokens": 2000,
+  "temperature": 0.2,
+  "done_tool": "done",
+  "tools": [
+    {"name": "done", "requires": []}
+  ],
+  "permissions": null,
+  "output_schema_fields": null,
+  "model": null,
+  "memory_source_count": 2
+}

--- a/tests/conformance/fixtures/README.md
+++ b/tests/conformance/fixtures/README.md
@@ -1,0 +1,32 @@
+# Conformance Fixtures for Cartridge-Spec v1.0
+
+Each subdirectory is a minimal cartridge plus an `expected.json`
+describing the loader output a v1.0 conformant runtime must produce.
+The four seed fixtures cover the new v1.0 slots.
+
+## Fixtures
+
+| Directory | What it pins |
+|---|---|
+| `01_minimal/`                  | Smallest legal cartridge: manifest, prompt, done tool. |
+| `02_permissions/`              | Declarative `permissions:` compiles into a `PermissionHook`. |
+| `03_model_and_output_schema/`  | Structured `model:` block + `output_schema:` on done. |
+| `04_long_term_memory/`         | `memory/long_term.md` is auto-loaded as a memory source. |
+
+## Adding fixtures
+
+1. Create `tests/conformance/fixtures/<NN>_<name>/cartridge/` with the
+   cartridge files.
+2. Create `tests/conformance/fixtures/<NN>_<name>/expected.json` using
+   the same key set as the existing fixtures.
+3. The parametric test in `test_conformance.py` will pick it up
+   automatically.
+
+The summary the test compares against is intentionally narrow.
+Implementation details (live Python objects, hook ordering beyond
+what the cartridge declares, etc.) are NOT pinned by v1.0.
+
+## Status
+
+Seed only — v1.0 conformance is documentation, not enforcement. v2 will
+mandate this suite as a release criterion.

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -1,0 +1,103 @@
+"""Conformance fixtures for cartridge-spec v1.0.
+
+Each fixture under :file:`tests/conformance/fixtures/` is a minimal
+cartridge paired with an ``expected.json`` describing the loader
+output any v1.0 conformant runtime must produce. The list grows over
+time; v2 will mandate this as a release criterion. For now it is the
+seed.
+
+A fixture's ``expected.json`` is a small JSON document describing the
+parts of the loader output the spec actually pins down. Implementation
+details (live Python objects, hook ordering beyond what the cartridge
+declares, etc.) are out of scope.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from looplet.permissions import PermissionDecision, PermissionHook
+from looplet.workspace import workspace_to_preset
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _list_fixtures() -> list[Path]:
+    if not FIXTURES_DIR.is_dir():
+        return []
+    return sorted(p for p in FIXTURES_DIR.iterdir() if p.is_dir())
+
+
+def _summarise_preset(preset: Any) -> dict[str, Any]:
+    """Reduce a loaded preset to the spec-pinned subset.
+
+    Adding a field to this summary widens the conformance contract.
+    Don't do it without updating SPEC.md.
+    """
+    cfg = preset.config
+    tools_summary = sorted(
+        (
+            {
+                "name": name,
+                "requires": list(getattr(preset.tools._tools[name], "requires", []) or []),  # type: ignore[attr-defined]
+            }
+            for name in preset.tools.tool_names
+        ),
+        key=lambda d: d["name"],
+    )
+
+    perm_hooks = [h for h in preset.hooks if isinstance(h, PermissionHook)]
+    permissions: dict[str, Any] | None = None
+    if perm_hooks:
+        engine = perm_hooks[0].engine
+        permissions = {
+            "default": engine.default.value,
+            "rules": [
+                {
+                    "tool": rule.tool,
+                    "decision": rule.decision.value,
+                    "reason": rule.reason,
+                }
+                for rule in engine.rules
+            ],
+        }
+
+    output_schema_fields: list[str] | None = None
+    if cfg.output_schema is not None:
+        output_schema_fields = sorted(cfg.output_schema.fields)
+
+    model_meta = (cfg.tool_metadata or {}).get("model")
+
+    return {
+        "max_steps": cfg.max_steps,
+        "max_tokens": cfg.max_tokens,
+        "temperature": cfg.temperature,
+        "done_tool": cfg.done_tool,
+        "tools": tools_summary,
+        "permissions": permissions,
+        "output_schema_fields": output_schema_fields,
+        "model": model_meta,
+        "memory_source_count": len(cfg.memory_sources or []),
+    }
+
+
+@pytest.mark.parametrize("fixture_dir", _list_fixtures(), ids=lambda p: p.name)
+def test_conformance_fixture(fixture_dir: Path) -> None:
+    """Load the fixture and compare the spec-pinned subset of the preset."""
+    expected_path = fixture_dir / "expected.json"
+    if not expected_path.is_file():
+        pytest.skip(f"fixture {fixture_dir.name} has no expected.json")
+    cartridge = fixture_dir / "cartridge"
+    assert cartridge.is_dir(), f"fixture {fixture_dir.name} missing cartridge/"
+    expected = json.loads(expected_path.read_text())
+    preset = workspace_to_preset(str(cartridge), strict=True)
+    summary = _summarise_preset(preset)
+    assert summary == expected, (
+        f"conformance fixture {fixture_dir.name!r} mismatch.\n"
+        f"  expected: {json.dumps(expected, indent=2)}\n"
+        f"  actual:   {json.dumps(summary, indent=2)}"
+    )

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -794,3 +794,46 @@ def test_permission_deny_message_includes_canonical_prefix(tmp_path: Path) -> No
     assert "forbidden" in err, f"rule reason 'forbidden' missing from error: {err!r}"
     assert blocked.tool_result.error_detail is not None
     assert blocked.tool_result.error_detail.kind == ErrorKind.PERMISSION_DENIED
+
+
+# ── fix 14: AGENTS.md symbol-index entries are all top-level importable ─
+
+
+def test_agents_md_symbol_index_entries_are_importable() -> None:
+    """The AGENTS.md "Symbol index (A-Z)" table promises:
+
+        Everything in ``from looplet import X`` is listed here.
+
+    A ninth-pass dogfood found ``scaffold_workspace`` in the table but
+    only at ``looplet.scaffold.scaffold_workspace``. This regression
+    test pins the contract: every symbol the table lists must be
+    importable from ``looplet`` top-level. New additions to the table
+    that aren't on the public API will fail this test.
+    """
+    import importlib  # noqa: PLC0415
+    import re  # noqa: PLC0415
+
+    text = (Path(__file__).resolve().parents[1] / "AGENTS.md").read_text(encoding="utf-8")
+    rows: list[tuple[str, str]] = []
+    in_table = False
+    for line in text.splitlines():
+        if "## Symbol index" in line:
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if line.startswith("|---"):
+            continue
+        m = re.match(r"^\|\s*`([A-Za-z_][A-Za-z0-9_]*)`\s*\|\s*`([a-z_]+)`\s*\|", line)
+        if m:
+            rows.append((m.group(1), m.group(2)))
+        elif line.strip() == "" and rows:
+            break
+
+    assert rows, "couldn't parse the symbol-index table from AGENTS.md"
+    looplet_pkg = importlib.import_module("looplet")
+    missing = [(s, m) for s, m in rows if not hasattr(looplet_pkg, s)]
+    assert not missing, (
+        f"AGENTS.md symbol-index lists {len(missing)} symbol(s) that aren't "
+        f"importable from `looplet`: {missing[:5]}"
+    )

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -441,3 +441,199 @@ def test_loader_warns_when_done_tool_unregistered(
     assert any("done_tool" in m and "dont" in m and "noop" in m for m in msgs), (
         f"expected done_tool warning naming missing+available, got: {msgs}"
     )
+
+
+# ── fix 7: malformed parameters: in tool.yaml gives a clear error ─
+
+
+def test_loader_clean_error_when_tool_parameters_is_a_list(tmp_path: Path) -> None:
+    """A common mistake: ``parameters:`` written as a list of dicts.
+
+    Before the fix, the loader called ``dict(...)`` on the list and
+    surfaced ``ValueError: dictionary update sequence element #0 has
+    length 1; 2 is required`` — a Python implementation detail with no
+    pointer to the offending file. Now the loader names the tool, file
+    path, and expected shape.
+    """
+    import json as _json  # noqa: PLC0415
+
+    ws = tmp_path / "bad.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "bad", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 4\ndone_tool: done\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text("name: done\ndescription: x\nparameters: {}\n")
+    (ws / "tools" / "done" / "execute.py").write_text("def execute(ctx) -> dict:\n    return {}\n")
+    (ws / "tools" / "weird").mkdir(parents=True)
+    (ws / "tools" / "weird" / "tool.yaml").write_text(
+        "name: weird\ndescription: x\nparameters:\n  - name: a\n  - name: b\n"
+    )
+    (ws / "tools" / "weird" / "execute.py").write_text(
+        "def execute(ctx, **kwargs) -> dict:\n    return {}\n"
+    )
+
+    with pytest.raises(Exception, match="weird") as exc_info:
+        workspace_to_preset(str(ws), strict=True)
+    # The error should also mention 'parameters' so the builder knows
+    # which YAML key to fix.
+    assert "parameters" in str(exc_info.value).lower()
+
+
+# ── fix 8: malformed hook return doesn't crash the loop ───────────
+
+
+def test_loop_isolates_check_done_returning_garbage(tmp_path: Path) -> None:
+    """A check_done hook that returns a non-HookDecision dict must
+    not bring the loop down with a TypeError. Log loudly, treat as
+    'no decision', let done() through.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        MockLLMBackend,
+        composable_loop,
+    )
+
+    ws = tmp_path / "weird_hook.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "wh", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 4\ndone_tool: done\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text(
+        "name: done\ndescription: x\nparameters:\n  answer: { type: string }\n"
+    )
+    (ws / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx, *, answer: str) -> dict:\n    return {'answer': answer, 'done': True}\n"
+    )
+    (ws / "hooks" / "00_WeirdHook").mkdir(parents=True)
+    (ws / "hooks" / "00_WeirdHook" / "config.yaml").write_text(
+        "class_name: WeirdHook\nkwargs: {}\n"
+    )
+    (ws / "hooks" / "00_WeirdHook" / "hook.py").write_text(
+        "class WeirdHook:\n"
+        "    def check_done(self, state, session_log, context, step_num):\n"
+        "        return {'this_is': 'not a HookDecision'}\n"
+    )
+
+    preset = workspace_to_preset(str(ws), strict=True)
+    backend = MockLLMBackend(
+        responses=[
+            _json.dumps({"tool": "done", "args": {"answer": "ok"}, "reasoning": "", "call_id": "1"})
+        ]
+    )
+    state = DefaultState(max_steps=preset.config.max_steps)
+    # The loop must not raise even though the hook's return value
+    # would otherwise crash normalize_hook_return.
+    steps = list(
+        composable_loop(
+            llm=backend,
+            tools=preset.tools,
+            state=state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"description": "go"},
+        )
+    )
+    assert len(steps) >= 1
+    assert steps[-1].tool_call.tool == "done"
+
+
+# ── fix 9: parse extracts call_id and doesn't promote it to args ─
+
+
+def test_parse_does_not_absorb_call_id_into_tool_args() -> None:
+    """A common LLM/Mock response shape includes ``call_id`` at the
+    top level alongside ``tool``/``args``. Before the fix, the
+    flat-args fallback in ``_dict_to_tool_call`` swept ``call_id``
+    into the tool's kwargs, so the dispatcher rejected every call
+    with ``unexpected argument: ['call_id']``.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet.parse import parse_multi_tool_calls  # noqa: PLC0415
+
+    raw = _json.dumps({"tool": "slow", "args": {}, "reasoning": "", "call_id": "abc-123"})
+    calls = parse_multi_tool_calls(raw)
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.tool == "slow"
+    assert call.args == {}, f"call_id leaked into args: {call.args}"
+    # The parser should also surface the call_id on the ToolCall
+    # itself so traces can correlate request <-> response.
+    assert call.call_id == "abc-123"
+
+
+# ── fix 10: ProvenanceSink redact also scrubs trace files ────────
+
+
+def test_provenance_sink_redact_scrubs_trace_file(tmp_path: Path) -> None:
+    """SPEC and AGENTS.md promise the trace file is sanitized when a
+    ``redact`` callable is passed. Before the fix, only upstream LLM
+    text was redacted; the trajectory.json captured tool args
+    (including the agent's ``done({answer: 'contact alice@x.com'})``)
+    verbatim.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import DefaultState, MockLLMBackend, composable_loop  # noqa: PLC0415
+    from looplet.provenance import ProvenanceSink  # noqa: PLC0415
+
+    ws = tmp_path / "redact.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "rd", "schema_version": 1}))
+    (ws / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text(
+        "name: done\ndescription: x\nparameters:\n  answer: { type: string }\n"
+    )
+    (ws / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx, *, answer: str) -> dict:\n    return {'answer': answer, 'done': True}\n"
+    )
+    preset = workspace_to_preset(str(ws), strict=True)
+
+    traces = tmp_path / "traces"
+    sink = ProvenanceSink(
+        dir=str(traces),
+        redact=lambda s: s.replace("alice@example.com", "[EMAIL]"),
+    )
+    base = MockLLMBackend(
+        responses=[
+            _json.dumps(
+                {
+                    "tool": "done",
+                    "args": {"answer": "contact alice@example.com"},
+                    "reasoning": "",
+                    "call_id": "1",
+                }
+            )
+        ]
+    )
+    llm = sink.wrap_llm(base)
+    hooks = list(preset.hooks) + [sink.trajectory_hook()]
+    state = DefaultState(max_steps=preset.config.max_steps)
+    list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=state,
+            config=preset.config,
+            hooks=hooks,
+            task={"description": "go"},
+        )
+    )
+    sink.flush()
+
+    files = list(traces.rglob("*.json")) + list(traces.rglob("*.jsonl"))
+    assert files, f"no trace files written under {traces}"
+    for tf in files:
+        text = tf.read_text(encoding="utf-8", errors="replace")
+        assert "alice@example.com" not in text, (
+            f"PII leaked into trace file {tf.name}: {text[:200]}"
+        )

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -704,3 +704,93 @@ def test_composable_loop_helpful_error_when_tools_is_a_list() -> None:
     msg = str(exc_info.value)
     # Must name the fix so a builder reading the traceback can act.
     assert "tools_from" in msg, f"expected 'tools_from' in error: {msg}"
+
+
+# ── fix 13: permission denial includes "Permission denied for tool X" prefix ─
+
+
+def test_permission_deny_message_includes_canonical_prefix(tmp_path: Path) -> None:
+    """Before the fix, a deny rule with ``reason: 'forbidden'`` produced
+    ``error='forbidden'`` — losing the canonical 'Permission denied for
+    tool X' phrase entirely. Builders grepping ``tool_result.error`` for
+    'denied' or 'permission' missed it. Now the canonical prefix is
+    always present and the rule reason is appended as context.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        MockLLMBackend,
+        composable_loop,
+    )
+    from looplet.types import ErrorKind  # noqa: PLC0415
+
+    ws = tmp_path / "p.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "p", "schema_version": 1}))
+    (ws / "config.yaml").write_text(
+        textwrap.dedent("""\
+            max_steps: 4
+            done_tool: done
+            permissions:
+              default: allow
+              deny:
+                - tool: shell
+                  contains:
+                    cmd: "danger"
+                  reason: "forbidden"
+        """)
+    )
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text(
+        "name: done\ndescription: x\nparameters:\n  summary: { type: string }\n"
+    )
+    (ws / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx, *, summary: str) -> dict:\n    return {'summary': summary}\n"
+    )
+    (ws / "tools" / "shell").mkdir(parents=True)
+    (ws / "tools" / "shell" / "tool.yaml").write_text(
+        "name: shell\ndescription: x\nparameters:\n  cmd: { type: string }\n"
+    )
+    (ws / "tools" / "shell" / "execute.py").write_text(
+        "def execute(ctx, *, cmd: str) -> dict:\n    return {'ran': cmd}\n"
+    )
+    preset = workspace_to_preset(str(ws), strict=True)
+    backend = MockLLMBackend(
+        responses=[
+            _json.dumps(
+                {
+                    "tool": "shell",
+                    "args": {"cmd": "danger-attempt"},
+                    "reasoning": "",
+                    "call_id": "1",
+                }
+            ),
+            _json.dumps(
+                {"tool": "done", "args": {"summary": "ok"}, "reasoning": "", "call_id": "2"}
+            ),
+        ]
+    )
+    state = DefaultState(max_steps=preset.config.max_steps)
+    steps = list(
+        composable_loop(
+            llm=backend,
+            tools=preset.tools,
+            state=state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"description": "go"},
+        )
+    )
+    blocked = next((s for s in steps if s.tool_call.tool == "shell"), None)
+    assert blocked is not None, "expected a shell step"
+    err = blocked.tool_result.error or ""
+    assert "permission denied" in err.lower(), (
+        f"expected canonical 'permission denied' in error: {err!r}"
+    )
+    # The rule reason still appears as context.
+    assert "forbidden" in err, f"rule reason 'forbidden' missing from error: {err!r}"
+    assert blocked.tool_result.error_detail is not None
+    assert blocked.tool_result.error_detail.kind == ErrorKind.PERMISSION_DENIED

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -330,3 +330,114 @@ def test_output_schema_rejection_populates_tool_result_error(tmp_path: Path) -> 
     second = steps[1]
     assert second.tool_result.error is None
     assert (second.tool_result.data or {}).get("summary") == "ok"
+
+
+# ── fix 5: extends does key-level config merge, not file-level ────
+
+
+def test_extends_carries_grandparent_config_keys(tmp_path: Path) -> None:
+    """A child extending a parent extending a grandparent inherits keys
+    from every level. Before the fix, the child's config.yaml overlay
+    silently wiped every grandparent key the child didn't redeclare.
+    """
+    import json as _json  # noqa: PLC0415
+
+    gp = tmp_path / "gp.workspace"
+    gp.mkdir()
+    (gp / "workspace.json").write_text(_json.dumps({"name": "gp", "schema_version": 1}))
+    (gp / "config.yaml").write_text(
+        "max_steps: 9\nmax_tokens: 1500\ntemperature: 0.5\ndone_tool: done\n"
+    )
+    (gp / "prompts").mkdir()
+    (gp / "prompts" / "system.md").write_text("gp\n")
+    (gp / "tools" / "done").mkdir(parents=True)
+    (gp / "tools" / "done" / "tool.yaml").write_text(
+        "name: done\ndescription: x\nparameters:\n  answer: { type: string }\n"
+    )
+    (gp / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx, *, answer): return {'answer': answer, 'done': True}\n"
+    )
+
+    p = tmp_path / "p.workspace"
+    p.mkdir()
+    (p / "workspace.json").write_text(_json.dumps({"name": "p", "schema_version": 1}))
+    (p / "config.yaml").write_text("extends: ../gp.workspace\ntemperature: 0.3\n")
+    (p / "prompts").mkdir()
+    (p / "prompts" / "system.md").write_text("p\n")
+
+    c = tmp_path / "c.workspace"
+    c.mkdir()
+    (c / "workspace.json").write_text(_json.dumps({"name": "c", "schema_version": 1}))
+    (c / "config.yaml").write_text("extends: ../p.workspace\ntemperature: 0.0\n")
+    (c / "prompts").mkdir()
+    (c / "prompts" / "system.md").write_text("c\n")
+
+    preset = workspace_to_preset(str(c), strict=True)
+    # Grandparent's max_tokens must survive 2 levels of extends.
+    assert preset.config.max_tokens == 1500, (
+        f"max_tokens={preset.config.max_tokens}; extends dropped grandparent key"
+    )
+    # Grandparent's max_steps must survive too.
+    assert preset.config.max_steps == 9
+    # Child's temperature wins (0.0 over parent's 0.3 over gp's 0.5).
+    assert preset.config.temperature == 0.0
+
+
+def test_extends_block_merge_preserves_unset_subkeys(tmp_path: Path) -> None:
+    """Child overriding one sub-key of a block (model.reasoning_effort) must
+    not erase sibling sub-keys (model.provider, model.name) from the parent.
+    """
+    import json as _json  # noqa: PLC0415
+
+    parent = tmp_path / "p.workspace"
+    parent.mkdir()
+    (parent / "workspace.json").write_text(_json.dumps({"name": "p", "schema_version": 1}))
+    (parent / "config.yaml").write_text(
+        "model:\n  provider: anthropic\n  name: claude-sonnet-4.6\n  reasoning_effort: medium\n"
+    )
+    (parent / "prompts").mkdir()
+    (parent / "prompts" / "system.md").write_text("p\n")
+
+    child = tmp_path / "c.workspace"
+    child.mkdir()
+    (child / "workspace.json").write_text(_json.dumps({"name": "c", "schema_version": 1}))
+    (child / "config.yaml").write_text(
+        "extends: ../p.workspace\nmodel:\n  reasoning_effort: high\n"
+    )
+    (child / "prompts").mkdir()
+    (child / "prompts" / "system.md").write_text("c\n")
+
+    preset = workspace_to_preset(str(child))
+    meta = (preset.config.tool_metadata or {}).get("model", {})
+    assert meta.get("provider") == "anthropic", f"parent model.provider erased; meta={meta}"
+    assert meta.get("name") == "claude-sonnet-4.6"
+    assert meta.get("reasoning_effort") == "high"
+
+
+# ── fix 6: missing done tool warns at load time ───────────────────
+
+
+def test_loader_warns_when_done_tool_unregistered(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A typo or missing done dir triggers a load-time warning that
+    names the missing tool and the available alternatives."""
+    import json as _json  # noqa: PLC0415
+
+    ws = tmp_path / "no_done.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "x", "schema_version": 1}))
+    # done_tool refers to a tool that doesn't exist.
+    (ws / "config.yaml").write_text("max_steps: 4\ndone_tool: dont\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test\n")
+    (ws / "tools" / "noop").mkdir(parents=True)
+    (ws / "tools" / "noop" / "tool.yaml").write_text("name: noop\ndescription: x\nparameters: {}\n")
+    (ws / "tools" / "noop" / "execute.py").write_text("def execute(ctx) -> dict:\n    return {}\n")
+
+    with caplog.at_level(logging.WARNING, logger="looplet.workspace"):
+        workspace_to_preset(str(ws), strict=True)
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("done_tool" in m and "dont" in m and "noop" in m for m in msgs), (
+        f"expected done_tool warning naming missing+available, got: {msgs}"
+    )

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -1,0 +1,332 @@
+"""Regression tests for two frictions surfaced by the runtime-trust dogfood.
+
+1. **Hot-reload bytecode-cache staleness.** Python's ``SourceFileLoader``
+   writes ``__pycache__/<name>.cpython-XYZ.pyc`` next to a workspace
+   tool's ``execute.py`` and reuses that bytecode whenever the source
+   mtime matches the value stored in the ``.pyc`` header. The mtime is
+   recorded with **second** resolution, so two writes within the same
+   wall-clock second silently re-use the old bytecode — a cartridge
+   reloaded after a fast edit returned the previous tool body.
+   ``_import_module_from_path`` now reads the source verbatim and
+   ``compile`` + ``exec`` it directly, so the cache is bypassed and
+   no ``__pycache__`` is written into the user's cartridge.
+
+2. **scaffold-then-edit silently rejects calls.** ``scaffold_workspace``
+   writes ``parameters: {}`` and ``def execute(ctx, **kwargs)`` together.
+   Users replace ``**kwargs`` with explicit keyword params (``*, name: str``)
+   but forget to update ``parameters:``. The dispatcher then rejects
+   every call with VALIDATION because the schema advertises zero
+   parameters. The loader now warns at strict-load time when an
+   ``execute.py`` declares explicit kwargs but ``tool.yaml`` is empty.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from looplet import workspace_to_preset
+from looplet.types import ToolCall
+
+
+def _write_basic_workspace(root: Path) -> Path:
+    ws = root / "rt.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(json.dumps({"name": "rt", "schema_version": 1}) + "\n")
+    (ws / "config.yaml").write_text("max_steps: 4\ndone_tool: done\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("test agent\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text(
+        "name: done\ndescription: Done.\nparameters: {}\n"
+    )
+    (ws / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'done': True}\n"
+    )
+    return ws
+
+
+# ── fix 1: hot-reload + no __pycache__ pollution ──────────────────
+
+
+def test_workspace_reload_picks_up_edited_tool_body(tmp_path: Path) -> None:
+    """Two loads in the same wall-clock second see the new tool body."""
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "stamp").mkdir(parents=True)
+    (ws / "tools" / "stamp" / "tool.yaml").write_text(
+        "name: stamp\ndescription: Return version.\nparameters: {}\n"
+    )
+    (ws / "tools" / "stamp" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'version': 1}\n"
+    )
+
+    preset1 = workspace_to_preset(str(ws), strict=True)
+    out1 = preset1.tools.dispatch(ToolCall(tool="stamp", args={}, reasoning="x", call_id="1")).data
+    assert (out1 or {}).get("version") == 1
+
+    # Edit immediately — must NOT depend on mtime ticking past one second.
+    (ws / "tools" / "stamp" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'version': 2}\n"
+    )
+
+    preset2 = workspace_to_preset(str(ws), strict=True)
+    out2 = preset2.tools.dispatch(ToolCall(tool="stamp", args={}, reasoning="x", call_id="2")).data
+    assert (out2 or {}).get("version") == 2, (
+        f"second load returned stale body: {out2!r} "
+        f"(if you see version=1, the bytecode cache is back)"
+    )
+
+
+def test_workspace_load_does_not_pollute_cartridge_with_pycache(tmp_path: Path) -> None:
+    """Loading a workspace must not create __pycache__/ inside the cartridge.
+
+    The cartridge boundary promises 'just files' — leaving compiled
+    bytecode in tools/<name>/__pycache__/ violates that promise (and
+    surfaces in `git status`, breaks `find . -type f` listings, etc.).
+    """
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "x").mkdir(parents=True)
+    (ws / "tools" / "x" / "tool.yaml").write_text("name: x\ndescription: x.\nparameters: {}\n")
+    (ws / "tools" / "x" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'ok': True}\n"
+    )
+
+    workspace_to_preset(str(ws), strict=True)
+
+    pycache_dirs = list(ws.rglob("__pycache__"))
+    assert pycache_dirs == [], (
+        f"workspace_to_preset created __pycache__ inside the cartridge: {pycache_dirs}"
+    )
+
+
+def test_workspace_reload_after_seconds_still_works(tmp_path: Path) -> None:
+    """The slow-edit path (mtime ticked past one second) still works.
+
+    Sanity: if someone reverts the cache fix to use SourceFileLoader
+    naively, this test would *also* catch the case where mtime DOES
+    tick but bytecode invalidation has another bug.
+    """
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "stamp").mkdir(parents=True)
+    (ws / "tools" / "stamp" / "tool.yaml").write_text(
+        "name: stamp\ndescription: x.\nparameters: {}\n"
+    )
+    (ws / "tools" / "stamp" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'version': 1}\n"
+    )
+    workspace_to_preset(str(ws), strict=True)
+    time.sleep(1.1)
+    (ws / "tools" / "stamp" / "execute.py").write_text(
+        "def execute(ctx) -> dict:\n    return {'version': 2}\n"
+    )
+    preset = workspace_to_preset(str(ws), strict=True)
+    out = preset.tools.dispatch(ToolCall(tool="stamp", args={}, reasoning="x", call_id="1")).data
+    assert (out or {}).get("version") == 2
+
+
+# ── fix 2: parameters-vs-signature mismatch warning ───────────────
+
+
+def test_loader_warns_on_empty_parameters_with_explicit_signature(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Mismatched ``parameters: {}`` and explicit kwargs trigger a warning."""
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "greet").mkdir(parents=True)
+    (ws / "tools" / "greet" / "tool.yaml").write_text(
+        "name: greet\ndescription: Greet.\nparameters: {}\n"
+    )
+    (ws / "tools" / "greet" / "execute.py").write_text(
+        "def execute(ctx, *, name: str) -> dict:\n    return {'hi': name}\n"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="looplet.workspace"):
+        workspace_to_preset(str(ws))
+
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("greet" in m and "parameters" in m and "VALIDATION" in m for m in msgs), (
+        f"expected parameters-mismatch warning, got: {msgs}"
+    )
+
+
+def test_loader_strict_rejects_empty_parameters_with_explicit_signature(
+    tmp_path: Path,
+) -> None:
+    """Strict mode upgrades the warning to a structured error."""
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "greet").mkdir(parents=True)
+    (ws / "tools" / "greet" / "tool.yaml").write_text(
+        "name: greet\ndescription: Greet.\nparameters: {}\n"
+    )
+    (ws / "tools" / "greet" / "execute.py").write_text(
+        "def execute(ctx, *, name: str) -> dict:\n    return {'hi': name}\n"
+    )
+    with pytest.raises(Exception, match="parameters"):
+        workspace_to_preset(str(ws), strict=True)
+
+
+def test_loader_does_not_warn_when_kwargs_signature(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``def execute(ctx, **kwargs)`` is internally consistent with empty parameters."""
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "greet").mkdir(parents=True)
+    (ws / "tools" / "greet" / "tool.yaml").write_text(
+        "name: greet\ndescription: Greet.\nparameters: {}\n"
+    )
+    (ws / "tools" / "greet" / "execute.py").write_text(
+        "def execute(ctx, **kwargs) -> dict:\n    return {**kwargs}\n"
+    )
+    with caplog.at_level(logging.WARNING, logger="looplet.workspace"):
+        workspace_to_preset(str(ws), strict=True)
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert not any("greet" in m and "VALIDATION" in m for m in msgs), (
+        f"unexpected mismatch warning for **kwargs: {msgs}"
+    )
+
+
+def test_loader_does_not_warn_when_parameters_filled(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Filled ``parameters:`` and explicit signature is the happy path."""
+    ws = _write_basic_workspace(tmp_path)
+    (ws / "tools" / "greet").mkdir(parents=True)
+    (ws / "tools" / "greet" / "tool.yaml").write_text(
+        textwrap.dedent("""\
+            name: greet
+            description: Greet.
+            parameters:
+              name: { type: string }
+        """)
+    )
+    (ws / "tools" / "greet" / "execute.py").write_text(
+        "def execute(ctx, *, name: str) -> dict:\n    return {'hi': name}\n"
+    )
+    with caplog.at_level(logging.WARNING, logger="looplet.workspace"):
+        workspace_to_preset(str(ws), strict=True)
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert not any("greet" in m and "VALIDATION" in m for m in msgs), (
+        f"unexpected mismatch warning when parameters are filled: {msgs}"
+    )
+
+
+# ── fix 3: watcher fingerprint must detect content edits even when
+# mtime resolution is coarse (tmpfs / network mounts) ─────────────────
+
+
+def test_fingerprint_detects_content_edit_with_same_mtime(tmp_path: Path) -> None:
+    """fingerprint changes when content changes even if mtime_ns collides."""
+    from looplet.hot_reload import fingerprint_workspace  # noqa: PLC0415
+
+    ws = _write_basic_workspace(tmp_path)
+    src = ws / "tools" / "done" / "execute.py"
+    src.write_text("def execute(ctx) -> dict:\n    return {'ver': 1}\n")
+    fp1 = fingerprint_workspace(ws)
+
+    # Two writes back-to-back can collide on mtime even with ns precision
+    # on tmpfs. We cannot reliably *force* the collision in a unit test,
+    # but we *can* verify that fingerprint changes whenever the content
+    # changes — which is the property we actually care about.
+    src.write_text("def execute(ctx) -> dict:\n    return {'ver': 2}\n")
+    fp2 = fingerprint_workspace(ws)
+
+    assert fp1 != fp2, "content edit did not change fingerprint; watcher would miss the edit"
+
+
+def test_watcher_detects_change_after_edit(tmp_path: Path) -> None:
+    """WorkspaceWatcher.changed() returns True after a content edit."""
+    from looplet.hot_reload import WorkspaceWatcher  # noqa: PLC0415
+
+    ws = _write_basic_workspace(tmp_path)
+    src = ws / "tools" / "done" / "execute.py"
+    src.write_text("def execute(ctx) -> dict:\n    return {'ver': 1}\n")
+
+    watcher = WorkspaceWatcher(ws)
+    # The watcher is lazy: it seeds its fingerprint on the first
+    # preset() call. Pre-load so the subsequent changed() probe is
+    # honest.
+    watcher.preset()
+    assert not watcher.changed(), "watcher reported change with no edit"
+
+    src.write_text("def execute(ctx) -> dict:\n    return {'ver': 2}\n")
+    assert watcher.changed(), "watcher missed a content edit"
+
+
+# ── fix 4: rejection reason mirrored into ToolResult.error ─────────────
+
+
+def test_output_schema_rejection_populates_tool_result_error(tmp_path: Path) -> None:
+    """output_schema rejection puts the reason on .error, not just .data.
+
+    Builders who grep tool_result.error to find failures otherwise miss
+    schema-level rejections entirely.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        MockLLMBackend,
+        composable_loop,
+        workspace_to_preset,
+    )
+
+    ws = tmp_path / "se.workspace"
+    ws.mkdir()
+    (ws / "workspace.json").write_text(_json.dumps({"name": "se", "schema_version": 1}) + "\n")
+    (ws / "config.yaml").write_text("max_steps: 3\ndone_tool: done\n")
+    (ws / "prompts").mkdir()
+    (ws / "prompts" / "system.md").write_text("go\n")
+    (ws / "tools" / "done").mkdir(parents=True)
+    (ws / "tools" / "done" / "tool.yaml").write_text(
+        textwrap.dedent("""\
+            name: done
+            description: x
+            parameters:
+              summary: { type: string }
+            output_schema:
+              type: object
+              required: [summary]
+              properties:
+                summary: { type: string }
+        """)
+    )
+    (ws / "tools" / "done" / "execute.py").write_text(
+        "def execute(ctx, **k) -> dict:\n    return {**k}\n"
+    )
+
+    preset = workspace_to_preset(str(ws), strict=True)
+    backend = MockLLMBackend(
+        responses=[
+            _json.dumps({"tool": "done", "args": {}, "reasoning": "r", "call_id": "1"}),
+            _json.dumps(
+                {"tool": "done", "args": {"summary": "ok"}, "reasoning": "r", "call_id": "2"}
+            ),
+        ]
+    )
+    state = DefaultState(max_steps=3)
+    steps = list(
+        composable_loop(
+            llm=backend,
+            tools=preset.tools,
+            state=state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"description": "go"},
+        )
+    )
+    # First step: malformed -> error must be set, data.rejected too.
+    first = steps[0]
+    assert first.tool_result.error is not None, (
+        "output_schema rejection did not set tool_result.error"
+    )
+    assert "schema" in first.tool_result.error.lower()
+    assert (first.tool_result.data or {}).get("rejected") is True
+    # Second step: well-formed, accepted.
+    second = steps[1]
+    assert second.tool_result.error is None
+    assert (second.tool_result.data or {}).get("summary") == "ok"

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -661,3 +661,46 @@ def test_preview_prompt_includes_system_prompt() -> None:
     )
     # Also smoke-check that the user-prompt section is still there.
     assert "TASK" in text
+
+
+# ── fix 12: helpful TypeError when tools= is a list ───────────────
+
+
+def test_composable_loop_helpful_error_when_tools_is_a_list() -> None:
+    """A common new-user mistake: pass a list of @tool ToolSpecs to
+    composable_loop instead of wrapping with tools_from. The downstream
+    failure was a bare ``AttributeError: 'list' object has no attribute
+    'tool_catalog_text'`` deep inside prompt assembly. The loop now
+    catches the mistake at the entry point and points at tools_from.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        LoopConfig,
+        MockLLMBackend,
+        composable_loop,
+        tool,
+    )
+
+    @tool
+    def greet(*, name: str) -> dict:
+        return {"hi": name}
+
+    backend = MockLLMBackend(
+        responses=[_json.dumps({"tool": "done", "args": {}, "reasoning": "", "call_id": "1"})]
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        list(
+            composable_loop(
+                llm=backend,
+                tools=[greet],  # mistake: list, not registry
+                state=DefaultState(max_steps=2),
+                config=LoopConfig(max_steps=2),
+                task={"description": "go"},
+            )
+        )
+    msg = str(exc_info.value)
+    # Must name the fix so a builder reading the traceback can act.
+    assert "tools_from" in msg, f"expected 'tools_from' in error: {msg}"

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -637,3 +637,27 @@ def test_provenance_sink_redact_scrubs_trace_file(tmp_path: Path) -> None:
         assert "alice@example.com" not in text, (
             f"PII leaked into trace file {tf.name}: {text[:200]}"
         )
+
+
+# ── fix 11: preview_prompt now includes the system prompt ─────────
+
+
+def test_preview_prompt_includes_system_prompt() -> None:
+    """preview_prompt promises to render 'the prompt the LLM would see'.
+
+    The LLM receives both a system prompt and a user message; before
+    the fix, preview_prompt returned only the user message, so anyone
+    debugging a prompt regression by reading preview output couldn't
+    see the system prompt at all. Now the system prompt is prepended
+    when ``config`` is provided.
+    """
+    from looplet import LoopConfig  # noqa: PLC0415
+    from looplet.prompts import preview_prompt  # noqa: PLC0415
+
+    cfg = LoopConfig(max_steps=4, system_prompt="MAGIC-SYSTEM-MARKER-XYZ")
+    text = preview_prompt(task={"goal": "go"}, config=cfg)
+    assert "MAGIC-SYSTEM-MARKER-XYZ" in text, (
+        f"preview_prompt dropped the system prompt; got: {text[:200]!r}"
+    )
+    # Also smoke-check that the user-prompt section is still there.
+    assert "TASK" in text

--- a/tests/test_runtime_trust_fixes.py
+++ b/tests/test_runtime_trust_fixes.py
@@ -837,3 +837,163 @@ def test_agents_md_symbol_index_entries_are_importable() -> None:
         f"AGENTS.md symbol-index lists {len(missing)} symbol(s) that aren't "
         f"importable from `looplet`: {missing[:5]}"
     )
+
+
+# ── fix 15: helpful error when task= is a string ─────────────────
+
+
+def test_composable_loop_helpful_error_when_task_is_a_string() -> None:
+    """A common new-user mistake is to pass a bare string as the task
+    (the README shows dicts, but copy-paste drift is real). Before the
+    fix, the loop crashed downstream with
+    ``AttributeError: 'str' object has no attribute 'items'`` deep
+    inside the prompt builder. Now the error is caught at the entry
+    point and tells the user how to fix it.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        LoopConfig,
+        MockLLMBackend,
+        composable_loop,
+        tool,
+        tools_from,
+    )
+
+    @tool
+    def noop() -> dict:
+        return {}
+
+    tools = tools_from([noop], include_done=True, done_parameters={"answer": "x"})
+    backend = MockLLMBackend(
+        responses=[_json.dumps({"tool": "done", "args": {}, "reasoning": "", "call_id": "1"})]
+    )
+    cfg = LoopConfig(max_steps=2)
+    state = DefaultState(max_steps=2)
+    with pytest.raises(TypeError) as exc_info:
+        list(
+            composable_loop(
+                llm=backend,
+                tools=tools,
+                state=state,
+                config=cfg,
+                task="just a string task",  # mistake: not a dict
+            )
+        )
+    msg = str(exc_info.value)
+    # The error must name 'dict' so the fix is obvious.
+    assert "dict" in msg.lower(), f"expected 'dict' in error: {msg}"
+
+
+# ── fix 16: memory source raising doesn't crash the loop ────────
+
+
+def test_loop_isolates_memory_source_that_raises(tmp_path: Path) -> None:
+    """A buggy memory source that raises during ``load(state)`` must
+    not crash the loop. AGENTS.md promises hooks are isolated; memory
+    sources should follow the same contract. Before the fix,
+    ``render_memory`` propagated the exception out of the prompt
+    builder, killing the entire run.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        CallableMemorySource,
+        DefaultState,
+        LoopConfig,
+        MockLLMBackend,
+        composable_loop,
+        tool,
+        tools_from,
+    )
+
+    def broken_load(state: object) -> str:
+        raise RuntimeError("memory broken")
+
+    @tool
+    def noop() -> dict:
+        return {}
+
+    tools = tools_from([noop], include_done=True, done_parameters={"answer": "x"})
+    backend = MockLLMBackend(
+        responses=[
+            _json.dumps({"tool": "done", "args": {"answer": "ok"}, "reasoning": "", "call_id": "1"})
+        ]
+    )
+    cfg = LoopConfig(
+        max_steps=2,
+        memory_sources=[CallableMemorySource(fn=broken_load)],
+    )
+    state = DefaultState(max_steps=2)
+    # The loop must not raise — memory source crash is isolated.
+    steps = list(
+        composable_loop(
+            llm=backend,
+            tools=tools,
+            state=state,
+            config=cfg,
+            task={"description": "go"},
+        )
+    )
+    assert len(steps) >= 1
+    assert steps[-1].tool_call.tool == "done"
+
+
+# ── fix 17: LLMResponsesExhausted is not retried ─────────────────
+
+
+def test_loop_does_not_retry_mock_exhaustion(tmp_path: Path) -> None:
+    """MockLLMBackend(cycle=False) raises LLMResponsesExhausted when a
+    test scripted fewer responses than the loop asked for. Before the
+    fix, the retry-with-backoff loop in scaffolding waited 1s + 2s
+    before giving up — making test failures slow and noisy. The new
+    type-name check short-circuits the retry, surfacing the clear
+    error immediately.
+    """
+    import json as _json  # noqa: PLC0415
+    import time as _time  # noqa: PLC0415
+
+    from looplet import (  # noqa: PLC0415
+        DefaultState,
+        LoopConfig,
+        MockLLMBackend,
+        composable_loop,
+        tool,
+        tools_from,
+    )
+
+    @tool
+    def noop() -> dict:
+        return {}
+
+    tools = tools_from([noop], include_done=True, done_parameters={"answer": "x"})
+    backend = MockLLMBackend(
+        responses=[_json.dumps({"tool": "noop", "args": {}, "reasoning": "", "call_id": "1"})],
+        cycle=False,
+    )
+    cfg = LoopConfig(max_steps=10)
+    state = DefaultState(max_steps=10)
+
+    t0 = _time.monotonic()
+    steps = list(
+        composable_loop(
+            llm=backend,
+            tools=tools,
+            state=state,
+            config=cfg,
+            task={"description": "spin"},
+        )
+    )
+    elapsed = _time.monotonic() - t0
+    # Without the fix, retry waited ~3s of backoff; with the fix it
+    # short-circuits, so a generous bound of 1s catches regressions.
+    assert elapsed < 1.0, (
+        f"loop took {elapsed:.2f}s before surfacing exhaustion; "
+        f"the retry-with-backoff path probably ran (regressed)."
+    )
+    # The loop should still surface the error as a step (existing
+    # behaviour) — we only changed how fast.
+    assert any(s.tool_call.tool == "__llm_error__" for s in steps), (
+        f"expected an __llm_error__ step; got tools {[s.tool_call.tool for s in steps]}"
+    )

--- a/tests/test_spec_boundary.py
+++ b/tests/test_spec_boundary.py
@@ -1,0 +1,98 @@
+"""Enforce the cartridge-spec / runtime boundary inside looplet.
+
+The spec modules listed in :mod:`looplet._spec_modules` constitute
+the surface that ``SPEC.md`` describes and that a future spec-only
+package would carve out. They MUST NOT take top-level imports on
+the looplet runtime (the loop, backends, presets, examples, CLI,
+etc.). Function-local imports and ``TYPE_CHECKING`` imports are
+fine; the check inspects the module AST.
+
+If you need to use a runtime module from a spec module, import it
+inside the function or guard it with ``if TYPE_CHECKING:``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from looplet._spec_modules import SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS, SPEC_MODULES
+
+PKG_ROOT = Path(__file__).resolve().parent.parent / "src" / "looplet"
+
+
+def _iter_module_files() -> list[tuple[str, Path]]:
+    """Return ``(short_name, path)`` for each spec module on disk.
+
+    A spec module is either ``<name>.py`` directly under
+    ``src/looplet/`` or a package directory ``<name>/`` with an
+    ``__init__.py``.
+    """
+    found: list[tuple[str, Path]] = []
+    for name in sorted(SPEC_MODULES):
+        py = PKG_ROOT / f"{name}.py"
+        pkg_init = PKG_ROOT / name / "__init__.py"
+        if py.is_file():
+            found.append((name, py))
+        elif pkg_init.is_file():
+            found.append((name, pkg_init))
+        else:
+            pytest.fail(
+                f"_spec_modules lists {name!r} but no module is on disk at {py} or {pkg_init}"
+            )
+    return found
+
+
+def _top_level_looplet_imports(source: str) -> set[str]:
+    """Return the short module names that ``source`` imports at module top level.
+
+    Function-local imports and ``TYPE_CHECKING`` imports are excluded.
+    The check is conservative: it walks ``ast.Module.body`` directly,
+    so anything wrapped in ``if TYPE_CHECKING:``, ``def``, ``class``,
+    or ``try/except`` falls outside its scope.
+    """
+    names: set[str] = set()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "looplet" or module.startswith("looplet."):
+                short = module.split(".", 2)[1] if module.startswith("looplet.") else ""
+                if short:
+                    names.add(short)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "looplet" or alias.name.startswith("looplet."):
+                    short = alias.name.split(".", 2)[1] if "." in alias.name else ""
+                    if short:
+                        names.add(short)
+    return names
+
+
+@pytest.mark.parametrize("module_name,module_path", _iter_module_files())
+def test_spec_module_has_no_runtime_top_level_imports(module_name: str, module_path: Path) -> None:
+    source = module_path.read_text(encoding="utf-8")
+    imported = _top_level_looplet_imports(source)
+    forbidden = imported & SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS
+    assert not forbidden, (
+        f"spec module {module_name!r} top-level-imports runtime modules {sorted(forbidden)}; "
+        f"move these into a function body or a ``TYPE_CHECKING`` block. "
+        f"See looplet._spec_modules for the boundary definition."
+    )
+
+
+def test_spec_module_files_exist() -> None:
+    """Every spec module name resolves to an actual file."""
+    found = _iter_module_files()
+    assert {name for name, _ in found} == set(SPEC_MODULES)
+
+
+def test_no_runtime_module_appears_in_spec_modules() -> None:
+    """Spec and runtime sets must be disjoint."""
+    assert not (SPEC_MODULES & SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS), (
+        "SPEC_MODULES and SPEC_FORBIDDEN_TOP_LEVEL_IMPORTS overlap; "
+        "this means a module is being declared as both spec and runtime, "
+        "which is contradictory."
+    )

--- a/tests/test_spec_slots.py
+++ b/tests/test_spec_slots.py
@@ -1,0 +1,363 @@
+"""Tests for the v1.0 declarative slots: model, permissions, memory, output_schema.
+
+Each block has a small unit test plus an integration test that goes
+through ``workspace_to_preset`` end-to-end on a tmp cartridge.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from looplet.permissions import PermissionDecision, PermissionEngine, PermissionHook
+from looplet.spec_slots import (
+    compile_model_block,
+    compile_output_schema,
+    compile_permissions_block,
+    default_long_term_memory_path,
+)
+from looplet.validation import OutputSchema, validate_args
+from looplet.workspace import workspace_to_preset
+
+# ── unit tests: compile_permissions_block ──────────────────────────
+
+
+def test_permissions_block_default_only() -> None:
+    hook = compile_permissions_block({})
+    assert isinstance(hook, PermissionHook)
+    assert hook.engine.default == PermissionDecision.ALLOW
+    assert hook.engine.rules == []
+
+
+def test_permissions_block_default_explicit() -> None:
+    hook = compile_permissions_block({"default": "deny"})
+    assert hook.engine.default == PermissionDecision.DENY
+
+
+def test_permissions_block_default_invalid() -> None:
+    with pytest.raises(ValueError, match="permissions.default"):
+        compile_permissions_block({"default": "maybe"})
+
+
+def test_permissions_block_bare_string_rule() -> None:
+    hook = compile_permissions_block({"deny": ["bash"]})
+    assert len(hook.engine.rules) == 1
+    rule = hook.engine.rules[0]
+    assert rule.tool == "bash"
+    assert rule.decision == PermissionDecision.DENY
+    assert rule.arg_matcher is None
+
+
+def test_permissions_block_contains_matcher() -> None:
+    hook = compile_permissions_block(
+        {
+            "deny": [
+                {"tool": "bash", "contains": {"command": "rm -rf"}, "reason": "destructive"},
+            ]
+        }
+    )
+    rule = hook.engine.rules[0]
+    assert rule.tool == "bash"
+    assert rule.reason == "destructive"
+    assert rule.arg_matcher is not None
+    assert rule.arg_matcher({"command": "rm -rf /"})
+    assert not rule.arg_matcher({"command": "echo hi"})
+
+
+def test_permissions_block_matches_matcher() -> None:
+    hook = compile_permissions_block(
+        {"allow": [{"tool": "write", "matches": {"file_path": "/tmp/ok"}}]}
+    )
+    rule = hook.engine.rules[0]
+    assert rule.arg_matcher is not None
+    assert rule.arg_matcher({"file_path": "/tmp/ok"})
+    assert not rule.arg_matcher({"file_path": "/etc/passwd"})
+
+
+def test_permissions_block_evaluation_order() -> None:
+    hook = compile_permissions_block(
+        {
+            "allow": ["bash"],
+            "deny": [{"tool": "bash", "contains": {"command": "rm -rf"}}],
+        }
+    )
+    # Deny rule is appended first (per the documented order); the
+    # PermissionEngine evaluates rules in order, so the deny rule
+    # for the dangerous arg matches before the broad allow.
+    rules = hook.engine.rules
+    assert rules[0].decision == PermissionDecision.DENY
+    assert rules[1].decision == PermissionDecision.ALLOW
+
+
+def test_permissions_block_missing_tool_field() -> None:
+    with pytest.raises(ValueError, match="missing 'tool'"):
+        compile_permissions_block({"deny": [{"contains": {"x": "y"}}]})
+
+
+def test_permissions_block_rejects_non_mapping() -> None:
+    with pytest.raises(ValueError, match="permissions block"):
+        compile_permissions_block("nope")  # type: ignore[arg-type]
+
+
+# ── unit tests: compile_model_block ────────────────────────────────
+
+
+def test_model_block_passes_sampling_to_loopconfig() -> None:
+    overrides = compile_model_block({"max_tokens": 8000, "temperature": 0.0}, existing_cfg={})
+    assert overrides == {"max_tokens": 8000, "temperature": 0.0}
+
+
+def test_model_block_metadata_carries_provider_and_name() -> None:
+    overrides = compile_model_block(
+        {
+            "provider": "anthropic",
+            "name": "claude-sonnet-4.6",
+            "reasoning_effort": "high",
+            "extra": {"cache_control": "ephemeral"},
+        },
+        existing_cfg={},
+    )
+    assert overrides["tool_metadata"]["model"] == {
+        "provider": "anthropic",
+        "name": "claude-sonnet-4.6",
+        "reasoning_effort": "high",
+        "extra": {"cache_control": "ephemeral"},
+    }
+    assert "max_tokens" not in overrides
+    assert "temperature" not in overrides
+
+
+def test_model_block_merges_with_existing_metadata() -> None:
+    overrides = compile_model_block(
+        {"provider": "openai"},
+        existing_cfg={"tool_metadata": {"other": 1}},
+    )
+    assert overrides["tool_metadata"]["other"] == 1
+    assert overrides["tool_metadata"]["model"]["provider"] == "openai"
+
+
+def test_model_block_rejects_non_mapping() -> None:
+    with pytest.raises(ValueError, match="model block"):
+        compile_model_block("anthropic", existing_cfg={})  # type: ignore[arg-type]
+
+
+# ── unit tests: compile_output_schema ──────────────────────────────
+
+
+def test_output_schema_basic() -> None:
+    schema = compile_output_schema(
+        {
+            "type": "object",
+            "required": ["summary", "pass"],
+            "properties": {
+                "summary": {"type": "string"},
+                "pass": {"type": "boolean"},
+            },
+        }
+    )
+    assert isinstance(schema, OutputSchema)
+    assert set(schema.fields) == {"summary", "pass"}
+    assert schema.fields["summary"].required is True
+    assert schema.fields["summary"].field_type == "str"
+    assert schema.fields["pass"].field_type == "bool"
+
+    ok = validate_args(schema, {"summary": "done", "pass": True})
+    assert ok.valid
+
+    missing = validate_args(schema, {"summary": "done"})
+    assert not missing.valid
+
+    wrong_type = validate_args(schema, {"summary": "done", "pass": "yes"})
+    assert not wrong_type.valid
+
+
+def test_output_schema_enum_to_allowed_values() -> None:
+    schema = compile_output_schema(
+        {
+            "type": "object",
+            "properties": {
+                "verdict": {"type": "string", "enum": ["ok", "fail"]},
+            },
+        }
+    )
+    spec = schema.fields["verdict"]
+    assert spec.allowed_values == ["ok", "fail"]
+
+
+def test_output_schema_rejects_non_object_root() -> None:
+    with pytest.raises(ValueError, match="output_schema.type"):
+        compile_output_schema({"type": "string"})
+
+
+def test_output_schema_rejects_non_mapping() -> None:
+    with pytest.raises(ValueError, match="output_schema"):
+        compile_output_schema("nope")  # type: ignore[arg-type]
+
+
+# ── default long_term path ─────────────────────────────────────────
+
+
+def test_default_long_term_memory_path() -> None:
+    assert default_long_term_memory_path() == "memory/long_term.md"
+
+
+# ── integration tests via workspace_to_preset ──────────────────────
+
+
+def _write_minimal_workspace(root: Path, *, config_yaml: str, done_yaml: str | None = None) -> None:
+    (root / "workspace.json").write_text(
+        json.dumps({"name": "test_agent", "schema_version": 1}) + "\n"
+    )
+    (root / "config.yaml").write_text(config_yaml)
+    (root / "prompts").mkdir(parents=True, exist_ok=True)
+    (root / "prompts" / "system.md").write_text("you are a test agent\n")
+    tools = root / "tools" / "done"
+    tools.mkdir(parents=True, exist_ok=True)
+    (tools / "tool.yaml").write_text(
+        done_yaml
+        or textwrap.dedent(
+            """\
+            name: done
+            description: Done.
+            parameters:
+              summary: { type: string }
+            """
+        )
+    )
+    (tools / "execute.py").write_text(
+        "def execute(ctx, *, summary: str) -> dict:\n    return {'summary': summary}\n"
+    )
+
+
+def test_loader_installs_permissions_hook(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml=textwrap.dedent(
+            """\
+            max_steps: 5
+            permissions:
+              default: allow
+              deny:
+                - tool: bash
+                  contains:
+                    command: "rm -rf"
+                  reason: "destructive"
+            """
+        ),
+    )
+    preset = workspace_to_preset(str(tmp_path))
+    perm_hooks = [h for h in preset.hooks if isinstance(h, PermissionHook)]
+    assert len(perm_hooks) == 1
+    engine = perm_hooks[0].engine
+    assert engine.default == PermissionDecision.ALLOW
+    assert any(r.tool == "bash" and r.decision == PermissionDecision.DENY for r in engine.rules)
+
+
+def test_loader_compiles_structured_model_block(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml=textwrap.dedent(
+            """\
+            model:
+              provider: anthropic
+              name: claude-sonnet-4.6
+              reasoning_effort: high
+              max_tokens: 4096
+              temperature: 0.0
+            """
+        ),
+    )
+    preset = workspace_to_preset(str(tmp_path))
+    assert preset.config.max_tokens == 4096
+    assert preset.config.temperature == 0.0
+    metadata = preset.config.tool_metadata.get("model", {})
+    assert metadata.get("provider") == "anthropic"
+    assert metadata.get("reasoning_effort") == "high"
+
+
+def test_loader_auto_loads_long_term_memory(tmp_path: Path) -> None:
+    _write_minimal_workspace(tmp_path, config_yaml="max_steps: 3\n")
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "memory" / "long_term.md").write_text("REMEMBER: always test in tmp.\n")
+    preset = workspace_to_preset(str(tmp_path))
+    rendered = "\n".join(s.text for s in preset.config.memory_sources if hasattr(s, "text"))
+    assert "REMEMBER" in rendered
+
+
+def test_loader_explicit_memory_long_term_path(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml=textwrap.dedent(
+            """\
+            memory:
+              long_term: notes/big.md
+            """
+        ),
+    )
+    (tmp_path / "notes").mkdir(exist_ok=True)
+    (tmp_path / "notes" / "big.md").write_text("THE-BIG-NOTE\n")
+    preset = workspace_to_preset(str(tmp_path))
+    rendered = "\n".join(s.text for s in preset.config.memory_sources if hasattr(s, "text"))
+    assert "THE-BIG-NOTE" in rendered
+
+
+def test_loader_installs_output_schema_from_done_tool(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml="max_steps: 3\n",
+        done_yaml=textwrap.dedent(
+            """\
+            name: done
+            description: Done.
+            parameters:
+              summary: { type: string }
+              passed:  { type: boolean }
+            output_schema:
+              type: object
+              required: [summary, passed]
+              properties:
+                summary: { type: string }
+                passed:  { type: boolean }
+            """
+        ),
+    )
+    preset = workspace_to_preset(str(tmp_path))
+    assert preset.config.output_schema is not None
+    assert "summary" in preset.config.output_schema.fields
+    assert "passed" in preset.config.output_schema.fields
+
+
+def test_loader_strict_rejects_invalid_permissions(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml=textwrap.dedent(
+            """\
+            permissions:
+              default: maybe
+            """
+        ),
+    )
+    with pytest.raises(Exception, match="permissions"):
+        workspace_to_preset(str(tmp_path), strict=True)
+
+
+def test_loader_strict_rejects_invalid_output_schema(tmp_path: Path) -> None:
+    _write_minimal_workspace(
+        tmp_path,
+        config_yaml="max_steps: 3\n",
+        done_yaml=textwrap.dedent(
+            """\
+            name: done
+            description: Done.
+            parameters:
+              summary: { type: string }
+            output_schema:
+              type: string
+            """
+        ),
+    )
+    with pytest.raises(Exception, match="output_schema"):
+        workspace_to_preset(str(tmp_path), strict=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -510,9 +510,8 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
 
     hook_names = [type(h).__name__ for h in preset.hooks]
     # Order: directory hooks (sorted by ``order:``) first, then
-    # ``builtin_hooks:`` entries in declaration order. The migration
-    # to ``builtin_hooks:`` moved StagnationHook + ThresholdCompactHook
-    # + PerToolLimitHook to the end without changing their kwargs.
+    # ``builtin_hooks:`` entries in declaration order, then the
+    # auto-installed ``permissions:`` PermissionHook (v1.0 spec slot).
     assert hook_names == [
         "TestGuardHook",
         "FileCacheHook",
@@ -522,6 +521,7 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
         "StagnationHook",
         "ThresholdCompactHook",
         "PerToolLimitHook",
+        "PermissionHook",
     ]
     assert sorted(preset.tools._tools.keys()) == [
         "bash",
@@ -806,6 +806,7 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
         "StagnationHook",
         "ThresholdCompactHook",
         "PerToolLimitHook",
+        "PermissionHook",
     ]
     assert sorted(reloaded.tools._tools.keys()) == [
         "bash",


### PR DESCRIPTION
## What

Establish a small internal boundary between the cartridge spec and the runtime so the schema can move to a neutral repo later, and add the four declarative slots agent builders need today: `model:`, `permissions:`, `memory.long_term`, and `output_schema:` on `done`. All additions are opt-in; every shipped example continues to load.

## SPEC + boundary (Part A)

- **[`SPEC.md`](SPEC.md)** — cartridge-spec v1.0 reference: layout, slot definitions, runtime contract, conformance promise.
- **[`cartridge.schema.json`](cartridge.schema.json)** — machine-readable JSON Schema for `workspace.json`, `config.yaml`, and `tool.yaml`.
- **[`src/looplet/_spec_modules.py`](src/looplet/_spec_modules.py)** — declares which modules constitute the spec surface (`workspace`, `spec_slots`, `memory`, `validation`, `permissions`, `hook_decision`, `skills`) versus the runtime.
- **[`tests/test_spec_boundary.py`](tests/test_spec_boundary.py)** — AST-walks each spec module and fails if any takes a top-level import on a runtime module. Function-local and `TYPE_CHECKING` imports are allowed. Caught one drift today (`workspace.py` top-level imported `memory`); fixed in this commit.

## v1.0 declarative slots (Part B)

| Slot | Where | What |
|---|---|---|
| `model:` | `config.yaml` | Structured block: `provider`, `name`, `reasoning_effort`, `max_tokens`, `temperature`, `top_p`, `extra`. Sampling overrides flat fields; provider/name/effort land in `tool_metadata['model']`. |
| `permissions:` | `config.yaml` | Declarative `allow`/`deny`/`ask` rules with bare-tool shorthand and `matches:`/`contains:` arg matchers. Compiles into a `PermissionHook` the loader auto-installs. |
| `memory.long_term` | `memory/long_term.md` (file) or `config.yaml` (path override) | Auto-loaded as a `PersistentMemorySource` (mirrors AHE's `LongTermMEMORY.md`). |
| `output_schema:` | `tools/done/tool.yaml` | When the done tool ships JSON-Schema-shaped `output_schema`, the loader compiles it into `LoopConfig.output_schema` so the loop validates `done()` args. |

All four implemented in [`src/looplet/spec_slots.py`](src/looplet/spec_slots.py) and called from `workspace.py` via lazy imports.

## YAML parser improvements

The looplet YAML parser now handles two long-overdue cases:

- **Inline flow scalars**: `{ key: value, k2: v2 }` and `[ a, b ]` inside any value position. Strict JSON is tried first; on failure a tolerant flow parser handles unquoted keys/values.
- **Multi-line block-mapping list items**: `- key: value\n  other: thing` now accumulates into a single dict, matching standard YAML. The previous parser only kept the first key.

Both improvements are required by the SPEC.md examples and the conformance fixtures, and are additive — every previously-valid input still parses to the same value.

## Conformance fixtures

[`tests/conformance/`](tests/conformance/) seeds the v1.0 conformance suite with four fixtures (minimal, permissions, model+output_schema, long_term_memory). A parametric test loads each and compares against `expected.json`. README explains how to add new fixtures and what is and isn't pinned by v1.0.

## Example workspace migration

`examples/coder.workspace` now demonstrates all four new slots:
- `model:` → anthropic / claude-sonnet-4.6 / `reasoning_effort: high`
- `permissions:` → 4 deny rules (`rm -rf`, `sudo `, `> /dev/`, `/etc/` writes)
- `output_schema:` on `done` (`summary` required, string)
- (long_term memory left empty — no built-in coder lessons to ship)

The other example workspaces are unchanged; the migration is opt-in.

## Verification

- **1863 passed, 1 skipped** (was 1825 before this branch).
- 38 new tests across `test_spec_boundary`, `test_spec_slots`, and `tests/conformance/`.
- ruff check + ruff format clean.
- pyright clean (0 errors, 0 warnings).
- All 7 example workspaces strict-load.

## Backwards compatibility

- All four new slots are optional. Cartridges that omit them load exactly as before.
- Flat `temperature:` / `max_tokens:` / etc. still work; structured `model:` wins when both are present.
- Hook-based permission policies still work; declarative `permissions:` appends a second hook.
- Existing `memory/*.md` files still load; `long_term.md` merely appends.
- The YAML parser change is additive.

## Why this PR matters

This is the smallest credible jump from "looplet has a workspace format" to "looplet has a versioned cartridge spec." It pins the schema with a number, draws the spec/runtime line as a lint rule, and answers the four most-asked agent-builder questions (which model, what permissions, how to remember, what done returns) declaratively rather than through hand-written hooks or `setup.py`.

The repo split (Phase 2 of the agents-as-files roadmap) is deliberately *not* done in this PR — it should wait until either a second loader exists or the registry MVP needs a non-Looplet thing to depend on.
