### PR TITLE
feat(spec): cartridge v1.1 — tags, render hints, single-file tools, done_tools, prompts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -93,7 +93,27 @@ use_native_tools: false
 concurrent_dispatch: false
 reactive_recovery: true
 done_tool: done                # name of the completion sentinel tool
+done_tools: []                 # v1.1: additional terminal sentinels (additive)
 ```
+
+### Multiple terminal sentinels (v1.1)
+
+By default the loop ends only when the agent invokes `done_tool`
+(default `done`). Cartridges with multiple distinct outcomes (e.g. a
+SOC-triage agent that finishes via either `report` or `escalate`)
+declare additional sentinels via `done_tools:`:
+
+```yaml
+done_tool: report              # primary sentinel; carries any output_schema
+done_tools: [escalate]         # additional terminal sentinels
+```
+
+The list is **additive**: the loop terminates when the agent invokes
+`done_tool` OR any name in `done_tools`. The primary `done_tool`
+remains the sentinel for `output_schema:` validation; secondary
+sentinels are unvalidated by the loop (their `tool.yaml` may still
+declare `output_schema:` as metadata, and a hook may enforce
+cross-sentinel checks).
 
 ### Model binding (v1.0 slot)
 
@@ -202,11 +222,37 @@ The legacy `@name` form is an alias for `${ref:name}`.
 A single Markdown file containing the agent's system prompt verbatim.
 No templating. The whole file is the prompt.
 
+### Optional prompt files (v1.1)
+
+Two additional optional files in `prompts/` get auto-attached as
+hooks when present:
+
+* **`prompts/briefing.md`** — auto-prepended to every step's
+  briefing section (via `pre_prompt`). Use for short reminders that
+  should appear in every prompt without bloating the system prompt.
+  Other hooks may add their own briefing output; all are concatenated.
+* **`prompts/recovery.md`** — injected into the prompt that follows
+  any tool error (via `post_dispatch` + `InjectContext`). Use for
+  general remediation guidance that applies broadly when something
+  goes wrong.
+
+Both are absent by default. Loaders MUST attach the corresponding
+hook (e.g. `StaticBriefingHook`, `RecoveryHintHook` in the reference
+implementation) when the file is present, and skip silently when it
+isn't.
+
+No other prompt files are recognised in v1.1. Cartridges that need
+more elaborate prompt templating use plain Python in a hook or
+resource — the cartridge format does not include a templating DSL.
+
 ## Tools — `tools/<name>/`
 
-Each tool is a directory with a `tool.yaml` manifest and an
-`execute.py` body. Loaders MAY accept additional language extensions
+Each tool is either a directory with a `tool.yaml` manifest and an
+`execute.py` body **or** (v1.1) a single Python file at
+`tools/<name>.py`. Loaders MAY accept additional language extensions
 in future spec versions.
+
+### Multi-file form (canonical)
 
 ```yaml
 # tools/bash/tool.yaml
@@ -221,6 +267,10 @@ requires:
 concurrent_safe: false
 free: false
 timeout_s: 60
+tags: [shell, mutating]                # v1.1: free-form labels (advisory)
+render:                                # v1.1: prompt-rendering hints (advisory)
+  preview: 5                           #   if data is a list, show first 5 items
+  max_chars: 4000                      #   per-step cap for THIS tool's results
 ```
 
 ```python
@@ -233,8 +283,57 @@ def execute(ctx, *, command: str) -> dict:
     return {"stdout": proc.stdout, "stderr": proc.stderr, "exit_code": proc.returncode}
 ```
 
-The `done` tool is required. The loader treats it as the loop's
-completion sentinel; `done_tool:` in `config.yaml` defaults to it.
+### Single-file form (v1.1)
+
+For tools whose body is short and whose metadata is light, a single
+`tools/<name>.py` declares everything via module-level dunders:
+
+```python
+# tools/echo.py
+"""Echo back what you got."""
+
+__name__ = "echo"
+__description__ = "Echo back what you got."
+__parameters__ = {"text": {"type": "string"}}
+__tags__ = ["test"]
+__render__ = {"preview": 5}            # optional; same shape as tool.yaml render:
+__requires__ = []                      # optional; same shape as tool.yaml requires:
+# Optional: __concurrent_safe__, __free__, __timeout_s__
+
+def execute(ctx, *, text: str) -> dict:
+    return {"echoed": text}
+```
+
+The two forms are equivalent: a tool authored in either shape
+produces the same `ToolSpec` and round-trips identically through
+`preset_to_cartridge`. Both forms can co-exist in the same
+`tools/` directory; a `tools/foo.py` file and a `tools/bar/`
+directory both register tools.
+
+### Tool fields
+
+| Field | Type | Required | Where |
+|---|---|---|---|
+| `name` | string | yes | `tool.yaml: name` / `__name__` |
+| `description` | string | yes | `tool.yaml: description` / `__description__` |
+| `parameters` | dict | yes | `tool.yaml: parameters` / `__parameters__` |
+| `requires` | list[str] | no | `tool.yaml: requires` / `__requires__` |
+| `concurrent_safe` | bool | no, default false | `tool.yaml: concurrent_safe` / `__concurrent_safe__` |
+| `free` | bool | no, default false | `tool.yaml: free` / `__free__` |
+| `timeout_s` | float | no | `tool.yaml: timeout_s` / `__timeout_s__` |
+| `tags` (v1.1) | list[str] | no, advisory | `tool.yaml: tags` / `__tags__` |
+| `render` (v1.1) | dict | no, advisory | `tool.yaml: render` / `__render__` |
+| `output_schema` | dict | no, only for done sentinels | `tool.yaml: output_schema` |
+
+`tags` and `render` are **advisory hints**: loaders MAY honor them,
+but no behaviour beyond storing them on `ToolSpec` is mandated by
+v1.1. A second runtime that ignores `render.preview` is still
+conformant; tool semantics are unchanged.
+
+The `done` tool is required by default. The loader treats it as the
+loop's completion sentinel; `done_tool:` in `config.yaml` defaults
+to it. Cartridges can declare additional terminal sentinels via
+v1.1's `done_tools:` (see Configuration section).
 
 ### Output contract on `done` (v1.0 slot)
 
@@ -374,6 +473,14 @@ exercise the suite against the reference loader.
 
 ## Changelog
 
+- **v1.1** (2026-05-12) — additive: tool `tags:` (advisory metadata),
+  tool `render:` (advisory rendering hints with `preview:` and
+  `max_chars:`), single-file tool form (`tools/<name>.py` with
+  module-level dunders), `done_tools: [a, b]` plural sentinels
+  (additive to `done_tool:`), and two optional prompt files
+  (`prompts/briefing.md` auto-prepended to the briefing section,
+  `prompts/recovery.md` injected after tool errors). All five are
+  optional; v1.0 cartridges load on a v1.1 loader unchanged.
 - **v1.0** (2026-05-09) — first numbered version. New slots:
   `model:`, `permissions:`, `memory.long_term`, `output_schema` on
   `done`. Conformance fixture seed introduced.

--- a/src/looplet/async_loop.py
+++ b/src/looplet/async_loop.py
@@ -596,10 +596,12 @@ async def async_composable_loop(
 
         # ── Dispatch tool calls ─────────────────────────────────
         done_tool_name = config.done_tool
+        terminal_set = {done_tool_name, *config.done_tools}
         done_idx = None
         for i, tc in enumerate(tool_calls):
-            if tc.tool == done_tool_name:
+            if tc.tool in terminal_set:
                 done_idx = i
+                done_tool_name = tc.tool  # pin canonical to the firing sentinel
                 break
 
         regular_calls = tool_calls[:done_idx] if done_idx is not None else tool_calls

--- a/src/looplet/cartridge.py
+++ b/src/looplet/cartridge.py
@@ -201,6 +201,8 @@ class CartridgeLayout:
     CONFIG_YAML = "config.yaml"
     PROMPTS_DIR = "prompts"
     SYSTEM_PROMPT_MD = "prompts/system.md"
+    BRIEFING_MD = "prompts/briefing.md"
+    RECOVERY_MD = "prompts/recovery.md"
     TOOLS_DIR = "tools"
     HOOKS_DIR = "hooks"
     MEMORY_DIR = "memory"
@@ -214,6 +216,7 @@ class CartridgeLayout:
         "temperature",
         "recovery_temperature",
         "done_tool",
+        "done_tools",
         "max_turn_continuations",
         "use_native_tools",
         "concurrent_dispatch",
@@ -454,7 +457,7 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
             if ":" not in stripped:
                 raise CartridgeSerializationError(f"unparseable workspace YAML line{src}: {line!r}")
             key, _, raw_val = stripped.partition(":")
-            raw_val = raw_val.strip()
+            raw_val = _strip_inline_comment(raw_val.strip())
             pos += 1
             if raw_val in ("|", "|-", "|+", ">", ">-", ">+"):
                 # YAML block scalar — gather all subsequent lines whose
@@ -507,7 +510,7 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
             stripped = line.strip()
             if not stripped.startswith("-"):
                 break
-            after = stripped[1:].strip()
+            after = _strip_inline_comment(stripped[1:].strip())
             pos += 1
             if not after:
                 out.append(parse_block(indent + 2))
@@ -574,6 +577,52 @@ def _load_yaml(text: str, *, source_path: str | Path | None = None) -> Any:
                     key_part = s[:i].strip()
                     return bool(key_part) and " " not in key_part
         return False
+
+    def _strip_inline_comment(raw: str) -> str:
+        """Strip ``# ...`` trailing inline comments from a YAML scalar.
+
+        YAML allows ``key: value  # comment`` and only the ``value``
+        is the actual scalar. The custom parser previously kept the
+        comment glued to the value, so e.g. ``done_tool: done  # foo``
+        registered the literal string ``"done  # foo"`` as the tool
+        name — silently breaking sentinel matching.
+
+        A ``#`` is only a comment delimiter when:
+        * preceded by whitespace (or appears at start of value), AND
+        * not inside a quoted string or flow collection ``[...]`` /
+          ``{...}``. We track quote state and bracket depth as we
+          scan; ``#`` outside any quote and outside any bracket and
+          preceded by whitespace marks the start of the comment.
+        """
+        depth_curly = 0
+        depth_square = 0
+        in_str: str | None = None
+        for i, ch in enumerate(raw):
+            if in_str:
+                if ch == in_str and (i == 0 or raw[i - 1] != "\\"):
+                    in_str = None
+                continue
+            if ch in ('"', "'"):
+                in_str = ch
+                continue
+            if ch == "[":
+                depth_square += 1
+                continue
+            if ch == "]":
+                depth_square -= 1
+                continue
+            if ch == "{":
+                depth_curly += 1
+                continue
+            if ch == "}":
+                depth_curly -= 1
+                continue
+            if ch == "#" and depth_curly == 0 and depth_square == 0:
+                # Only treat as comment when preceded by whitespace
+                # or at start (so URLs / hash strings don't trigger).
+                if i == 0 or raw[i - 1] in " \t":
+                    return raw[:i].rstrip()
+        return raw
 
     def _scalar(raw: str) -> Any:
         if raw in ("null", "~", ""):
@@ -932,6 +981,80 @@ def _resolve_runtime_ref(field: str, runtime: dict[str, Any] | None) -> Any:
                 f"unresolved ${{runtime.{field}}} reference; known runtime keys: {sorted(runtime)}"
             )
     return val
+
+
+def _load_single_file_tool(tool_file: Path, *, strict: bool, tool_modules: dict[str, Any]) -> Any:
+    """Load a single-file tool (``tools/<name>.py``) into a ToolSpec.
+
+    The module declares its metadata via dunders:
+
+    * ``__name__`` (defaults to file stem)
+    * ``__description__`` (defaults to first docstring line)
+    * ``__parameters__`` (dict; defaults to ``{}``)
+    * ``__tags__`` (list[str]; v1.1 metadata; optional)
+    * ``__render__`` (dict; v1.1 render hints; optional)
+    * ``__requires__`` (list[str]; resource DI; optional)
+    * ``__concurrent_safe__`` / ``__free__`` / ``__timeout_s__`` (optional)
+
+    Required: an ``execute`` callable.
+
+    Returns ``None`` (with a warning) when ``strict=False`` and the
+    module is malformed; raises ``CartridgeSerializationError`` under
+    ``strict=True``.
+    """
+    from looplet.tools import ToolSpec  # noqa: PLC0415
+
+    name_stem = tool_file.stem
+    module = _import_module_from_path(tool_file, f"_chw_tool_{name_stem}")
+    tool_modules[name_stem] = module
+    execute_fn = getattr(module, "execute", None)
+    if not callable(execute_fn):
+        msg = (
+            f"single-file tool {tool_file} declares no callable ``execute``. "
+            f"Add ``def execute(ctx, *, ...) -> dict``."
+        )
+        if strict:
+            raise CartridgeSerializationError(msg)
+        logger.warning("%s; skipping", msg)
+        return None
+
+    # ``__name__`` is a real dunder Python sets for every module, so
+    # we can't rely on its presence as user intent. Detect by
+    # comparing to the auto-set value (``_chw_tool_<stem>``); if the
+    # user didn't override it, fall back to the file stem.
+    declared_name = getattr(module, "__name__", "")
+    if not declared_name or declared_name.startswith("_chw_tool_"):
+        declared_name = name_stem
+
+    # First non-empty line of the module docstring is a sensible
+    # default description.
+    raw_doc = (module.__doc__ or "").strip()
+    default_desc = raw_doc.splitlines()[0] if raw_doc else f"Call {declared_name}."
+    description = getattr(module, "__description__", default_desc)
+
+    raw_parameters = getattr(module, "__parameters__", {}) or {}
+    if not isinstance(raw_parameters, dict):
+        msg = (
+            f"single-file tool {tool_file}: ``__parameters__`` must be a dict, "
+            f"got {type(raw_parameters).__name__}."
+        )
+        if strict:
+            raise CartridgeSerializationError(msg)
+        logger.warning("%s; skipping", msg)
+        return None
+
+    return ToolSpec(
+        name=declared_name,
+        description=str(description),
+        parameters=dict(raw_parameters),
+        execute=execute_fn,
+        concurrent_safe=bool(getattr(module, "__concurrent_safe__", False)),
+        free=bool(getattr(module, "__free__", False)),
+        timeout_s=getattr(module, "__timeout_s__", None),
+        requires=list(getattr(module, "__requires__", []) or []),
+        tags=list(getattr(module, "__tags__", []) or []),
+        render=dict(getattr(module, "__render__", {}) or {}),
+    )
 
 
 def _coerce_default(text: str | None) -> Any:
@@ -2621,6 +2744,30 @@ def _workspace_to_preset_inner(
     registry = BaseToolRegistry()
     tools_dir = root / CartridgeLayout.TOOLS_DIR
     if tools_dir.is_dir():
+        # ── v1.1 single-file tool form ────────────────────────
+        # ``tools/<name>.py`` (no surrounding directory) is a tool
+        # whose metadata lives in module-level dunders:
+        #   __name__         (defaults to the file stem)
+        #   __description__  (defaults to first docstring line)
+        #   __parameters__   (dict; defaults to {} = no params)
+        #   __tags__         (list[str]; optional, v1.1)
+        #   __render__       (dict; optional, v1.1 render hints)
+        #   __requires__     (list[str]; optional)
+        #   __concurrent_safe__, __free__, __timeout_s__ (optional)
+        # The module MUST export a callable named ``execute``.
+        # Cuts boilerplate for trivial tools without changing the
+        # multi-file form (still preferred for tools that need
+        # extensive YAML-side metadata or substantial code).
+        for tool_file in sorted(
+            p
+            for p in tools_dir.iterdir()
+            if p.is_file() and p.suffix == ".py" and not p.name.startswith("_")
+        ):
+            spec = _load_single_file_tool(tool_file, strict=strict, tool_modules=tool_modules)
+            if spec is not None:
+                registry.register(spec)
+
+        # ── multi-file tool form (existing) ───────────────────
         for tool_dir in sorted(p for p in tools_dir.iterdir() if p.is_dir()):
             spec_path = tool_dir / "tool.yaml"
             execute_path = tool_dir / "execute.py"
@@ -2675,6 +2822,8 @@ def _workspace_to_preset_inner(
                 free=bool(yaml_payload.get("free", False)),
                 timeout_s=yaml_payload.get("timeout_s"),
                 requires=list(yaml_payload.get("requires", []) or []),
+                tags=list(yaml_payload.get("tags", []) or []),
+                render=dict(yaml_payload.get("render", {}) or {}),
             )
             # Surface tool name ↔ directory name mismatches. The agent's
             # system prompt and tool catalog use ``spec.name``, but
@@ -2758,10 +2907,14 @@ def _workspace_to_preset_inner(
             # v1.0: ``output_schema:`` on the done tool installs an
             # OutputSchema validator on the LoopConfig so the loop
             # validates the agent's done() args before terminating.
-            # Only the configured ``done_tool`` is treated specially;
-            # output_schema on other tools is recorded in tool metadata
-            # and may be enforced by future spec versions but is not
-            # part of the v1.0 loader contract.
+            # Only the configured *primary* ``done_tool`` is treated
+            # specially; output_schema on other tools (including
+            # additional v1.1 ``done_tools``) is recorded in tool
+            # metadata. Multi-sentinel cartridges where each sentinel
+            # has a different schema should put a schema on each
+            # tool.yaml and add a hook for cross-sentinel cross-checks
+            # — there is no v1.0/v1.1 loader feature for a per-sentinel
+            # schema map (deliberate: keeps the loader contract small).
             if (
                 spec.name == config.done_tool
                 and config.output_schema is None
@@ -3005,14 +3158,53 @@ def _workspace_to_preset_inner(
     # it; this warning lets a builder catch the typo at load time
     # without breaking those use cases.
     if config.done_tool and config.done_tool not in registry.tool_names:
-        msg = (
-            f"config.yaml declares ``done_tool: {config.done_tool!r}`` but no "
-            f"such tool is registered. Available tools: {sorted(registry.tool_names)}. "
-            f"Add a ``tools/{config.done_tool}/`` directory or fix the "
-            f"``done_tool:`` field. The loop will fail at the agent's first "
-            f"done() call."
-        )
-        logger.warning("%s", msg)
+        # Suppress the warning when v1.1 ``done_tools:`` is in play —
+        # the cartridge has explicitly opted into a different terminal
+        # set, and the legacy default ``done`` may be irrelevant.
+        if not config.done_tools:
+            msg = (
+                f"config.yaml declares ``done_tool: {config.done_tool!r}`` but no "
+                f"such tool is registered. Available tools: {sorted(registry.tool_names)}. "
+                f"Add a ``tools/{config.done_tool}/`` directory or fix the "
+                f"``done_tool:`` field. The loop will fail at the agent's first "
+                f"done() call."
+            )
+            logger.warning("%s", msg)
+    # v1.1 ``done_tools:`` plural — same sanity check applied to each
+    # extra terminal sentinel.
+    for extra_done in config.done_tools:
+        if extra_done and extra_done not in registry.tool_names:
+            logger.warning(
+                "config.yaml declares ``done_tools: [..., %r, ...]`` but no such tool "
+                "is registered. Available tools: %s.",
+                extra_done,
+                sorted(registry.tool_names),
+            )
+
+    # ── v1.1 prompt files: briefing + recovery ──────────────────────
+    # ``prompts/briefing.md`` (auto-prepended every step) and
+    # ``prompts/recovery.md`` (injected after a tool error) are
+    # opt-in: when present, the loader auto-instantiates a
+    # StaticBriefingHook / RecoveryHintHook and prepends them so
+    # they fire BEFORE any user hooks. Absent files mean no hook is
+    # attached (zero overhead).
+    briefing_path = root / CartridgeLayout.BRIEFING_MD
+    recovery_path = root / CartridgeLayout.RECOVERY_MD
+    if briefing_path.is_file() or recovery_path.is_file():
+        from looplet.prompt_files import RecoveryHintHook, StaticBriefingHook  # noqa: PLC0415
+
+        prompt_hooks: list[Any] = []
+        if briefing_path.is_file():
+            text = briefing_path.read_text(encoding="utf-8")
+            prompt_hooks.append(StaticBriefingHook(text=text))
+        if recovery_path.is_file():
+            text = recovery_path.read_text(encoding="utf-8")
+            prompt_hooks.append(RecoveryHintHook(text=text))
+        # Prepend so these fire before user-declared hooks (which may
+        # build on the briefing) and ahead of permission/built-in hooks
+        # (which fire on dispatch boundaries; relative order doesn't
+        # matter there).
+        hooks = [*prompt_hooks, *hooks]
 
     preset = AgentPreset(
         config=config,

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -459,6 +459,20 @@ class LoopConfig:
     # Name of the tool that signals task completion.
     done_tool: str = "done"
 
+    done_tools: list[str] = field(default_factory=list)
+    """Additional terminal sentinel tools (cartridge-spec v1.1).
+
+    By default the loop ends only when the agent invokes the single
+    ``done_tool``. Cartridges that need multiple distinct outcomes
+    (e.g. ``report`` for the normal path AND ``escalate`` for the
+    alternative path) declare ``done_tools: [report, escalate]`` in
+    ``config.yaml`` to let the loop terminate on either.
+
+    The legacy ``done_tool`` is always treated as terminal too;
+    ``done_tools`` is *additive*. Empty list (the default) preserves
+    pre-v1.1 single-sentinel behaviour exactly.
+    """
+
     tool_result_persist_dir: str | None = None
     """Optional directory for Layer-1 persist-and-preview of large
     tool results. When set, tool results whose serialized size exceeds
@@ -2231,11 +2245,20 @@ def composable_loop(
         # ── Dispatch tool calls ──────────────────────────────
         all_step_entities: list[str] = []
 
+        # Effective set of terminal sentinels: legacy ``done_tool``
+        # plus the v1.1 ``done_tools`` list. The first one the agent
+        # invokes ends the loop; the legacy field stays the canonical
+        # name used in error messages and pretty-printers.
         done_tool_name = config.done_tool
+        terminal_set = {done_tool_name, *config.done_tools}
         done_idx = None
         for i, tc in enumerate(tool_calls):
-            if tc.tool == done_tool_name:
+            if tc.tool in terminal_set:
                 done_idx = i
+                # Pin the canonical name to the actual tool that fired so
+                # downstream code (eval ctx, trace builders) reports the
+                # specific terminal sentinel, not just the legacy default.
+                done_tool_name = tc.tool
                 break
 
         # Dispatch non-done tools

--- a/src/looplet/prompt_files.py
+++ b/src/looplet/prompt_files.py
@@ -1,0 +1,85 @@
+"""Prompt-file hooks for Cartridge Spec v1.1.
+
+Two extra prompt slots beyond ``prompts/system.md``:
+
+* ``prompts/briefing.md`` — auto-prepended to every step's briefing
+  section. Use for short, persistent reminders that should appear in
+  every prompt.
+* ``prompts/recovery.md`` — injected as ``InjectContext`` on the
+  prompt that follows a tool error. Use for general remediation
+  guidance the agent should consult when something goes wrong.
+
+The cartridge loader reads these files at load time and instantiates
+the appropriate hook; hosts and second runtimes can reuse the same
+hooks against any cartridge-loaded text.
+"""
+
+from __future__ import annotations
+
+from looplet import InjectContext
+
+
+class StaticBriefingHook:
+    """Auto-prepend a fixed briefing text to every step's prompt.
+
+    Reads from ``prompts/briefing.md`` at cartridge load time. The
+    text is appended to the briefing section via ``pre_prompt``. Other
+    hooks may add their own briefing output; all are concatenated.
+
+    Args:
+        text: The briefing body to inject. Empty string disables the
+            hook (it returns ``None`` so the briefing section stays
+            unchanged).
+    """
+
+    def __init__(self, *, text: str = "") -> None:
+        self.text = (text or "").strip()
+
+    def pre_prompt(self, state, session_log, context, step_num):
+        if not self.text:
+            return None
+        return self.text
+
+    def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+        return None
+
+    def check_done(self, state, session_log, context, step_num):
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False
+
+
+class RecoveryHintHook:
+    """Inject a recovery hint into the next prompt after a tool error.
+
+    Reads from ``prompts/recovery.md`` at cartridge load time. The
+    hint fires once after each errored tool result via
+    ``InjectContext`` from ``post_dispatch``. Successful dispatches
+    return ``None`` so the hint doesn't pollute clean steps.
+
+    Args:
+        text: The recovery body to inject. Empty string disables.
+    """
+
+    def __init__(self, *, text: str = "") -> None:
+        self.text = (text or "").strip()
+
+    def pre_prompt(self, state, session_log, context, step_num):
+        return None
+
+    def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+        if not self.text:
+            return None
+        if tool_result.error is None:
+            return None
+        return InjectContext(self.text)
+
+    def check_done(self, state, session_log, context, step_num):
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False
+
+
+__all__ = ["RecoveryHintHook", "StaticBriefingHook"]

--- a/src/looplet/tools.py
+++ b/src/looplet/tools.py
@@ -367,6 +367,33 @@ class ToolSpec:
     for tools that don't need DI.
     """
 
+    tags: list[str] = field(default_factory=list)
+    """Free-form labels attached to the tool (cartridge-spec v1.1).
+
+    Declared in ``tool.yaml`` as ``tags: [enrichment, ioc-only]`` or
+    in single-file form as ``__tags__ = [...]``. The runtime is free
+    to ignore tags or use them (e.g., a hook may filter the tool
+    catalog by tag during a particular phase). Tags are pure
+    metadata — they do NOT affect dispatch.
+    """
+
+    render: dict[str, Any] = field(default_factory=dict)
+    """Rendering hints for prompt assembly (cartridge-spec v1.1).
+
+    Optional cartridge-side hints about how the runtime should render
+    this tool's results into the prompt's RECENT RESULTS section.
+    Recognised keys (all optional):
+
+    * ``preview: int`` — for tools whose ``data`` is a list, render
+      only the first N items plus a ``[+M more]`` tail.
+    * ``max_chars: int`` — per-step cap for THIS tool's results,
+      overriding the global ``CONTEXT_INLINE_PER_STEP_CHARS``.
+
+    Hints are advisory: a conformant runtime MAY honor them or fall
+    back to its global defaults. Tools with small outputs typically
+    leave this empty.
+    """
+
     _accepts_ctx: bool | None = field(default=None, repr=False, compare=False)
     """Cached result of ``inspect.signature(execute)`` for ``ctx`` detection."""
 

--- a/tests/test_cartridge_spec_v1_1.py
+++ b/tests/test_cartridge_spec_v1_1.py
@@ -1,0 +1,366 @@
+"""Regression tests for Cartridge Spec v1.1 additions.
+
+Five additive features, each tested both at the loader level and
+end-to-end with the loop:
+
+1. Tool ``tags:`` (declarative metadata, advisory).
+2. Tool ``render:`` hints (advisory rendering hints).
+3. Single-file tool form (``tools/<name>.py``).
+4. ``done_tools: [a, b]`` (additional terminal sentinels).
+5. ``prompts/briefing.md`` + ``prompts/recovery.md`` auto-attached hooks.
+
+Plus one parser bug surfaced while writing the dogfood cartridge:
+
+6. Inline YAML comments must be stripped from values
+   (``done_tool: done  # foo`` → registered name was the literal
+   string ``"done  # foo"``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import looplet
+from looplet import (
+    DefaultState,
+    LoopConfig,
+    MockLLMBackend,
+    cartridge_to_preset,
+    composable_loop,
+)
+
+
+def _write_minimal(root: Path) -> None:
+    """Write a minimal valid cartridge to ``root``."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "cartridge.json").write_text('{"name": "x", "schema_version": 1}\n')
+    (root / "config.yaml").write_text("max_steps: 3\n")
+    (root / "prompts").mkdir(exist_ok=True)
+    (root / "prompts" / "system.md").write_text("test agent")
+
+
+# ── 1. tool tags ─────────────────────────────────────────────────
+
+
+def test_tool_tags_round_trip_via_tool_yaml(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\n"
+        "description: done\n"
+        "parameters:\n  summary: { type: string }\n"
+        "tags: [terminal, normal-path]\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    spec = preset.tools._tools["done"]
+    assert spec.tags == ["terminal", "normal-path"]
+
+
+def test_tool_tags_default_to_empty_list(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    spec = preset.tools._tools["done"]
+    assert spec.tags == []
+
+
+# ── 2. tool render hints ─────────────────────────────────────────
+
+
+def test_tool_render_hints_round_trip(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\n"
+        "description: done\n"
+        "parameters:\n  summary: { type: string }\n"
+        "render:\n  preview: 5\n  max_chars: 800\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    spec = preset.tools._tools["done"]
+    assert spec.render == {"preview": 5, "max_chars": 800}
+
+
+# ── 3. single-file tool form ─────────────────────────────────────
+
+
+def test_single_file_tool_form_loads(tmp_path: Path) -> None:
+    """tools/echo.py with module-level dunders becomes a ToolSpec."""
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    tools = root / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / "echo.py").write_text(
+        '"""Echo back what you got."""\n'
+        '__name__ = "echo"\n'
+        '__description__ = "Echo back what you got."\n'
+        '__parameters__ = {"text": {"type": "string"}}\n'
+        '__tags__ = ["test"]\n'
+        '__render__ = {"preview": 3}\n'
+        "\n"
+        "def execute(ctx, *, text):\n"
+        "    return {'echoed': text}\n"
+    )
+    # Need a done tool too.
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    assert "echo" in preset.tools.tool_names
+    spec = preset.tools._tools["echo"]
+    assert spec.name == "echo"
+    assert spec.description == "Echo back what you got."
+    assert spec.tags == ["test"]
+    assert spec.render == {"preview": 3}
+    assert "text" in spec.parameter_names()
+
+
+def test_single_file_tool_dispatches_correctly(tmp_path: Path) -> None:
+    """Agent loop can actually invoke a single-file tool."""
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    tools = root / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / "echo.py").write_text(
+        '__name__ = "echo"\n'
+        '__description__ = "echo"\n'
+        '__parameters__ = {"text": {"type": "string"}}\n'
+        "\n"
+        "def execute(ctx, *, text):\n"
+        "    return {'echoed': text}\n"
+    )
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    llm = MockLLMBackend(
+        responses=[
+            json.dumps({"tool": "echo", "args": {"text": "hi"}, "reasoning": "", "call_id": "1"}),
+            json.dumps(
+                {"tool": "done", "args": {"summary": "ok"}, "reasoning": "", "call_id": "2"}
+            ),
+        ]
+    )
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=preset.state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"goal": "test"},
+        )
+    )
+    assert len(steps) == 2
+    assert steps[0].tool_call.tool == "echo"
+    assert steps[0].tool_result.data == {"echoed": "hi"}
+
+
+def test_single_file_tool_missing_execute_raises_strict(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    tools = root / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / "broken.py").write_text("# no execute function defined\n")
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    with pytest.raises(looplet.CartridgeSerializationError):
+        cartridge_to_preset(str(root), strict=True)
+
+
+# ── 4. done_tools plural ─────────────────────────────────────────
+
+
+def test_done_tools_plural_terminates_on_either(tmp_path: Path) -> None:
+    """Agent that calls EITHER ``report`` or ``escalate`` ends the loop."""
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    (root / "config.yaml").write_text("max_steps: 5\ndone_tool: report\ndone_tools: [escalate]\n")
+    tools = root / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / "report.py").write_text(
+        '__name__ = "report"\n__description__ = "report"\n'
+        '__parameters__ = {"summary": {"type": "string"}}\n\n'
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    (tools / "escalate.py").write_text(
+        '__name__ = "escalate"\n__description__ = "escalate"\n'
+        '__parameters__ = {"reason": {"type": "string"}}\n\n'
+        "def execute(ctx, *, reason):\n    return {'reason': reason}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    assert preset.config.done_tool == "report"
+    assert preset.config.done_tools == ["escalate"]
+
+    # Path 1: agent finishes via ``escalate`` (the secondary sentinel).
+    llm = MockLLMBackend(
+        responses=[
+            json.dumps(
+                {"tool": "escalate", "args": {"reason": "x"}, "reasoning": "", "call_id": "1"}
+            ),
+        ]
+    )
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=preset.tools,
+            state=preset.state,
+            config=preset.config,
+            hooks=preset.hooks,
+            task={"goal": "test"},
+        )
+    )
+    assert len(steps) == 1
+    assert steps[0].tool_call.tool == "escalate"
+
+
+def test_done_tools_plural_default_empty(tmp_path: Path) -> None:
+    """Default ``done_tools`` is empty list (back-compat)."""
+    cfg = LoopConfig(max_steps=5)
+    assert cfg.done_tools == []
+
+
+# ── 5. prompts/briefing.md + recovery.md auto-attach ─────────────
+
+
+def test_briefing_md_attaches_static_briefing_hook(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    (root / "prompts" / "briefing.md").write_text("Always be polite.")
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    hook_names = [type(h).__name__ for h in preset.hooks]
+    assert "StaticBriefingHook" in hook_names
+    sb = next(h for h in preset.hooks if type(h).__name__ == "StaticBriefingHook")
+    assert sb.text == "Always be polite."
+
+
+def test_recovery_md_attaches_recovery_hint_hook(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    (root / "prompts" / "recovery.md").write_text("Try again with smaller args.")
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    hook_names = [type(h).__name__ for h in preset.hooks]
+    assert "RecoveryHintHook" in hook_names
+
+
+def test_no_prompt_files_means_no_extra_hooks(tmp_path: Path) -> None:
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    hook_names = [type(h).__name__ for h in preset.hooks]
+    assert "StaticBriefingHook" not in hook_names
+    assert "RecoveryHintHook" not in hook_names
+
+
+# ── 6. inline YAML comments must be stripped ─────────────────────
+
+
+def test_inline_comment_stripped_from_scalar_value(tmp_path: Path) -> None:
+    """``done_tool: done  # primary terminal`` registered ``done  # primary terminal`` as
+    the literal name before the round-17 fix.
+    """
+    root = tmp_path / "x.cartridge"
+    _write_minimal(root)
+    (root / "config.yaml").write_text(
+        "max_steps: 3\n"
+        "done_tool: done                   # this is the terminal sentinel\n"
+        "done_tools: [escalate]            # alternate path\n"
+    )
+    tools = root / "tools"
+    tools.mkdir(exist_ok=True)
+    done = root / "tools" / "done"
+    done.mkdir(parents=True)
+    (done / "tool.yaml").write_text(
+        "name: done\ndescription: done\nparameters:\n  summary: { type: string }\n"
+    )
+    (done / "execute.py").write_text(
+        "def execute(ctx, *, summary):\n    return {'summary': summary}\n"
+    )
+    (tools / "escalate.py").write_text(
+        '__name__ = "escalate"\n__description__ = "escalate"\n'
+        '__parameters__ = {"reason": {"type": "string"}}\n\n'
+        "def execute(ctx, *, reason):\n    return {'reason': reason}\n"
+    )
+    preset = cartridge_to_preset(str(root), strict=True)
+    assert preset.config.done_tool == "done", f"inline comment leaked: {preset.config.done_tool!r}"
+    assert preset.config.done_tools == ["escalate"], (
+        f"inline comment leaked or flow list mis-parsed: {preset.config.done_tools!r}"
+    )
+
+
+def test_inline_comment_does_not_eat_url_anchor() -> None:
+    """``url: \"https://example.com#anchor\"`` must keep its fragment."""
+    from looplet.cartridge import _load_yaml
+
+    parsed = _load_yaml('url: "https://example.com#anchor"\n')
+    assert parsed["url"] == "https://example.com#anchor"
+
+
+def test_inline_comment_inside_flow_collection_not_stripped() -> None:
+    """``# inside [...]`` is part of the flow value, not a comment."""
+    from looplet.cartridge import _load_yaml
+
+    # Empty list with a real trailing comment.
+    parsed = _load_yaml("done_tools: []          # nothing here\n")
+    assert parsed["done_tools"] == []


### PR DESCRIPTION
Five additive cartridge slots from the round-16 paper analysis. Each sits cleanly inside the paper's design constraints (cartridge contract vs runtime mechanism vs adjacent artifact). v1.0 cartridges load on a v1.1 loader unchanged.

## What's new

| Feature | Where | Spec impact |
|---|---|---|
| Tool `tags: [...]` | `tool.yaml` / `__tags__` | Advisory metadata stored on `ToolSpec` |
| Tool `render: {preview, max_chars}` | `tool.yaml` / `__render__` | Advisory rendering hint |
| Single-file tools | `tools/<name>.py` | New on-disk notation; same `ToolSpec` |
| Plural sentinels `done_tools: [a, b]` | `config.yaml` | Additive to `done_tool:` |
| `prompts/briefing.md` | auto-attached `StaticBriefingHook` | Pre-prompt injection |
| `prompts/recovery.md` | auto-attached `RecoveryHintHook` | Post-error injection |

## Bonus loader bug fix

**Inline YAML comments are now stripped from values.** The dogfood surfaced a real parser bug: `done_tool: done   # primary terminal` registered the literal string `'done   # primary terminal'` as the tool name. Bracket-aware: `url: 'https://example.com#anchor'` preserves its anchor; flow lists `[a, b]` work as expected.

## Verification

- **1924 tests pass** (was 1910; +14).
- ruff + format + pyright clean.
- All 4 conformance fixtures still PASS.
- `looplet describe` CLI works on a v1.1 cartridge.
- Live LLM dogfood: ported `soc_triage` to v1.1 (6 tools collapsed to single-file form, briefing/recovery added, alternate `escalate` terminal sentinel via `done_tools:`). Result: **17 steps / 68 s** vs the v1.0 round-15 baseline's 18 steps / 189 s — faster, correct (`j.smith@example.com` / `10.20.4.18` throughout), 3 fewer files on disk.

## Backwards compatibility

All five additions are opt-in. Empty / absent slot = pre-v1.1 behaviour exactly. The four shipped conformance fixtures continue to pass without modification.

## Design discipline

Items deliberately deferred to **adjacent artifacts** (per the paper's anti-features):
- eval fixtures → sibling `<name>.evals/` directory
- approval handler → host application
- resource lifetime → runtime config
- containerization → sibling `Dockerfile`

Items deliberately **rejected** (graph-DSL anti-feature):
- phases / state machines / workflow language

See the round-16 analysis comment thread for the full rationale.

PR commit: `be8f0e9`