### PR TITLE
feat: declarative hook contract (ViewSpec, rewrite_thread)

### DIFF
--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -100,6 +100,7 @@ from looplet.hook_decision import (
     Deny,
     HookDecision,
     InjectContext,
+    RewriteThread,
     Stop,
 )
 from looplet.limits import BudgetWarningHook, PerToolLimitHook
@@ -231,6 +232,7 @@ __all__ = [
     "Deny",
     "Stop",
     "InjectContext",
+    "RewriteThread",
     "preview_prompt",
     "last_accepted_done",
     "last_rejected_done",

--- a/src/looplet/compact.py
+++ b/src/looplet/compact.py
@@ -37,6 +37,7 @@ __all__ = [
     "compact_chain",
     "default_compact_service",
     "run_compact",
+    "apply_thread_rewrite",
 ]
 
 
@@ -63,7 +64,19 @@ class CompactOutcome:
     invokes it after firing the ``POST_COMPACT`` event. Use for
     domain-specific state resets (clear caches, re-inject file
     context, reset token baselines) that the loop shouldn't know
-    about."""
+    about.
+
+    Prefer the declarative :attr:`follow_up` for anything an
+    out-of-process / cross-runtime compactor must express, since a
+    Python closure cannot cross a process boundary."""
+
+    follow_up: dict[str, Any] | None = None
+    """Declarative, JSON-safe post-compact thread rewrite — the portable
+    reification of :attr:`cleanup`. Same schema as
+    :class:`~looplet.hook_decision.HookDecision.rewrite_thread`
+    (``reset_metadata_keys`` / ``metadata_updates``); applied by
+    :func:`run_compact` via :func:`apply_thread_rewrite` after the
+    ``POST_COMPACT`` event."""
 
     @property
     def compacted(self) -> bool:
@@ -105,6 +118,7 @@ class CompactOutcome:
             "llm_calls_spent": self.llm_calls_spent,
             "compacted": self.compacted,
             "extra": dict(self.extra or {}),
+            "follow_up": dict(self.follow_up) if self.follow_up else None,
         }
 
 
@@ -378,7 +392,7 @@ def run_compact(
         reason=reason,
     )
 
-    _emit_compact_event(
+    post_decisions = _emit_compact_event(
         hooks,
         LifecycleEvent.POST_COMPACT,
         state=state,
@@ -389,6 +403,14 @@ def run_compact(
         reason=reason,
         outcome=outcome,
     )
+
+    # Declarative post-compact rewrites (portable replacement for the
+    # imperative ``cleanup`` closure). Apply the outcome's own follow-up
+    # first, then any ``rewrite_thread`` a POST_COMPACT hook requested.
+    apply_thread_rewrite(state, outcome.follow_up)
+    for d in post_decisions:
+        if getattr(d, "rewrite_thread", None):
+            apply_thread_rewrite(state, d.rewrite_thread)
 
     # Post-compact cleanup callback — domain-specific state resets.
     if outcome.cleanup is not None:
@@ -402,6 +424,34 @@ def run_compact(
             )
 
     return outcome
+
+
+def apply_thread_rewrite(state: Any, spec: "dict[str, Any] | None") -> None:
+    """Apply a declarative, JSON-safe thread rewrite to ``state``.
+
+    This is the portable counterpart to :attr:`CompactOutcome.cleanup`
+    and the executor for
+    :attr:`~looplet.hook_decision.HookDecision.rewrite_thread`. An
+    out-of-process / cross-runtime compactor cannot ship a Python
+    closure, so it declares its post-compact state resets as data:
+
+    * ``reset_metadata_keys``: list of ``state.metadata`` keys to delete
+      (e.g. clear a cache, reset a token baseline).
+    * ``metadata_updates``: dict merged into ``state.metadata``.
+
+    Unknown keys are ignored. Missing ``state`` / non-dict ``metadata``
+    is tolerated so the call is always safe.
+    """
+    if not isinstance(spec, dict) or state is None:
+        return
+    meta = getattr(state, "metadata", None)
+    if not isinstance(meta, dict):
+        return
+    for key in spec.get("reset_metadata_keys") or []:
+        meta.pop(key, None)
+    updates = spec.get("metadata_updates")
+    if isinstance(updates, dict):
+        meta.update(updates)
 
 
 def _emit_compact_event(

--- a/src/looplet/hook_decision.py
+++ b/src/looplet/hook_decision.py
@@ -39,6 +39,7 @@ __all__ = [
     "Stop",
     "Continue",
     "InjectContext",
+    "RewriteThread",
     "normalize_hook_return",
 ]
 
@@ -92,6 +93,7 @@ class HookDecision:
     updated_result: ToolResult | None = None
     permission: str | None = None  # "allow" | "deny" | None
     additional_context: str | None = None
+    rewrite_thread: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     # ── Convenience predicates ───────────────────────────────────
@@ -113,8 +115,138 @@ class HookDecision:
             and self.updated_result is None
             and self.permission is None
             and self.additional_context is None
+            and self.rewrite_thread is None
             and not self.metadata
         )
+
+    # ── Wire round-trip (Loop Effect Protocol §3) ───────────────
+    #
+    # ``to_wire`` / ``from_wire`` are the executable fidelity map: an
+    # out-of-process hook returns an *effect* as JSON, and the host
+    # reconstructs the identical :class:`HookDecision` it would have
+    # gotten from an in-process hook. The form is loss-free for every
+    # field a hook can set, which is what makes cartridge⇄library
+    # translation behaviourally lossless for pure hooks (§5).
+
+    def to_wire(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe effect dict (all fields preserved)."""
+        return {
+            "kind": "HookDecision",
+            "block": self.block,
+            "stop": self.stop,
+            "updated_args": self.updated_args,
+            "updated_result": _toolresult_to_wire(self.updated_result),
+            "permission": self.permission,
+            "additional_context": self.additional_context,
+            "rewrite_thread": dict(self.rewrite_thread) if self.rewrite_thread else None,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_wire(cls, raw: Any) -> "HookDecision | None":
+        """Reconstruct a :class:`HookDecision` from an effect dict.
+
+        Accepts two shapes:
+
+        * the canonical generic form emitted by :meth:`to_wire`
+          (``{"kind": "HookDecision", ...}``), and
+        * the *ergonomic* algebra forms a hand-written or non-Python
+          policy server is likely to emit, keyed by effect constructor
+          name (``Allow``/``Deny``/``Block``/``Stop``/``Continue``/
+          ``InjectContext``/``UpdateArgs``/``UpdateResult``).
+
+        ``None`` or an explicit ``{"kind": "Continue"}`` with no payload
+        yields ``None`` (no-opinion), matching legacy hook semantics.
+        """
+        if raw is None:
+            return None
+        if not isinstance(raw, dict):
+            raise TypeError(f"effect must be a dict, got {type(raw).__name__}")
+        kind = raw.get("kind")
+
+        if kind == "HookDecision":
+            return cls(
+                block=raw.get("block"),
+                stop=raw.get("stop"),
+                updated_args=raw.get("updated_args"),
+                updated_result=_toolresult_from_wire(raw.get("updated_result")),
+                permission=raw.get("permission"),
+                additional_context=raw.get("additional_context"),
+                rewrite_thread=(
+                    dict(raw["rewrite_thread"])
+                    if isinstance(raw.get("rewrite_thread"), dict)
+                    else None
+                ),
+                metadata=dict(raw.get("metadata") or {}),
+            )
+
+        # Ergonomic algebra forms (the §3 constructors).
+        if kind in (None, "Continue", "Allow") and not any(
+            raw.get(k) for k in ("text", "block", "reason", "args", "result")
+        ):
+            if kind == "Allow":
+                return Allow()
+            ctx = raw.get("additional_context") or raw.get("text")
+            return Continue(ctx) if ctx else None
+        if kind == "Allow":
+            return Allow(updated_args=raw.get("args") or raw.get("updated_args"))
+        if kind == "Deny":
+            return Deny(raw.get("block") or raw.get("reason") or "permission denied")
+        if kind == "Block":
+            return Block(raw.get("reason") or raw.get("block") or "blocked")
+        if kind == "Stop":
+            return Stop(raw.get("reason") or raw.get("stop") or "hook_requested_stop")
+        if kind == "InjectContext":
+            return InjectContext(raw.get("text") or raw.get("additional_context") or "")
+        if kind == "UpdateArgs":
+            return HookDecision(updated_args=raw.get("args") or raw.get("updated_args"))
+        if kind == "UpdateResult":
+            return HookDecision(
+                updated_result=_toolresult_from_wire(raw.get("result") or raw.get("updated_result"))
+            )
+        if kind == "RewriteThread":
+            spec = raw.get("rewrite_thread") or raw.get("spec")
+            return HookDecision(rewrite_thread=dict(spec) if isinstance(spec, dict) else {})
+        raise ValueError(f"unrecognised effect kind {kind!r}")
+
+
+# ── ToolResult wire helpers ─────────────────────────────────────
+
+
+def _toolresult_to_wire(result: "ToolResult | None") -> dict[str, Any] | None:
+    if result is None:
+        return None
+    return {
+        "tool": result.tool,
+        "args_summary": result.args_summary,
+        "data": result.data,
+        "error": result.error,
+        "duration_ms": result.duration_ms,
+        "result_key": result.result_key,
+        "call_id": result.call_id,
+        "warnings": list(result.warnings),
+        "metadata": dict(result.metadata),
+    }
+
+
+def _toolresult_from_wire(raw: Any) -> "ToolResult | None":
+    if raw is None:
+        return None
+    if isinstance(raw, ToolResult):
+        return raw
+    if not isinstance(raw, dict):
+        raise TypeError(f"updated_result must be a dict, got {type(raw).__name__}")
+    return ToolResult(
+        tool=raw.get("tool", ""),
+        args_summary=raw.get("args_summary", ""),
+        data=raw.get("data"),
+        error=raw.get("error"),
+        duration_ms=raw.get("duration_ms", 0.0),
+        result_key=raw.get("result_key"),
+        call_id=raw.get("call_id"),
+        warnings=list(raw.get("warnings") or []),
+        metadata=dict(raw.get("metadata") or {}),
+    )
 
 
 # ── Ergonomic constructors ──────────────────────────────────────
@@ -170,6 +302,28 @@ def InjectContext(text: str) -> HookDecision:
     plain string from the legacy ``pre_prompt`` / ``post_dispatch``
     hook signatures."""
     return HookDecision(additional_context=text)
+
+
+def RewriteThread(
+    *,
+    reset_metadata_keys: list[str] | None = None,
+    metadata_updates: dict[str, Any] | None = None,
+) -> HookDecision:
+    """Declaratively rewrite run state after compaction.
+
+    This is the portable, JSON-safe replacement for the imperative
+    ``CompactOutcome.cleanup`` closure: instead of a Python callback
+    (which an out-of-process / cross-runtime compactor cannot ship),
+    a hook or compactor declares *which* metadata keys to clear and
+    *what* to set. The host applies the spec via
+    :func:`looplet.compact.apply_thread_rewrite`.
+    """
+    spec: dict[str, Any] = {}
+    if reset_metadata_keys:
+        spec["reset_metadata_keys"] = list(reset_metadata_keys)
+    if metadata_updates:
+        spec["metadata_updates"] = dict(metadata_updates)
+    return HookDecision(rewrite_thread=spec)
 
 
 # ── Legacy → HookDecision coercion ─────────────────────────────

--- a/src/looplet/hook_view.py
+++ b/src/looplet/hook_view.py
@@ -1,0 +1,211 @@
+"""Capability-scoped *views* of loop state for out-of-process hooks.
+
+The portability boundary for a hook is not its code but its **declared
+view** of loop state (HOOK_CARTRIDGE_DESIGN.md §4, hazard H2). A hook
+that runs out-of-process — over the Loop Effect Protocol (LEP) — never
+touches live ``state``/``session_log`` objects; the host serialises only
+the *subset of fields the hook subscribed to* and ships that subset over
+the wire.
+
+``ViewSpec`` is that subscription (a field whitelist + a fidelity knob).
+``extract_view`` is the pure projection from the live loop objects to a
+JSON-safe dict containing exactly the subscribed fields and nothing else.
+Because the projection is explicit and total, two properties hold:
+
+* **Soundness (H2).** A hook can only observe what it declared; a hook
+  that reads outside its view cannot exist over the wire, so the view is
+  an enforceable upper bound on the hook's read set.
+* **Determinism.** ``extract_view`` is a pure function of its inputs, so
+  the same loop position yields the same wire payload on every runtime —
+  the precondition for behavioural round-trip equivalence (§5.3).
+
+Field vocabulary (the only keys a ``ViewSpec`` may name):
+
+    tool          the pending/just-run tool name (str | None)
+    args          the tool call arguments (dict)
+    reasoning     the model's stated reason for the call (str)
+    tool_result   {data, error, duration_ms, warnings} of the result
+    step          the current step number (int)
+    transcript    session-log entries — counts under ``digest`` fidelity,
+                  full serialised entries under ``full`` fidelity
+    usage         provider token usage / cost, when surfaced on state
+    state_digest  a small, stable digest of agent state (counts only)
+
+``fidelity`` is ``"digest"`` (default — cheap, counts/sizes only) or
+``"full"`` (ship entry bodies; needed by hooks that legitimately read
+the transcript, at the cost of bandwidth).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["ViewSpec", "extract_view", "KNOWN_VIEW_FIELDS"]
+
+#: Every field name a ``ViewSpec`` is allowed to subscribe to. Naming an
+#: unknown field is a configuration error (caught at load), not a silent
+#: empty — that is what keeps the view an *enforceable* contract.
+KNOWN_VIEW_FIELDS: frozenset[str] = frozenset(
+    {
+        "tool",
+        "args",
+        "reasoning",
+        "tool_result",
+        "step",
+        "transcript",
+        "usage",
+        "state_digest",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ViewSpec:
+    """A hook's declared subscription to loop state (§4).
+
+    Attributes:
+        fields: The subset of :data:`KNOWN_VIEW_FIELDS` the hook may
+            observe. The empty set means "no loop state at all" — valid
+            for hooks that decide purely from the event slot.
+        fidelity: ``"digest"`` (counts/sizes only — the default) or
+            ``"full"`` (ship entry bodies for ``transcript``).
+    """
+
+    fields: frozenset[str] = field(default_factory=frozenset)
+    fidelity: str = "digest"
+
+    def __post_init__(self) -> None:
+        unknown = set(self.fields) - KNOWN_VIEW_FIELDS
+        if unknown:
+            raise ValueError(
+                f"ViewSpec names unknown field(s) {sorted(unknown)}; "
+                f"allowed: {sorted(KNOWN_VIEW_FIELDS)}"
+            )
+        if self.fidelity not in ("digest", "full"):
+            raise ValueError(f"ViewSpec.fidelity must be 'digest' or 'full', got {self.fidelity!r}")
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> "ViewSpec":
+        """Build a ``ViewSpec`` from a cartridge ``view:`` block.
+
+        Accepts ``{"fields": [...], "fidelity": "digest"}`` or a bare
+        list of field names. ``None`` yields the empty (no-state) view.
+        """
+        if raw is None:
+            return cls()
+        if isinstance(raw, (list, tuple, set, frozenset)):
+            return cls(fields=frozenset(str(f) for f in raw))
+        if isinstance(raw, dict):
+            fields = raw.get("fields") or []
+            if not isinstance(fields, (list, tuple, set, frozenset)):
+                raise ValueError("view.fields must be a list of field names")
+            return cls(
+                fields=frozenset(str(f) for f in fields),
+                fidelity=str(raw.get("fidelity", "digest")),
+            )
+        raise ValueError(f"unrecognised view spec: {raw!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise back to a cartridge ``view:`` block (round-trip)."""
+        return {"fields": sorted(self.fields), "fidelity": self.fidelity}
+
+
+def _json_safe(value: Any) -> Any:
+    """Best-effort coercion of arbitrary tool data to a JSON-safe value."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
+def _result_view(tool_result: Any) -> dict[str, Any] | None:
+    if tool_result is None:
+        return None
+    return {
+        "data": _json_safe(getattr(tool_result, "data", None)),
+        "error": getattr(tool_result, "error", None),
+        "duration_ms": getattr(tool_result, "duration_ms", 0.0),
+        "warnings": list(getattr(tool_result, "warnings", []) or []),
+    }
+
+
+def _transcript_view(session_log: Any, *, full: bool) -> Any:
+    entries = list(getattr(session_log, "entries", None) or [])
+    if not full:
+        return {"entry_count": len(entries)}
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        to_dict = getattr(entry, "to_dict", None)
+        if callable(to_dict):
+            try:
+                out.append(_json_safe(to_dict()))
+                continue
+            except Exception:  # pragma: no cover - defensive
+                pass
+        out.append({"repr": str(entry)})
+    return out
+
+
+def _state_digest(state: Any) -> dict[str, Any]:
+    """A small, stable digest of agent state — counts only, never bodies."""
+    digest: dict[str, Any] = {}
+    entities = getattr(state, "entities", None)
+    if entities is not None:
+        try:
+            digest["entity_count"] = len(entities)
+        except TypeError:  # pragma: no cover - defensive
+            pass
+    return digest
+
+
+def extract_view(
+    spec: ViewSpec,
+    *,
+    state: Any = None,
+    session_log: Any = None,
+    tool_call: Any = None,
+    tool_result: Any = None,
+    step: int | None = None,
+    usage: Any = None,
+) -> dict[str, Any]:
+    """Project the live loop objects onto the hook's declared ``spec``.
+
+    Returns a JSON-safe dict whose keys are **exactly** the subscribed
+    fields that are applicable at this call site. Fields the hook did not
+    subscribe to are never included — even if the data is available — so
+    the wire payload is a faithful witness of the hook's read set.
+    """
+    view: dict[str, Any] = {}
+    full = spec.fidelity == "full"
+
+    if "tool" in spec.fields:
+        view["tool"] = getattr(tool_call, "tool", None) if tool_call is not None else None
+    if "args" in spec.fields:
+        view["args"] = (
+            _json_safe(getattr(tool_call, "args", {}) or {}) if tool_call is not None else {}
+        )
+    if "reasoning" in spec.fields:
+        view["reasoning"] = getattr(tool_call, "reasoning", "") if tool_call is not None else ""
+    if "tool_result" in spec.fields:
+        view["tool_result"] = _result_view(tool_result)
+    if "step" in spec.fields:
+        view["step"] = step
+    if "transcript" in spec.fields:
+        view["transcript"] = _transcript_view(session_log, full=full)
+    if "usage" in spec.fields:
+        if usage is None and state is not None:
+            # Fall back to usage surfaced on state by the loop, so a hook
+            # that only declares a `usage` view (e.g. a budget/cost hook)
+            # still sees token usage at slots other than POST_LLM_RESPONSE.
+            meta = getattr(state, "metadata", None)
+            if isinstance(meta, dict):
+                usage = meta.get("usage_total") or meta.get("last_usage")
+        view["usage"] = _json_safe(usage)
+    if "state_digest" in spec.fields:
+        view["state_digest"] = _state_digest(state)
+
+    return view

--- a/tests/test_cartridge_package_layout.py
+++ b/tests/test_cartridge_package_layout.py
@@ -105,6 +105,7 @@ ALLOWED_LOOPLET_DEPS = frozenset(
         "looplet.builtin_tools",
         "looplet.compact",  # public CompactService types
         "looplet.hook_decision",  # public HookDecision factories
+        "looplet.hook_view",  # public ViewSpec (capability-scoped hook views)
         "looplet.loop",  # public LoopConfig / hook protocol
         "looplet.memory",  # public MemorySource types
         "looplet.mcp",  # public MCPToolAdapter (mcp_servers: in config.yaml)

--- a/tests/test_hook_view.py
+++ b/tests/test_hook_view.py
@@ -1,0 +1,92 @@
+"""Dogfood tests for capability-scoped hook views (``looplet.hook_view``).
+
+A view is the *only* state an out-of-process hook is allowed to read.
+These tests pin two contract guarantees:
+
+* ``ViewSpec`` rejects unknown fields and invalid fidelity at
+  construction time (fail-loud, not silent drop);
+* ``extract_view`` projects **only** the declared fields and produces a
+  JSON-safe payload (so it can cross a process boundary intact).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from looplet.hook_view import (
+    KNOWN_VIEW_FIELDS,
+    ViewSpec,
+    extract_view,
+)
+from looplet.types import ToolCall, ToolResult
+
+
+class TestViewSpec:
+    def test_defaults(self):
+        spec = ViewSpec()
+        assert spec.fidelity == "digest"
+        assert spec.fields == frozenset()
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValueError, match="unknown"):
+            ViewSpec(fields=frozenset({"not_a_field"}))
+
+    def test_invalid_fidelity_rejected(self):
+        with pytest.raises(ValueError, match="fidelity"):
+            ViewSpec(fields=frozenset({"tool"}), fidelity="telepathic")
+
+    def test_from_dict_accepts_none_list_dict(self):
+        assert ViewSpec.from_dict(None).fields == frozenset()
+        assert ViewSpec.from_dict(["tool", "args"]).fields == frozenset({"tool", "args"})
+        spec = ViewSpec.from_dict({"fields": ["tool"], "fidelity": "full"})
+        assert spec.fields == frozenset({"tool"})
+        assert spec.fidelity == "full"
+
+    def test_to_dict_roundtrip(self):
+        spec = ViewSpec(fields=frozenset({"tool", "args"}), fidelity="full")
+        again = ViewSpec.from_dict(spec.to_dict())
+        assert again == spec
+
+    def test_known_fields_are_all_extractable(self):
+        # Every advertised field must be a real key extract_view can emit.
+        assert "tool" in KNOWN_VIEW_FIELDS
+        assert "transcript" in KNOWN_VIEW_FIELDS
+
+
+class TestExtractView:
+    def test_projects_only_declared_fields(self):
+        spec = ViewSpec(fields=frozenset({"tool", "args"}))
+        call = ToolCall(tool="rm", args={"path": "/x"}, reasoning="cleanup")
+        view = extract_view(spec, tool_call=call, step=3)
+        assert set(view) == {"tool", "args"}
+        assert view["tool"] == "rm"
+        assert view["args"] == {"path": "/x"}
+        # ``reasoning`` and ``step`` were not declared → not present.
+        assert "reasoning" not in view
+        assert "step" not in view
+
+    def test_step_field(self):
+        spec = ViewSpec(fields=frozenset({"step"}))
+        view = extract_view(spec, step=7)
+        assert view == {"step": 7}
+
+    def test_result_view(self):
+        spec = ViewSpec(fields=frozenset({"tool_result"}))
+        result = ToolResult(tool="ls", args_summary="ls", data=["a", "b"])
+        view = extract_view(spec, tool_result=result)
+        assert "tool_result" in view
+        # JSON-safe — must serialise without error.
+        json.dumps(view)
+
+    def test_payload_is_json_safe(self):
+        spec = ViewSpec(fields=frozenset({"tool", "args"}))
+        call = ToolCall(tool="x", args={"n": 1, "nested": {"k": [1, 2, 3]}})
+        view = extract_view(spec, tool_call=call)
+        # round-trips through JSON unchanged
+        assert json.loads(json.dumps(view)) == view
+
+    def test_empty_spec_emits_nothing(self):
+        view = extract_view(ViewSpec(), tool_call=ToolCall(tool="x", args={}), step=1)
+        assert view == {}

--- a/tests/test_thread_rewrite.py
+++ b/tests/test_thread_rewrite.py
@@ -1,0 +1,127 @@
+"""T8 dogfood: declarative ``rewrite_thread`` effect (portable compaction).
+
+``CompactOutcome.cleanup`` is a Python closure — it cannot cross a
+process boundary, so an out-of-process / cross-runtime compactor cannot
+use it. T8 adds a declarative, JSON-safe equivalent:
+:func:`~looplet.hook_decision.RewriteThread` /
+``HookDecision.rewrite_thread`` and ``CompactOutcome.follow_up``, applied
+by :func:`looplet.compact.apply_thread_rewrite`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from looplet import DefaultState, HookDecision, RewriteThread
+from looplet.compact import CompactOutcome, apply_thread_rewrite, run_compact
+
+pytestmark = pytest.mark.smoke
+
+
+class TestRewriteThreadEffect:
+    def test_constructor_builds_spec(self):
+        d = RewriteThread(
+            reset_metadata_keys=["cache", "baseline"],
+            metadata_updates={"token_baseline": 0},
+        )
+        assert d.rewrite_thread == {
+            "reset_metadata_keys": ["cache", "baseline"],
+            "metadata_updates": {"token_baseline": 0},
+        }
+
+    def test_wire_roundtrip_preserves_rewrite_thread(self):
+        d = RewriteThread(reset_metadata_keys=["cache"], metadata_updates={"x": 1})
+        wire = d.to_wire()
+        # JSON-safe: only primitives / lists / dicts.
+        assert wire["rewrite_thread"] == {
+            "reset_metadata_keys": ["cache"],
+            "metadata_updates": {"x": 1},
+        }
+        back = HookDecision.from_wire(wire)
+        assert back is not None
+        assert back.rewrite_thread == d.rewrite_thread
+
+    def test_ergonomic_rewrite_thread_kind(self):
+        back = HookDecision.from_wire(
+            {"kind": "RewriteThread", "rewrite_thread": {"reset_metadata_keys": ["c"]}}
+        )
+        assert back is not None
+        assert back.rewrite_thread == {"reset_metadata_keys": ["c"]}
+
+    def test_rewrite_thread_not_noop(self):
+        assert RewriteThread(reset_metadata_keys=["c"]).is_noop() is False
+
+
+class TestApplyThreadRewrite:
+    def test_reset_and_update_metadata(self):
+        state = DefaultState()
+        state.metadata["cache"] = {"big": "blob"}
+        state.metadata["keep"] = "yes"
+        apply_thread_rewrite(
+            state,
+            {"reset_metadata_keys": ["cache"], "metadata_updates": {"baseline": 0}},
+        )
+        assert "cache" not in state.metadata
+        assert state.metadata["keep"] == "yes"
+        assert state.metadata["baseline"] == 0
+
+    def test_none_spec_is_safe(self):
+        state = DefaultState()
+        state.metadata["keep"] = "yes"
+        apply_thread_rewrite(state, None)
+        assert state.metadata == {"keep": "yes"}
+
+
+class _NoopCompactService:
+    """Minimal service returning a fixed outcome with a declarative follow-up."""
+
+    def compact(self, *, state, session_log, llm, conversation, step_num, reason):
+        return CompactOutcome(
+            reason=reason,
+            follow_up={
+                "reset_metadata_keys": ["token_cache"],
+                "metadata_updates": {"compacted": True},
+            },
+        )
+
+
+class TestRunCompactAppliesFollowUp:
+    def test_follow_up_applied_after_post_compact(self):
+        state = DefaultState()
+        state.metadata["token_cache"] = [1, 2, 3]
+        outcome = run_compact(
+            service=_NoopCompactService(),
+            hooks=[],
+            state=state,
+            session_log=None,
+            llm=None,
+            conversation=None,
+            step_num=1,
+            reason="pressure",
+        )
+        assert outcome.reason == "pressure"
+        assert "token_cache" not in state.metadata
+        assert state.metadata["compacted"] is True
+
+    def test_post_compact_hook_rewrite_thread_applied(self):
+        class _RewriteHook:
+            def on_event(self, payload):
+                from looplet.events import LifecycleEvent
+
+                if payload.event == LifecycleEvent.POST_COMPACT:
+                    return RewriteThread(reset_metadata_keys=["hook_cache"])
+                return None
+
+        state = DefaultState()
+        state.metadata["hook_cache"] = "x"
+        run_compact(
+            service=_NoopCompactService(),
+            hooks=[_RewriteHook()],
+            state=state,
+            session_log=None,
+            llm=None,
+            conversation=None,
+            step_num=1,
+            reason="pressure",
+        )
+        assert "hook_cache" not in state.metadata


### PR DESCRIPTION
Introduces the declarative hook primitives that later portability work builds on:

- `looplet.hook_view.ViewSpec` / `extract_view` — capability-scoped, serialisable hook views.
- `HookDecision.rewrite_thread` + `RewriteThread` — declarative thread-rewrite decisions.
- `compact.apply_thread_rewrite` + `CompactOutcome.follow_up` — apply a rewrite spec to loop state.

Leaf modules only; no behavioural change to existing hooks. First in a stacked series.

Tests: test_hook_view, test_thread_rewrite (full suite green, 2007 passed).