### PR TITLE
fix: coerce JSON-string MCP args and guard non-dict tool results

### DIFF
--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -353,13 +353,14 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
             if pretty is not None:
                 pretty.step(step)
             elif not args.quiet:
+                _data = tool_result.data if tool_result else None
                 err = (tool_result and tool_result.error) or (
-                    tool_result.data.get("error") if tool_result and tool_result.data else None
+                    _data.get("error") if isinstance(_data, dict) else None
                 )
                 tag = _red("✗") if err else _green("✓")
                 short = json.dumps(tool_call.args, default=str)[:80]
                 print(f"  {tag} step {n_steps:>2}: {tool_call.tool}({short})")
-            if tool_call.tool == "done" and tool_result and tool_result.data:
+            if tool_call.tool == "done" and tool_result and isinstance(tool_result.data, dict):
                 final_data = dict(tool_result.data)
                 final_summary = str(tool_result.data.get("summary", ""))
     except KeyboardInterrupt:

--- a/src/looplet/mcp.py
+++ b/src/looplet/mcp.py
@@ -102,7 +102,7 @@ class MCPToolAdapter:
                     name=name,
                     description=desc,
                     parameters=params,
-                    execute=self._make_executor(name),
+                    execute=self._make_executor(name, params),
                 )
             )
         return specs
@@ -242,15 +242,23 @@ class MCPToolAdapter:
             return None
         return data.get("result", data)
 
-    def _make_executor(self, tool_name: str) -> Any:
-        """Create an execute function that calls the MCP server."""
+    def _make_executor(self, tool_name: str, param_types: dict[str, str] | None = None) -> Any:
+        """Create an execute function that calls the MCP server.
+
+        ``param_types`` maps each declared parameter to its flattened
+        JSON-Schema type string (e.g. ``"array"``, ``"object"``,
+        ``"(optional) array"``). It is used to coerce structured
+        arguments that arrive double-encoded as JSON strings.
+        """
+        param_types = param_types or {}
 
         def execute(**kwargs: Any) -> dict:
+            arguments = self._coerce_structured_args(kwargs, param_types)
             resp = self._send_request(
                 "tools/call",
                 {
                     "name": tool_name,
-                    "arguments": kwargs,
+                    "arguments": arguments,
                 },
             )
             if resp is None:
@@ -269,6 +277,44 @@ class MCPToolAdapter:
             return {"content": content}
 
         return execute
+
+    @staticmethod
+    def _coerce_structured_args(
+        kwargs: dict[str, Any], param_types: dict[str, str]
+    ) -> dict[str, Any]:
+        """Parse JSON-string args for params declared as array/object.
+
+        A model driving the loop via JSON-text tool calls sometimes
+        double-encodes a structured argument — e.g. it emits
+        ``"edits": "[{\\"old_string\\": ...}]"`` (a JSON string) instead
+        of a real list. In-process dispatch tolerates this loosely, but
+        an MCP server validating against its inputSchema rejects the
+        stringified value. When a parameter's declared type is
+        ``array``/``object`` and its value arrived as a ``str`` that
+        parses to the matching Python type, substitute the parsed value.
+        Anything that doesn't cleanly match is passed through untouched.
+        """
+        coerced = dict(kwargs)
+        for key, value in kwargs.items():
+            if not isinstance(value, str):
+                continue
+            type_str = param_types.get(key, "")
+            wants_array = "array" in type_str
+            wants_object = "object" in type_str
+            if not (wants_array or wants_object):
+                continue
+            stripped = value.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if wants_array and isinstance(parsed, list):
+                coerced[key] = parsed
+            elif wants_object and isinstance(parsed, dict):
+                coerced[key] = parsed
+        return coerced
 
     @staticmethod
     def _extract_params(schema: dict) -> dict[str, str]:

--- a/tests/test_mcp_adapter_smoke.py
+++ b/tests/test_mcp_adapter_smoke.py
@@ -53,6 +53,46 @@ class TestMCPToolAdapter:
 
         assert MCP is MCPToolAdapter
 
+    def test_coerce_structured_args_parses_json_string_array(self):
+        """A double-encoded JSON-string array arg is parsed when the
+        param's declared type is ``array`` (the multi_edit ``edits`` gap)."""
+        param_types = {"edits": "array", "file_path": "string"}
+        kwargs = {
+            "file_path": "a.py",
+            "edits": '[{"old_string": "x", "new_string": "y"}]',
+        }
+        out = MCPToolAdapter._coerce_structured_args(kwargs, param_types)
+        assert out["edits"] == [{"old_string": "x", "new_string": "y"}]
+        assert out["file_path"] == "a.py"  # plain string untouched
+
+    def test_coerce_structured_args_object_and_optional(self):
+        param_types = {"opts": "(optional) object", "tags": "(optional) array"}
+        kwargs = {"opts": '{"a": 1}', "tags": '["x", "y"]'}
+        out = MCPToolAdapter._coerce_structured_args(kwargs, param_types)
+        assert out["opts"] == {"a": 1}
+        assert out["tags"] == ["x", "y"]
+
+    def test_coerce_structured_args_passes_through_non_matching(self):
+        param_types = {"edits": "array", "count": "integer", "name": "string"}
+        kwargs = {
+            "edits": [{"old_string": "x", "new_string": "y"}],  # already a list
+            "count": 3,  # not a str
+            "name": "not json",  # string param, leave alone
+            "missing": "[1,2]",  # unknown param, no declared type
+        }
+        out = MCPToolAdapter._coerce_structured_args(kwargs, param_types)
+        assert out["edits"] == [{"old_string": "x", "new_string": "y"}]
+        assert out["count"] == 3
+        assert out["name"] == "not json"
+        assert out["missing"] == "[1,2]"
+
+    def test_coerce_structured_args_type_mismatch_passthrough(self):
+        """A JSON string that parses to the wrong shape is left as-is."""
+        param_types = {"edits": "array"}
+        kwargs = {"edits": '{"not": "a list"}'}
+        out = MCPToolAdapter._coerce_structured_args(kwargs, param_types)
+        assert out["edits"] == '{"not": "a list"}'
+
 
 # ── Real-subprocess regression test for NDJSON framing ──────────
 #

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -1,0 +1,58 @@
+"""Regression: `looplet run-cartridge` must not crash when a tool returns a
+non-dict ``ToolResult.data`` (e.g. an out-of-process MCP tool that returns an
+``int``).
+
+Before the fix, the per-step printer in ``cmd_run_workspace`` did
+``tool_result.data.get("error")`` unconditionally, which raised
+``AttributeError: 'int' object has no attribute 'get'`` for the bundled
+``mcp_demo`` cartridge whose ``add`` MCP tool returns an integer sum.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from looplet.cli import factory_commands
+from looplet.testing import MockLLMBackend
+
+pytestmark = pytest.mark.smoke
+
+_MCP_DEMO = Path(__file__).resolve().parents[1] / "examples" / "mcp_demo.cartridge"
+
+
+def _args() -> argparse.Namespace:
+    return argparse.Namespace(
+        workspace=_MCP_DEMO,
+        task="What is 12345 + 67890?",
+        max_steps=5,
+        quiet=False,
+        pretty=False,
+    )
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_survives_int_tool_result(monkeypatch, capsys):
+    """The non-quiet printer tolerates an int ToolResult.data without crashing."""
+    responses = [
+        '{"tool":"add","args":{"a":12345,"b":67890},"reasoning":"sum"}',
+        '{"tool":"done","args":{"total":80235},"reasoning":"report"}',
+    ]
+    monkeypatch.setenv("OPENAI_MODEL", "mock-model")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:1/v1")
+    monkeypatch.setattr(factory_commands, "_check_env", lambda: 0)
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: MockLLMBackend(responses=responses, cycle=False),
+    )
+
+    rc = factory_commands.cmd_run_workspace(_args())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The add step printed without raising, and the run reached `done`.
+    assert "add(" in out
+    assert "80235" in out


### PR DESCRIPTION
Two robustness fixes at the MCP/runtime boundary:
- `_coerce_structured_args` parses JSON-string arguments into list/dict when the tool param type expects a structured value (some MCP clients send stringified JSON).
- The run-workspace step printer no longer assumes `tool_result.data` is a dict — guards with `isinstance(..., dict)` so an int/str tool result can't crash the CLI.

Stacked on #84. Tests: test_mcp_adapter_smoke, test_run_cartridge_nondict_smoke.