### PR TITLE
docs: fill missing docstrings in DefaultState

### DIFF
--- a/src/looplet/types.py
+++ b/src/looplet/types.py
@@ -413,10 +413,12 @@ class DefaultState:
 
     @property
     def step_count(self) -> int:
+        """Return the total number of steps completed so far in this run."""
         return len(self.steps)
 
     @property
     def budget_remaining(self) -> int:
+        """Return how many more steps the agent may take before the loop stops."""
         return max(0, self.max_steps - len(self.steps))
 
     def context_summary(self) -> str:
@@ -524,6 +526,14 @@ class DefaultState:
         return "\n\n".join(b for _, b in rendered)
 
     def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serialisable dict snapshot of the current run state.
+
+           Always includes step_count, queries_used, and budget_remaining.
+           Any entries in metadata are merged in at the top level.
+
+           Returns:
+               A plain dict suitable for json.dumps or checkpoint storage.
+           """
         return {
             "step_count": self.step_count,
             "queries_used": self.queries_used,

--- a/src/looplet/types.py
+++ b/src/looplet/types.py
@@ -528,12 +528,12 @@ class DefaultState:
     def snapshot(self) -> dict[str, Any]:
         """Return a JSON-serialisable dict snapshot of the current run state.
 
-           Always includes step_count, queries_used, and budget_remaining.
-           Any entries in metadata are merged in at the top level.
+        Always includes step_count, queries_used, and budget_remaining.
+        Any entries in metadata are merged in at the top level.
 
-           Returns:
-               A plain dict suitable for json.dumps or checkpoint storage.
-           """
+        Returns:
+            A plain dict suitable for json.dumps or checkpoint storage.
+        """
         return {
             "step_count": self.step_count,
             "queries_used": self.queries_used,


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out the sections below.
Delete any section that doesn't apply.
-->

## Summary

Adds missing docstrings to three public methods in DefaultState in src/looplet/types.py:
- step_count
- budget_remaining
- snapshot

## Motivation

<!-- Why is this change needed? Link any related issues. -->

Fixes #

Fixes #9

<!-- Bullet list of the most important changes. -->

-

## Sync ↔ async parity

<!-- If this touches the loop, how did you keep sync and async in sync? -->

- [x ] Not applicable (no loop change).
- [ ] Behavior mirrored in both `composable_loop` and `async_composable_loop`.
- [ ] Tests cover both paths.

## Checklist

- [ ] `uv run pytest` passes.
- [ ] `uv run ruff check .` reports no new issues.
- [ ] New public API has docstrings and tests.
- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` (or change is docs-only).
- [x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
