### PR TITLE
chore(cartridge): make spec v2 the standard everywhere + cross-runtime rejection coverage

### DIFF
--- a/examples/agent_factory.cartridge/config.yaml
+++ b/examples/agent_factory.cartridge/config.yaml
@@ -1,5 +1,5 @@
 extends: ../coder.cartridge
 max_steps: 80
 builtin_tools:
-  - scaffold_workspace
+  - scaffold_cartridge
 

--- a/examples/alt_runtime/tinyloop.py
+++ b/examples/alt_runtime/tinyloop.py
@@ -30,6 +30,10 @@ What it implements
   required) and dispatches tool calls to the loaded bodies.
 * A ``conformance_summary()`` matching the v1.0 spec-pinned subset
   produced by :file:`tests/conformance/test_conformance.py`.
+* Cartridge Spec v2 hard-rejections: refuses to load a v2 cartridge
+  containing ``setup.py`` or magic ``prompts/briefing.md`` /
+  ``prompts/recovery.md`` files. Demonstrates the rejection
+  contract is portable, not a quirk of the reference loader.
 
 What it does NOT implement
 --------------------------
@@ -294,6 +298,15 @@ class TinyCartridge:
 _MANIFEST_NAMES = ("workspace.json", "cartridge.json")
 
 
+class CartridgeSerializationError(Exception):
+    """Raised on a malformed or spec-rejected cartridge.
+
+    Mirrors the reference loader's ``looplet.cartridge.CartridgeSerializationError``
+    so callers (and conformance tests) can catch the same kind of
+    failure regardless of which runtime loaded the cartridge.
+    """
+
+
 def load_cartridge(root: Path) -> TinyCartridge:
     """Load a cartridge from ``root`` using only stdlib.
 
@@ -314,6 +327,26 @@ def load_cartridge(root: Path) -> TinyCartridge:
             f"cartridge manifest not found at {root / _MANIFEST_NAMES[0]} (or {_MANIFEST_NAMES[1]})"
         )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    schema_version = int(manifest.get("schema_version", 1))
+
+    # Cartridge Spec v2 hard-rejections (see SPEC.md "Backwards
+    # compatibility"). v1.x accepted these with a deprecation warning;
+    # v2 fail-louds. Implementing them here demonstrates the v2
+    # rejection contract is portable across runtimes, not a quirk of
+    # the reference loader.
+    if schema_version >= 2:
+        forbidden = [
+            (root / "setup.py", "setup.py"),
+            (root / "prompts" / "briefing.md", "prompts/briefing.md"),
+            (root / "prompts" / "recovery.md", "prompts/recovery.md"),
+        ]
+        for path, label in forbidden:
+            if path.is_file():
+                raise CartridgeSerializationError(
+                    f"Cartridge {root}: {label} is forbidden in spec v2 "
+                    f"(was a v1.x escape hatch). Declare an explicit "
+                    f"hook or builtin_hook instead."
+                )
 
     config_path = root / "config.yaml"
     config = (
@@ -392,7 +425,7 @@ def load_cartridge(root: Path) -> TinyCartridge:
 
     return TinyCartridge(
         name=str(manifest.get("name", root.name)),
-        schema_version=int(manifest.get("schema_version", 1)),
+        schema_version=schema_version,
         system_prompt=system_prompt,
         config=config,
         tools=tools,

--- a/examples/snippets/01_inheritance/pytest_refactorer.cartridge/cartridge.json
+++ b/examples/snippets/01_inheritance/pytest_refactorer.cartridge/cartridge.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "pytest-refactorer",
   "description": "Two-hop child of coder. Inherits coder's tools and resources; inherits the python-only refactoring stance from refactorer.cartridge; adds a stricter test-discipline prompt."
 }

--- a/examples/snippets/01_inheritance/refactorer.cartridge/cartridge.json
+++ b/examples/snippets/01_inheritance/refactorer.cartridge/cartridge.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "name": "refactorer",
   "description": "Python-only refactoring agent. Inherits tools, hooks, resources, and config from coder.cartridge; overrides the system prompt and disables bash."
 }

--- a/tests/conformance/test_tinyloop_cross_runtime.py
+++ b/tests/conformance/test_tinyloop_cross_runtime.py
@@ -157,3 +157,32 @@ def test_tinyloop_summary_matches_for_declarative_slot_fixtures(
         f"reference loader. Expected:\n{json.dumps(expected, indent=2)}\n"
         f"Actual:\n{json.dumps(summary, indent=2)}"
     )
+
+
+# ── Spec v2 hard-rejections (cross-runtime) ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "fixture_name, expected_substr",
+    [
+        ("06_v2_setup_py_rejected", "setup.py"),
+        ("07_v2_magic_files_rejected", "prompts/briefing.md"),
+    ],
+)
+def test_tinyloop_rejects_v2_forbidden_files(
+    tinyloop_module, fixture_name: str, expected_substr: str
+) -> None:
+    """tinyloop also fails-loud on v2 forbidden files.
+
+    Locks the v2 hard-rejection contract as cross-runtime, not a
+    quirk of the reference loader. Both runtimes raise their own
+    ``CartridgeSerializationError`` with a message naming the
+    offending file.
+    """
+    fixture_dir = REPO_ROOT / "tests" / "conformance" / "fixtures" / fixture_name
+    with pytest.raises(tinyloop_module.CartridgeSerializationError) as excinfo:
+        tinyloop_module.load_cartridge(fixture_dir / "cartridge")
+    assert expected_substr in str(excinfo.value), (
+        f"tinyloop rejection message for {fixture_name!r} did not contain "
+        f"{expected_substr!r}; got: {excinfo.value}"
+    )


### PR DESCRIPTION
Two-part follow-up to PR #75. Closes the open items from the cross-reference review.

## 1. Spec v2 everywhere

All shipped example cartridges now declare `schema_version: 2`:

- Upgraded the two stragglers under [examples/snippets/01_inheritance/](examples/snippets/01_inheritance/) (refactorer + pytest_refactorer). Both already had v2-clean configs; only the manifest version was stale.
- Updated [agent_factory.cartridge/config.yaml](examples/agent_factory.cartridge/config.yaml) to use the canonical `scaffold_cartridge` builtin name (was `scaffold_workspace`, the back-compat alias). Alias remains in the registry for older cartridges in the wild.

Verified via `cartridge_to_preset(strict=True)` on all upgraded cartridges.

The conformance fixtures `01` through `04_long_term_memory` deliberately stay at `schema_version: 1` — they exist precisely to verify the v1 backwards-compat surface keeps loading. Fixture `04_v2_tier_split` mirrors `04_long_term_memory` at schema_version 2.

## 2. Cross-runtime v2 hard-rejection contract

PR #75 added fixtures 06/07 to pin v2 hard-rejection of `setup.py` and magic `prompts/briefing.md`. Those fixtures only exercised the **reference** loader. This PR widens the contract to **cross-runtime**:

- [examples/alt_runtime/tinyloop.py](examples/alt_runtime/tinyloop.py) now raises a local `CartridgeSerializationError` (mirroring the reference loader's class) when a v2 cartridge contains `setup.py`, `prompts/briefing.md`, or `prompts/recovery.md`.
- New parametrised test `test_tinyloop_rejects_v2_forbidden_files` in [tests/conformance/test_tinyloop_cross_runtime.py](tests/conformance/test_tinyloop_cross_runtime.py) asserts both fixtures fail-loud under tinyloop with a message naming the offending file.

This is the highest-signal item from the cross-reference review: it locks the v2 rejection contract as **portable**, evidenced by a second runtime — not a quirk of the reference loader.

## What this PR is NOT

- **No `render`/`tags` removal.** Re-evaluated under user's "opinionated but show alternatives" guideline. They're declared as part of v1.1 in SPEC.md, pinned by [tests/test_cartridge_spec_v1_1.py](tests/test_cartridge_spec_v1_1.py), round-trip cleanly, and cost the loop nothing — pure advisory metadata that runtimes may consume. Not kitchen-sink behavior; no removal warranted.
- **No paper edits.** Already evidenced by the now-extended cross-runtime suite.

## Validation

- `uv run pytest tests/ -q` — **1988 passed, 1 skipped** (was 1986; +2 = the new tinyloop rejection tests)
- `uv run pytest tests/conformance/ -v` — **18 passed**
- `uv run ruff check .` — clean
- `uv run pyright src/looplet/` — 0 errors
- Pre-push CI gate — passed locally