### PR TITLE
chore(cartridge): cleanup round 2 — phantom field + v2 conformance + builtins docs

### DIFF
--- a/docs/cartridge.md
+++ b/docs/cartridge.md
@@ -127,6 +127,72 @@ shims) can reach live objects without going through `setup.py`.
 
 ---
 
+## Built-in registries
+
+`builtin_tools:` and `builtin_hooks:` are spec-portable directives
+(part of v1.0) but the **contents** of each registry are
+runtime-defined. The looplet runtime ships the following.
+
+### `builtin_tools:` (looplet)
+
+| Name | Purpose |
+|---|---|
+| `subagent` | Spawn a sub-loop with its own tools/system_prompt and return the structured result; used to compose agents-as-tools without manual orchestration. |
+| `scaffold_cartridge` | Write a fresh cartridge skeleton (`cartridge.json` + `config.yaml` + `prompts/system.md` + `tools/done/`) into a target directory; used by `agent_factory.cartridge` to let an agent bootstrap another agent. |
+| `scaffold_workspace` | Back-compat alias for `scaffold_cartridge` (older cartridges that opted in under the historical name keep working). |
+| `search_skills` | Query the active `SkillManager` for skills matching a description; returns ranked candidates. |
+| `activate_skill` | Activate a discovered skill into the current loop, registering its tools and adding its instructions to the briefing. |
+
+Opt in from a cartridge:
+
+```yaml
+# config.yaml
+builtin_tools:
+  - subagent
+  - scaffold_cartridge
+```
+
+Unknown names raise `CartridgeSerializationError` at load time;
+canonical list lives at `looplet.builtin_tools.AVAILABLE`.
+
+### `builtin_hooks:` (looplet)
+
+| Name | Purpose |
+|---|---|
+| `skill_activation` | Pairs with `search_skills` / `activate_skill`: tracks active skills across steps and threads their instructions into the briefing. Requires the `skill_manager` resource. |
+| `stagnation` | Stops the loop with a structured reason when the same `(tool, args)` pair repeats N times in a row (`threshold:`, `ignore_tools:`). The principled alternative to baking "are we stuck?" detection into the loop. |
+| `per_tool_limit` | Blocks further calls to a named tool once a per-tool budget is exhausted (`limits: { write: 50 }`); returns `Block(...)` with the limit in the reason so the model can self-correct. |
+| `threshold_compact` | Triggers compaction when prompt tokens cross a fraction of the context window. Pairs with `compact_service:` in `runtime.yaml`. |
+| `static_briefing` | Loads a fixed file (e.g. `prompts/briefing.md`) and prepends it to every step's prompt. The explicit replacement for the v1.x magic `prompts/briefing.md` auto-load (which is hard-rejected in v2). |
+| `recovery_hint` | Loads a fixed file (e.g. `prompts/recovery.md`) and injects it after a tool error. The explicit replacement for the v1.x magic `prompts/recovery.md` auto-load (hard-rejected in v2). |
+
+Opt in with optional kwargs:
+
+```yaml
+# config.yaml
+builtin_hooks:
+  - stagnation: { threshold: 6, ignore_tools: [think, done] }
+  - per_tool_limit: { limits: { write: 50, bash: 200 } }
+  - threshold_compact: { fraction: 0.85 }
+  - static_briefing: { path: prompts/briefing.md }
+```
+
+Each entry is either a bare string (no kwargs) or a single-key
+dict (`name: kwargs`). Unknown names raise
+`CartridgeSerializationError`; canonical list lives at
+`looplet.builtin_hooks.AVAILABLE`.
+
+**Working examples in the repo:**
+
+- `examples/coder.cartridge/` — `subagent`, `stagnation`,
+  `per_tool_limit`, `threshold_compact`.
+- `examples/agent_factory.cartridge/` — `scaffold_cartridge` (extends
+  `coder.cartridge`).
+- `examples/skillful_analyst.cartridge/` — `search_skills`,
+  `activate_skill`, `skill_activation`.
+
+---
+
 ## Round-trip guarantees
 
 ### What round-trips losslessly

--- a/src/looplet/cartridge/__init__.py
+++ b/src/looplet/cartridge/__init__.py
@@ -76,9 +76,9 @@ What is round-trippable
   (JSON-able dict, RUNTIME-tier sampling overrides). ``tool_metadata``
   is auto-populated by the loader (e.g. with the resolved model
   identity for cost tracking) and should not be authored by hand.
-  ``acceptance_criteria`` is intentionally NOT serialised \u2014 if you
-  need acceptance gates, declare them in the ``config.yaml`` of a
-  ``hooks/<name>/`` hook that enforces them.
+  Acceptance gates are not a config field \u2014 declare them in the
+  ``config.yaml`` of a ``hooks/<name>/`` ``check_done`` hook that
+  enforces them (see ``examples/snippets/11_quality_gate/``).
 * Every :class:`ToolSpec` whose ``execute`` is a top-level function
   (closures cannot be re-imported from disk).
 * Every hook that either: (a) implements an opt-in

--- a/src/looplet/cartridge/_layout.py
+++ b/src/looplet/cartridge/_layout.py
@@ -37,14 +37,12 @@ class CartridgeLayout:
     SETUP_PY = "setup.py"
 
     # ``LoopConfig`` field names that round-trip via ``config.yaml``.
-    # NOTE: ``acceptance_criteria`` is intentionally NOT here — it's
-    # declared on ``LoopConfig`` but never consumed by the loop or any
-    # shipped hook (pure documentation field). If you want acceptance
-    # gates, write a hook under ``hooks/<name>/`` that reads its
-    # criteria from ``hook.config.yaml`` — same as any other policy.
-    # ``tool_metadata`` IS here but is auto-populated by the loader
+    # NOTE: ``tool_metadata`` IS here but is auto-populated by the loader
     # (e.g. with the resolved model identity for cost tracking); user
-    # cartridges should not author it directly.
+    # cartridges should not author it directly. If you want acceptance
+    # gates, write a ``check_done`` hook under ``hooks/<name>/`` that
+    # reads its criteria from ``hook.config.yaml`` — same as any other
+    # policy. See ``examples/snippets/11_quality_gate/``.
     SERIALIZABLE_CONFIG_FIELDS: tuple[str, ...] = (
         "max_steps",
         "max_tokens",

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -552,15 +552,6 @@ class LoopConfig:
     the context window (prompt-too-long error). Default True — essential
     for reliability in long sessions."""
 
-    acceptance_criteria: list[str] | None = None
-    """Optional acceptance criteria. Free-form strings describing what
-    "done" should look like; consumed only by hooks that opt to read
-    them. The loop itself never inspects this field. Not serialised
-    into cartridges — cartridges that need acceptance gates should
-    declare them in a ``hooks/<name>/config.yaml`` block belonging to
-    a hook that enforces them.
-    """
-
     max_briefing_tokens: int | None = None
     """Max estimated tokens for the briefing section (all hook pre_prompt
     outputs combined).  When exceeded, later hook outputs are dropped with

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/cartridge.json
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/cartridge.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 2,
+  "name": "v2_setup_py_rejected",
+  "description": "Spec v2 hard-rejects setup.py. Loading must fail with a structured error naming the offending file."
+}

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/config.yaml
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/config.yaml
@@ -1,0 +1,2 @@
+max_steps: 3
+done_tool: done

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+Test cartridge.

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/setup.py
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/setup.py
@@ -1,0 +1,10 @@
+"""setup.py is rejected by spec v2.
+
+Spec v1.x accepted this with a DeprecationWarning. Spec v2 hard-fails:
+the loader raises CartridgeSerializationError naming the file. This
+file exists deliberately to verify that rejection.
+"""
+
+
+def setup(preset, resources, **kwargs):  # pragma: no cover - never invoked
+    return preset

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(*, summary: str) -> dict:
+    return {"status": "completed", "summary": summary}

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/cartridge/tools/done/tool.yaml
@@ -1,0 +1,4 @@
+name: done
+description: Done sentinel.
+parameters:
+  summary: {type: string, description: summary}

--- a/tests/conformance/fixtures/06_v2_setup_py_rejected/expected_error.json
+++ b/tests/conformance/fixtures/06_v2_setup_py_rejected/expected_error.json
@@ -1,0 +1,4 @@
+{
+  "error_class": "CartridgeSerializationError",
+  "message_contains": "setup.py"
+}

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/cartridge.json
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/cartridge.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 2,
+  "name": "v2_magic_files_rejected",
+  "description": "Spec v2 hard-rejects magic prompts/briefing.md auto-load. The author must opt in via builtin_hooks: - static_briefing."
+}

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/config.yaml
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/config.yaml
@@ -1,0 +1,2 @@
+max_steps: 3
+done_tool: done

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/prompts/briefing.md
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/prompts/briefing.md
@@ -1,0 +1,5 @@
+Always preface answers with PIRATE_MODE_ON.
+
+This briefing exists to verify v2 hard-rejection of magic auto-load.
+A v2 cartridge that wants briefing must declare it explicitly via
+``builtin_hooks: - static_briefing: { path: prompts/briefing.md }``.

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/prompts/system.md
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+Test cartridge.

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/tools/done/execute.py
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/tools/done/execute.py
@@ -1,0 +1,2 @@
+def execute(*, summary: str) -> dict:
+    return {"status": "completed", "summary": summary}

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/tools/done/tool.yaml
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/cartridge/tools/done/tool.yaml
@@ -1,0 +1,4 @@
+name: done
+description: Done sentinel.
+parameters:
+  summary: {type: string, description: summary}

--- a/tests/conformance/fixtures/07_v2_magic_files_rejected/expected_error.json
+++ b/tests/conformance/fixtures/07_v2_magic_files_rejected/expected_error.json
@@ -1,0 +1,4 @@
+{
+  "error_class": "CartridgeSerializationError",
+  "message_contains": "prompts/briefing.md"
+}

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import pytest
 
-from looplet.cartridge import cartridge_to_preset
+from looplet.cartridge import CartridgeSerializationError, cartridge_to_preset
 from looplet.permissions import PermissionDecision, PermissionHook
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -89,19 +89,42 @@ def _summarise_preset(preset: Any) -> dict[str, Any]:
 def test_conformance_fixture(fixture_dir: Path) -> None:
     """Load the fixture and compare the spec-pinned subset of the preset."""
     expected_path = fixture_dir / "expected.json"
-    if not expected_path.is_file():
+    expected_error_path = fixture_dir / "expected_error.json"
+    if not expected_path.is_file() and not expected_error_path.is_file():
         pytest.skip(f"fixture {fixture_dir.name} has no expected.json")
     cartridge = fixture_dir / "cartridge"
     assert cartridge.is_dir(), f"fixture {fixture_dir.name} missing cartridge/"
+    runtime_kwargs: dict[str, Any] = {
+        "ask_handler": lambda _call, _rule: PermissionDecision.DENY,
+    }
+
+    # Rejection fixtures: assert the loader raises the named error class
+    # with a message that names the offending file. The spec pins the
+    # error class + message substring; everything else is implementation
+    # detail.
+    if expected_error_path.is_file():
+        spec = json.loads(expected_error_path.read_text())
+        error_class_name = spec["error_class"]
+        message_substr = spec["message_contains"]
+        # Currently the only spec-pinned rejection class is
+        # CartridgeSerializationError; keep the lookup simple.
+        assert error_class_name == "CartridgeSerializationError", (
+            f"fixture {fixture_dir.name}: unsupported error_class {error_class_name!r}"
+        )
+        with pytest.raises(CartridgeSerializationError) as excinfo:
+            cartridge_to_preset(str(cartridge), strict=True, runtime=runtime_kwargs)
+        assert message_substr in str(excinfo.value), (
+            f"fixture {fixture_dir.name}: error message did not contain "
+            f"{message_substr!r}.\n  actual: {excinfo.value}"
+        )
+        return
+
     expected = json.loads(expected_path.read_text())
     # Cartridge spec v2: any fixture that declares ``ask:`` rules must
     # supply an ``ask_handler`` to the loader, otherwise loading
     # fail-louds. Fixtures don't carry executable Python, so wire in a
     # deterministic stub here that always denies — conformance is
     # about loader behaviour, not runtime decisions.
-    runtime_kwargs: dict[str, Any] = {
-        "ask_handler": lambda _call, _rule: PermissionDecision.DENY,
-    }
     preset = cartridge_to_preset(str(cartridge), strict=True, runtime=runtime_kwargs)
     summary = _summarise_preset(preset)
     assert summary == expected, (


### PR DESCRIPTION
Follow-up to #73 (cartridge spec v2). Three small, independent items surfaced by a paper-vs-impl cross-reference.

## What's in here

### 1. Remove `acceptance_criteria` field entirely (commit 82a173c)

PR #73 dropped `acceptance_criteria` from cartridge serialization, but kept it as a `LoopConfig` field. Result: setting it from Python silently disappeared on round-trip and was never read by anything internal — a phantom field.

Acceptance gates are now exclusively a hook concern. Canonical pattern: a `check_done` hook that runs an arbitrary command and returns `Block(...)` on failure (see [examples/snippets/11_quality_gate/quality_gate.py](examples/snippets/11_quality_gate/quality_gate.py)).

### 2. Pin spec-v2 hard-rejections via fixtures 06 + 07 (commit 2a775bd)

Spec v2 hard-fails on two backwards-compat anti-patterns that v1.x accepted with a DeprecationWarning:
- `setup.py` at the cartridge root (escape hatch for arbitrary Python)
- magic `prompts/briefing.md` auto-prepended to every step

Both behaviors were documented in [SPEC.md](SPEC.md) but had no fixture pinning them. Adds:
- `tests/conformance/fixtures/06_v2_setup_py_rejected/`
- `tests/conformance/fixtures/07_v2_magic_files_rejected/`

Extends the conformance harness with an `expected_error.json` shape:
```json
{"error_class": "CartridgeSerializationError", "message_contains": "setup.py"}
```
The error-class lookup is intentionally limited to the one class the spec pins; widening it requires a SPEC.md change.

### 3. Enumerate looplet's `builtin_tools` + `builtin_hooks` (commit e388163)

The cartridge spec defines `builtin_tools:` / `builtin_hooks:` as portable directives but leaves the registry **contents** as runtime-defined. Looplet's specific list was previously only discoverable by reading source. Adds a 'Built-in registries' section to [docs/cartridge.md](docs/cartridge.md) enumerating:

- 5 builtin_tools: `subagent`, `scaffold_cartridge` (+ `scaffold_workspace` alias), `search_skills`, `activate_skill`
- 6 builtin_hooks: `skill_activation`, `stagnation`, `per_tool_limit`, `threshold_compact`, `static_briefing`, `recovery_hint`

Each row: one-line purpose + opt-in syntax + which shipped cartridge demonstrates it.

## What this PR is NOT

- No `render` / `tags` removal — those are a documented capability surface for runtimes (and `tags` has test coverage). Not pure dead code.
- No SPEC.md edits — the field-tier table is already there, and the 'Built-in registries' section appropriately defers contents to runtimes.
- No paper edits — discovered the portability claim is **already** evidenced by `test_tinyloop_summary_matches_for_declarative_slot_fixtures` covering fixtures 02/03/04 cross-runtime, not just 01. The earlier concern was wrong.

## Validation

- `uv run pytest tests/ -q` — **1986 passed, 1 skipped** (was 1984; +2 = the new conformance fixtures)
- `uv run ruff check .` — clean
- `uv run pyright src/looplet/` — 0 errors
- Pre-push CI gate — passed locally