### PR TITLE
feat: surface provider token usage on state and step events

### DIFF
--- a/src/looplet/events.py
+++ b/src/looplet/events.py
@@ -100,6 +100,7 @@ class EventPayload:
     # juggling at every call site.
     prompt: str | None = None
     raw_response: Any | None = None
+    usage: Any | None = None
     tool_call: Any | None = None
     tool_result: Any | None = None
     termination_reason: str | None = None

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -2137,6 +2137,25 @@ def composable_loop(
         # ── Record LLM turn in conversation thread via unified recorder ──
         _history.record_llm_turn(prompt=prompt, response=raw_response)
 
+        # Surface provider token usage / cost onto state so budget hooks
+        # read it from the declared view instead of a backend side-channel
+        # (keeps cost/budget hooks portable across runtimes — §9 T9).
+        _step_usage = getattr(effective_llm, "last_usage", None) or None
+        if _step_usage:
+            try:
+                _meta = getattr(state, "metadata", None)
+                if isinstance(_meta, dict):
+                    _meta["last_usage"] = dict(_step_usage)
+                    _totals = _meta.get("usage_total")
+                    if not isinstance(_totals, dict):
+                        _totals = {}
+                    for _k, _v in _step_usage.items():
+                        if isinstance(_v, (int, float)):
+                            _totals[_k] = _totals.get(_k, 0) + _v
+                    _meta["usage_total"] = _totals
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("usage surfacing failed", exc_info=True)
+
         # Fire POST_LLM_RESPONSE — hooks can observe raw text before
         # it hits the parser. Stop requests are honored at end-of-step.
         _post_llm_decisions = emit_event(
@@ -2148,6 +2167,7 @@ def composable_loop(
             context=context,
             prompt=prompt,
             raw_response=raw_response,
+            usage=_step_usage,
         )
         for _d in _post_llm_decisions:
             if _d.stop is not None:

--- a/tests/test_usage_surface.py
+++ b/tests/test_usage_surface.py
@@ -1,0 +1,116 @@
+"""T9 dogfood: provider usage/cost surfaced onto state + view.
+
+Budget/cost hooks historically read ``backend.last_usage`` directly — a
+runtime-local side-channel that an out-of-process (LEP) hook cannot see.
+These tests lock the portable path: the loop stamps token usage onto
+``state.metadata`` and into the ``POST_LLM_RESPONSE`` event payload, and
+:func:`extract_view` projects it through a declared ``usage`` view so the
+same hook works in-process or across a runtime boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from looplet import (
+    BaseToolRegistry,
+    DefaultState,
+    HookDecision,
+    LifecycleEvent,
+    LoopConfig,
+    composable_loop,
+)
+from looplet.events import EventPayload
+from looplet.hook_view import ViewSpec, extract_view
+from looplet.testing import MockLLMBackend
+from looplet.tools import ToolSpec
+
+pytestmark = pytest.mark.smoke
+
+
+class _UsageBackend(MockLLMBackend):
+    """Mock backend that reports token usage like a real provider."""
+
+    def generate(self, prompt, **kwargs):  # type: ignore[override]
+        text = super().generate(prompt, **kwargs)
+        self.last_usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+        return text
+
+
+def _tools() -> BaseToolRegistry:
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="done",
+            description="Finish",
+            parameters={"answer": "str"},
+            execute=lambda *, answer: {"answer": answer},
+        )
+    )
+    return reg
+
+
+class _UsageRecorder:
+    def __init__(self) -> None:
+        self.post_llm_usage: list = []
+
+    def on_event(self, payload: EventPayload) -> HookDecision | None:
+        if payload.event == LifecycleEvent.POST_LLM_RESPONSE:
+            self.post_llm_usage.append(payload.usage)
+        return None
+
+
+def _run(hook):
+    state = DefaultState(max_steps=3)
+    responses = [
+        '{"tool":"done","args":{"answer":"ok"},"reasoning":"r"}',
+    ]
+    list(
+        composable_loop(
+            llm=_UsageBackend(responses=responses),
+            tools=_tools(),
+            state=state,
+            hooks=[hook],
+            config=LoopConfig(max_steps=3),
+        )
+    )
+    return state
+
+
+class TestUsageSurface:
+    def test_usage_stamped_on_state_metadata(self):
+        rec = _UsageRecorder()
+        state = _run(rec)
+        assert state.metadata.get("last_usage") == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+        # Running total accumulates numeric fields across steps.
+        assert state.metadata.get("usage_total", {}).get("total_tokens", 0) >= 15
+
+    def test_post_llm_event_carries_usage(self):
+        rec = _UsageRecorder()
+        _run(rec)
+        assert rec.post_llm_usage, "POST_LLM_RESPONSE should have fired"
+        assert rec.post_llm_usage[0]["total_tokens"] == 15
+
+    def test_view_reads_usage_from_state_fallback(self):
+        # A hook that declares only a `usage` view, with no explicit usage
+        # argument, still sees token usage projected from state metadata.
+        state = DefaultState(max_steps=3)
+        state.metadata["usage_total"] = {"total_tokens": 42}
+        spec = ViewSpec(fields=frozenset({"usage"}))
+        view = extract_view(spec, state=state)
+        assert view == {"usage": {"total_tokens": 42}}
+
+    def test_view_omits_usage_when_not_subscribed(self):
+        state = DefaultState(max_steps=3)
+        state.metadata["usage_total"] = {"total_tokens": 42}
+        spec = ViewSpec(fields=frozenset({"tool"}))
+        view = extract_view(spec, state=state)
+        assert "usage" not in view


### PR DESCRIPTION
Stamps the active backend's `last_usage` onto `state.metadata['last_usage']` / `['usage_total']` each step, and threads a `usage` field through the step event. Lets cost/budget hooks read usage from the declared view rather than a backend side-channel.

Stacked on #83. Tests: test_usage_surface (full suite green, 2011 passed).