### PR TITLE
feat: out-of-process protocol surfaces (LEP/SSP/MGP)

### DIFF
--- a/examples/coder.cartridge/hooks/08_ShellSafetyGate/config.yaml
+++ b/examples/coder.cartridge/hooks/08_ShellSafetyGate/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/coder.cartridge/hooks/08_ShellSafetyGate/server.py
+++ b/examples/coder.cartridge/hooks/08_ShellSafetyGate/server.py
@@ -1,0 +1,52 @@
+"""ShellSafetyGate — a portable ``kind: lep`` permission policy.
+
+A catastrophic-command guardrail for the coder agent that runs *out of
+process* over the Loop Effect Protocol (LEP). The host ships only the
+declared view (``tool`` + ``args``); this server inspects the proposed
+``bash`` command and denies a small, conservative set of irreversibly
+destructive patterns (root/home wipes, raw-disk writes, filesystem
+formats, fork bombs, world-writable recursion on ``/``). Everything else
+is allowed — ordinary coding shell usage is untouched.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a self-contained
+``kind: lep`` block alongside the cartridge's in-process hooks
+(TestGuard, FileCache, StaleFile, Linter, Eval) — demonstrating both the
+out-of-process and in-process authoring styles in one cartridge.
+"""
+
+import re
+
+from looplet.lep import LEPServerBase
+
+# Conservative, high-confidence catastrophic patterns. Each is something
+# a coding agent should never need and that is effectively irreversible.
+_DANGEROUS = [
+    re.compile(r"\brm\s+(-[a-z]*\s+)*-[a-z]*[rf][a-z]*\s+(-[a-z]*\s+)*(/|~|\$HOME)\s*($|\s)"),
+    re.compile(r":\(\)\s*\{\s*:\|:&\s*\}\s*;\s*:"),  # classic fork bomb
+    re.compile(r"\bmkfs(\.\w+)?\b"),
+    re.compile(r"\bdd\b[^\n]*\bof=/dev/"),
+    re.compile(r">\s*/dev/sd[a-z]\b"),
+    re.compile(r"\bchmod\s+(-[a-z]*\s+)*-R\s+0*777\s+/\s*($|\s)"),
+]
+
+
+class ShellSafetyServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "bash":
+            command = (view.get("args") or {}).get("command")
+            if isinstance(command, str):
+                for pattern in _DANGEROUS:
+                    if pattern.search(command):
+                        return {
+                            "kind": "Deny",
+                            "block": (
+                                "shell-safety policy: refusing a catastrophic "
+                                f"command ({pattern.pattern!r})"
+                            ),
+                        }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(ShellSafetyServer().serve())

--- a/examples/dep_doctor.cartridge/hooks/00_RegistryGuard/config.yaml
+++ b/examples/dep_doctor.cartridge/hooks/00_RegistryGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/dep_doctor.cartridge/hooks/00_RegistryGuard/server.py
+++ b/examples/dep_doctor.cartridge/hooks/00_RegistryGuard/server.py
@@ -1,0 +1,36 @@
+"""RegistryGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``check_package`` or ``find_alternatives`` call whose
+``package_name`` argument is empty or whitespace. Querying a package
+registry with a blank name wastes a tool budget step and never returns
+useful data, so the guard short-circuits it before dispatch.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+_GUARDED = {"check_package", "find_alternatives"}
+
+
+class RegistryGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") in _GUARDED:
+            name = (view.get("args") or {}).get("package_name")
+            if not isinstance(name, str) or not name.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing a registry lookup with an empty package_name",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(RegistryGuardServer().serve())

--- a/examples/git_detective.cartridge/hooks/00_CouplingGuard/config.yaml
+++ b/examples/git_detective.cartridge/hooks/00_CouplingGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/git_detective.cartridge/hooks/00_CouplingGuard/server.py
+++ b/examples/git_detective.cartridge/hooks/00_CouplingGuard/server.py
@@ -1,0 +1,39 @@
+"""CouplingGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``coupled_files`` call whose ``min_coupling``
+argument does not parse to a positive integer. The tool treats a
+non-positive or non-numeric threshold as "no filter", which floods the
+agent with every co-changed pair and burns its read budget — so the
+guard rejects the call and asks for a sane threshold instead.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class CouplingGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "coupled_files":
+            raw = (view.get("args") or {}).get("min_coupling", "3")
+            try:
+                threshold = int(str(raw).strip())
+            except (TypeError, ValueError):
+                threshold = 0
+            if threshold < 1:
+                return {
+                    "kind": "Deny",
+                    "block": 'min_coupling must be a positive integer (e.g. "3")',
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(CouplingGuardServer().serve())

--- a/examples/hello.cartridge/hooks/01_NameGuard/config.yaml
+++ b/examples/hello.cartridge/hooks/01_NameGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/hello.cartridge/hooks/01_NameGuard/server.py
+++ b/examples/hello.cartridge/hooks/01_NameGuard/server.py
@@ -1,0 +1,32 @@
+"""NameGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host never hands it live loop state; it ships only the declared
+view (``tool`` + ``args``) over line-delimited JSON-RPC, and this
+server returns a permission decision.
+
+Policy: refuse any ``greet`` call whose ``name`` argument is empty or
+whitespace. Everything else is allowed. Because the decision is a pure
+function of the declared view, the hook is classified ``portable`` and
+round-trips losslessly as a declarative ``kind: lep`` block — no Python
+source needs to be vendored beyond this self-contained server.
+
+The complementary ``00_PolitenessGate`` hook stays in-process: it reads
+a shared greeting-log instance (live state) that cannot cross the wire.
+Together they demonstrate both authoring styles in one cartridge.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class NameGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "greet":
+            name = (view.get("args") or {}).get("name")
+            if not isinstance(name, str) or not name.strip():
+                return {"kind": "Deny", "block": "refusing to greet an empty name"}
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(NameGuardServer().serve())

--- a/examples/mcp_demo.cartridge/hooks/00_CalcGuard/config.yaml
+++ b/examples/mcp_demo.cartridge/hooks/00_CalcGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/mcp_demo.cartridge/hooks/00_CalcGuard/server.py
+++ b/examples/mcp_demo.cartridge/hooks/00_CalcGuard/server.py
@@ -1,0 +1,50 @@
+"""CalcGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP) and
+guards the ``add`` tool that is itself served by a *separate* MCP stdio
+process (see ``_server/calc.py``). It demonstrates that LEP permission
+policies and MCP transport tools compose cleanly: the host ships the
+declared view (``tool`` + ``args``) to this server, which vets the call
+before it is ever dispatched to the MCP server.
+
+Policy: refuse any ``add`` call whose ``a`` or ``b`` operand is missing
+or not a number. The calculator server's schema requires two integers,
+so a non-numeric operand would fault the MCP process — the guard turns
+that into a clean, early permission denial instead.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+def _is_number(value):
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value.strip())
+            return True
+        except (TypeError, ValueError):
+            return False
+    return False
+
+
+class CalcGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "add":
+            args = view.get("args") or {}
+            if not (_is_number(args.get("a")) and _is_number(args.get("b"))):
+                return {
+                    "kind": "Deny",
+                    "block": "add requires two numeric operands 'a' and 'b'",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(CalcGuardServer().serve())

--- a/examples/planner.cartridge/hooks/00_SubagentTaskGuard/config.yaml
+++ b/examples/planner.cartridge/hooks/00_SubagentTaskGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/planner.cartridge/hooks/00_SubagentTaskGuard/server.py
+++ b/examples/planner.cartridge/hooks/00_SubagentTaskGuard/server.py
@@ -1,0 +1,33 @@
+"""SubagentTaskGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``subagent`` call whose ``task`` argument is empty or
+whitespace. Spawning a child loop with no task wastes an entire nested
+run and its token budget, so the guard blocks it before dispatch.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class SubagentTaskGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "subagent":
+            task = (view.get("args") or {}).get("task")
+            if not isinstance(task, str) or not task.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing to spawn a subagent with an empty task",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(SubagentTaskGuardServer().serve())

--- a/examples/skillful_analyst.cartridge/hooks/00_WriteScopeGuard/config.yaml
+++ b/examples/skillful_analyst.cartridge/hooks/00_WriteScopeGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/skillful_analyst.cartridge/hooks/00_WriteScopeGuard/server.py
+++ b/examples/skillful_analyst.cartridge/hooks/00_WriteScopeGuard/server.py
@@ -1,0 +1,41 @@
+"""WriteScopeGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``write_text`` call whose ``path`` is empty or
+escapes the project root via a ``..`` parent-directory traversal. The
+analyst writes its findings inside the workspace; a blank or traversing
+path is almost always a mistake (or an attempt to clobber a file
+outside the sandbox), so the guard blocks it before the write happens.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class WriteScopeGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "write_text":
+            path = (view.get("args") or {}).get("path")
+            if not isinstance(path, str) or not path.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing write_text with an empty path",
+                }
+            parts = path.replace("\\", "/").split("/")
+            if ".." in parts:
+                return {
+                    "kind": "Deny",
+                    "block": "refusing write_text with a '..' path escaping the project root",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(WriteScopeGuardServer().serve())

--- a/examples/threat_intel.cartridge/hooks/00_FeedAllowlistGuard/config.yaml
+++ b/examples/threat_intel.cartridge/hooks/00_FeedAllowlistGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/threat_intel.cartridge/hooks/00_FeedAllowlistGuard/server.py
+++ b/examples/threat_intel.cartridge/hooks/00_FeedAllowlistGuard/server.py
@@ -1,0 +1,39 @@
+"""FeedAllowlistGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``fetch_feed`` call whose ``feed_name`` is not on the
+trusted allowlist. A threat-intel agent should only pull from vetted
+sources (CISA, NVD, curated OSINT); an unknown feed name is either a
+hallucination or an attempt to reach an unapproved source, so the guard
+denies it. This is the classic out-of-process "egress allowlist"
+pattern expressed as a portable cartridge hook.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+_ALLOWED_FEEDS = {"cisa_alerts", "nvd_recent", "osint_reports"}
+
+
+class FeedAllowlistGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "fetch_feed":
+            feed = (view.get("args") or {}).get("feed_name")
+            if not isinstance(feed, str) or feed.strip() not in _ALLOWED_FEEDS:
+                allowed = ", ".join(sorted(_ALLOWED_FEEDS))
+                return {
+                    "kind": "Deny",
+                    "block": f"feed_name must be one of the allowlisted sources: {allowed}",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(FeedAllowlistGuardServer().serve())

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -118,6 +118,11 @@ from looplet.memory import (
     CallableMemorySource,
     StaticMemorySource,
 )
+from looplet.model_gateway import (
+    ModelGatewayClient,
+    ModelGatewayHandle,
+    ModelGatewayServer,
+)
 from looplet.native_tools import (
     NativeToolProbeResult,
     probe_native_tool_support,
@@ -152,6 +157,11 @@ from looplet.stagnation import (
     StagnationHook,
     result_size_fingerprint,
     tool_call_fingerprint,
+)
+from looplet.state_service import (
+    StateServiceBase,
+    StateServiceClient,
+    StateServiceHandle,
 )
 from looplet.streaming import StreamingHook
 from looplet.subagent import run_sub_loop
@@ -243,6 +253,12 @@ __all__ = [
     "AnthropicBackend",
     "NativeToolBackend",
     "MCPToolAdapter",
+    "StateServiceBase",
+    "StateServiceClient",
+    "StateServiceHandle",
+    "ModelGatewayServer",
+    "ModelGatewayClient",
+    "ModelGatewayHandle",
     "NativeToolProbeResult",
     "probe_native_tool_support",
     "supports_native_tools",

--- a/src/looplet/cartridge/_load.py
+++ b/src/looplet/cartridge/_load.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 import re
 import shutil
 from pathlib import Path
@@ -50,6 +51,77 @@ from looplet.cartridge._yaml import _dump_yaml, _load_yaml
 logger = logging.getLogger(__name__)
 
 # ── Deserialise: directory → AgentPreset ───────────────────────
+
+
+def _build_lep_hook(
+    hook_dir: Path,
+    hook_cfg: dict[str, Any],
+    *,
+    strict: bool,
+) -> Any | None:
+    """Build an :class:`~looplet.lep.LEPHookAdapter` from a ``kind: lep`` dir.
+
+    Recognised ``config.yaml`` keys:
+
+        kind: lep            (required marker)
+        command: [...]       argv to launch the server, or
+        server: server.py    shorthand → ``[python, <hook_dir>/server.py]``
+        view:                {fields: [...], fidelity: digest|full}
+        on_failure:          fail_closed|fail_open|continue
+        run_id:              optional correlation id
+
+    Relative path tokens that resolve to a file under ``hook_dir`` are
+    rewritten to absolute paths so the server launches regardless of cwd.
+    """
+    import sys  # noqa: PLC0415
+
+    from looplet.hook_view import ViewSpec  # noqa: PLC0415
+    from looplet.lep import LEPHookAdapter  # noqa: PLC0415
+
+    def _abs_token(tok: str) -> str:
+        candidate = hook_dir / tok
+        return str(candidate.resolve()) if candidate.is_file() else tok
+
+    command = hook_cfg.get("command")
+    if command is None and hook_cfg.get("server"):
+        command = [sys.executable, str((hook_dir / str(hook_cfg["server"])).resolve())]
+    if isinstance(command, str):
+        command = [command]
+    if not isinstance(command, list) or not command:
+        msg = (
+            f"lep hook {hook_dir.name!r} needs a non-empty 'command' list or "
+            f"'server' path in config.yaml"
+        )
+        if strict:
+            raise CartridgeSerializationError(msg)
+        logger.warning("%s; skipping", msg)
+        return None
+    argv = [_abs_token(str(tok)) for tok in command]
+
+    try:
+        view = ViewSpec.from_dict(hook_cfg.get("view"))
+    except ValueError as exc:
+        msg = f"lep hook {hook_dir.name!r} has an invalid view: {exc}"
+        if strict:
+            raise CartridgeSerializationError(msg) from exc
+        logger.warning("%s; skipping", msg)
+        return None
+
+    on_failure = str(hook_cfg.get("on_failure", "fail_closed"))
+    try:
+        return LEPHookAdapter(
+            argv,
+            view=view,
+            run_id=str(hook_cfg.get("run_id", f"lep-{hook_dir.name}")),
+            on_failure=on_failure,
+            cartridge_id=hook_dir.name,
+        )
+    except ValueError as exc:
+        msg = f"lep hook {hook_dir.name!r} could not be built: {exc}"
+        if strict:
+            raise CartridgeSerializationError(msg) from exc
+        logger.warning("%s; skipping", msg)
+        return None
 
 
 def cartridge_to_preset(
@@ -639,7 +711,103 @@ def _workspace_to_preset_inner(
     # context manager) to terminate the subprocesses cleanly.
     _mcp_servers_block: dict[str, Any] = dict(cfg_kwargs.pop("mcp_servers", None) or {})
 
-    # ``state:`` is a workspace-loader directive that lets a workspace
+    # ``state_services:`` declares out-of-process shared-mutable-state
+    # servers (State Service Protocol). Sibling of ``mcp_servers:``: each
+    # entry spawns a server that owns a piece of state behind a Unix
+    # socket; the loader injects a :class:`StateServiceClient` into the
+    # resource registry under the service name, so existing ``@ref`` /
+    # ``requires:`` wiring resolves to the (now portable) out-of-process
+    # state unchanged. Handles are stashed on ``preset.state_service_handles``
+    # for caller-side cleanup. Spawned below, after the resource registry
+    # exists.
+    _state_services_block: dict[str, Any] = dict(cfg_kwargs.pop("state_services", None) or {})
+
+    # ``llm_gateway:`` (default on whenever there are out-of-process tool
+    # servers) starts a host-resident Model Gateway (MGP): a 1:N socket
+    # server that exposes the loop's LLM backend to out-of-process MCP
+    # tool / LEP hook servers. Without it, a portable tool that wants
+    # ``ctx.llm`` (summarise/classify/extract) has no host LLM and
+    # silently degrades. The gateway must be started *before* any child
+    # is spawned so the ``LOOPLET_LLM_SOCKET`` env var is inherited; the
+    # backend is bound later at run time (``AgentPreset.run(llm)``). Set
+    # ``llm_gateway: false`` to opt out.
+    _llm_gateway_enabled = bool(cfg_kwargs.pop("llm_gateway", True))
+    _model_gateway: Any = None
+    if _llm_gateway_enabled and _mcp_servers_block:
+        from looplet.model_gateway import (  # noqa: PLC0415
+            ModelGatewayError,
+            ModelGatewayHandle,
+        )
+
+        try:
+            _model_gateway = ModelGatewayHandle.start()
+        except (ModelGatewayError, OSError) as exc:
+            logger.warning(
+                "could not start model gateway (out-of-process tools will "
+                "degrade ctx.llm to None): %s",
+                exc,
+            )
+            _model_gateway = None
+
+    # Spawn declared state services now, before hook ``@ref`` kwargs and
+    # tool ``requires:`` resolve against the resource registry, so a
+    # ``@<service>`` ref or a ``requires: [<service>]`` resolves to the
+    # live :class:`StateServiceClient`. ``${runtime.*}`` placeholders in
+    # the ``command:`` are already substituted (config text was rendered
+    # before YAML parse). The per-service socket path is also exported as
+    # ``LOOPLET_STATE_<NAME>`` so out-of-process MCP tool / LEP hook
+    # servers spawned afterwards can connect to the same state.
+    _state_service_handles: list[Any] = []
+    if _state_services_block:
+        from looplet.state_service import (  # noqa: PLC0415
+            PER_SERVICE_ENV_PREFIX,
+            StateServiceError,
+            StateServiceHandle,
+        )
+
+        for _svc_name, _svc_cfg in _state_services_block.items():
+            if not isinstance(_svc_cfg, dict):
+                msg = (
+                    f"state_services.{_svc_name} must be a mapping with "
+                    f"``command:`` (and optional ``timeout_s:``, ``env:``); "
+                    f"got {type(_svc_cfg).__name__}"
+                )
+                if strict:
+                    raise CartridgeSerializationError(msg)
+                logger.warning("%s; skipping", msg)
+                continue
+            _svc_cmd = _svc_cfg.get("command")
+            if not _svc_cmd or not isinstance(_svc_cmd, str):
+                msg = f"state_services.{_svc_name}: ``command:`` is required and must be a string"
+                if strict:
+                    raise CartridgeSerializationError(msg)
+                logger.warning("%s; skipping", msg)
+                continue
+            try:
+                _handle = StateServiceHandle.spawn(
+                    _svc_cmd,
+                    name=_svc_name,
+                    timeout_s=float(_svc_cfg.get("timeout_s", 10.0)),
+                    env=_svc_cfg.get("env"),
+                )
+            except (StateServiceError, OSError) as exc:
+                for _h in _state_service_handles:
+                    try:
+                        _h.close()
+                    except Exception:
+                        pass
+                msg = f"state_services.{_svc_name}: failed to start ({_svc_cmd!r}): {exc}"
+                if strict:
+                    raise CartridgeSerializationError(msg) from exc
+                logger.warning("%s; skipping service", msg)
+                continue
+            # Inject the client so ``@<name>`` / ``requires: [<name>]``
+            # resolve to it, and export the socket path for sibling
+            # out-of-process servers.
+            resources[_svc_name] = _handle.client
+            os.environ[f"{PER_SERVICE_ENV_PREFIX}{_svc_name.upper()}"] = _handle.socket_path
+            _state_service_handles.append(_handle)
+
     # describe the state object declaratively (any reference: a
     # ``${ref:...}`` resource, a ``${py:...}`` factory callable, or a
     # pre-resolved instance from ``_resolve_refs``). Falls back to the
@@ -1178,14 +1346,6 @@ def _workspace_to_preset_inner(
         for _key, hook_dir in hook_entries:
             hook_py = hook_dir / "hook.py"
             cfg_yaml = hook_dir / "config.yaml"
-            if not hook_py.is_file():
-                msg = f"malformed hook dir {hook_dir} (missing hook.py)"
-                if strict:
-                    raise CartridgeSerializationError(msg)
-                logger.warning("skipping %s", msg)
-                continue
-            module = _import_module_from_path(hook_py, f"_chw_hook_{hook_dir.name}")
-            hook_modules[hook_dir.name] = module
             hook_cfg = (
                 _load_yaml(
                     _apply_runtime_substitutions(
@@ -1196,6 +1356,25 @@ def _workspace_to_preset_inner(
                 if cfg_yaml.is_file()
                 else {}
             ) or {}
+            # ── kind: lep — an out-of-process hook (no hook.py) ──────
+            # A ``kind: lep`` hook ships only declarative data: a command
+            # to launch a policy server, the capability view it subscribes
+            # to, and a failure policy. The host bridges it via
+            # ``LEPHookAdapter`` so it is behaviourally identical to an
+            # in-process hook (HOOK_CARTRIDGE_DESIGN.md §3/§5).
+            if str(hook_cfg.get("kind") or "").lower() == "lep":
+                lep_hook = _build_lep_hook(hook_dir, hook_cfg, strict=strict)
+                if lep_hook is not None:
+                    hooks.append(lep_hook)
+                continue
+            if not hook_py.is_file():
+                msg = f"malformed hook dir {hook_dir} (missing hook.py)"
+                if strict:
+                    raise CartridgeSerializationError(msg)
+                logger.warning("skipping %s", msg)
+                continue
+            module = _import_module_from_path(hook_py, f"_chw_hook_{hook_dir.name}")
+            hook_modules[hook_dir.name] = module
             class_name = str(hook_cfg.get("class_name") or "")
             if not class_name:
                 # Pick the first class defined in the module.
@@ -1253,6 +1432,13 @@ def _workspace_to_preset_inner(
         for entry in _builtin_hook_specs:
             if isinstance(entry, str):
                 hname, raw_kwargs = entry, {}
+            elif isinstance(entry, dict) and "use" in entry:
+                # ``use: stdlib/<name>`` alias form — a portable, explicit
+                # spelling that names a looplet-shipped (standard-library)
+                # hook archetype. Any other keys are its kwargs.
+                use_val = str(entry.get("use") or "")
+                hname = use_val.split("/", 1)[1] if "/" in use_val else use_val
+                raw_kwargs = {k: v for k, v in entry.items() if k != "use"}
             elif isinstance(entry, dict) and len(entry) == 1:
                 hname, raw_kwargs = next(iter(entry.items()))
                 raw_kwargs = dict(raw_kwargs or {})
@@ -1386,6 +1572,21 @@ def _workspace_to_preset_inner(
     )
     if _mcp_adapters:
         preset.mcp_adapters = list(_mcp_adapters)
+    if _state_service_handles:
+        preset.state_service_handles = list(_state_service_handles)
+    if _model_gateway is not None:
+        preset.model_gateway = _model_gateway
+    # Record declarative tool provenance so ``preset_to_cartridge`` can
+    # re-emit the ``builtin_tools:`` / ``mcp_servers:`` directives rather
+    # than trying to serialise loader-built specs (builtin tools need
+    # loader-provided resources like ``workspace_config``; MCP tools have
+    # closure executors that cannot round-trip to disk).
+    if _builtin_tool_names:
+        preset.builtin_tool_names = list(_builtin_tool_names)
+    if _mcp_servers_block:
+        preset.mcp_servers = dict(_mcp_servers_block)
+    if _state_services_block:
+        preset.state_services = dict(_state_services_block)
 
     # ── v1.0 declarative slots: permissions, memory.long_term ───────
     # Both are processed AFTER hooks/state/preset are built so the
@@ -1510,5 +1711,25 @@ def _workspace_to_preset_inner(
         result = setup_fn(preset, resources, **kwargs)
         if isinstance(result, AgentPreset):
             preset = result
+
+    # Portability classification (advisory, non-mutating): label every
+    # assembled hook ``portable`` (faithfully reproducible across runtimes)
+    # or ``inprocess`` (faithful, but Python-pinned) and log a one-line
+    # summary. This is purely diagnostic — it never changes preset shape,
+    # so cartridge round-trip/serialise behaviour is unaffected.
+    try:
+        from looplet.hook_contract import classify  # noqa: PLC0415
+
+        labels = [classify(h).kind for h in preset.hooks]
+        if labels:
+            portable_n = sum(1 for k in labels if k == "portable")
+            logger.info(
+                "cartridge hooks portability: %d/%d portable (%s)",
+                portable_n,
+                len(labels),
+                ", ".join(f"{type(h).__name__}={k}" for h, k in zip(preset.hooks, labels)),
+            )
+    except Exception:  # noqa: BLE001 - diagnostics must never break load
+        logger.debug("hook portability classification skipped", exc_info=True)
 
     return preset

--- a/src/looplet/cartridge/_serialise.py
+++ b/src/looplet/cartridge/_serialise.py
@@ -18,6 +18,7 @@ import importlib
 import inspect
 import json
 import logging
+import re
 import shutil
 from collections.abc import Iterable
 from pathlib import Path
@@ -147,6 +148,19 @@ def preset_to_cartridge(
         serialized_cfg[fname] = f"{_REF_PREFIX}{fname}"
         config_field_refs[fname] = value
 
+    # Re-emit declarative tool directives so the round-tripped cartridge
+    # re-derives these tools from the loader instead of carrying inlined
+    # specs. ``builtin_tools`` re-registers looplet-shipped tools (which
+    # need loader-provided resources like ``workspace_config``);
+    # ``mcp_servers`` re-spawns the MCP subprocess (whose tool executors
+    # are closures that cannot serialise to disk).
+    builtin_tool_names = list(getattr(preset, "builtin_tool_names", None) or [])
+    if builtin_tool_names:
+        serialized_cfg["builtin_tools"] = builtin_tool_names
+    mcp_servers = dict(getattr(preset, "mcp_servers", None) or {})
+    if mcp_servers:
+        serialized_cfg["mcp_servers"] = _relativise_mcp_servers(mcp_servers, preset, root, warnings)
+
     if serialized_cfg:
         # ── Cartridge spec v2 split: contract → config.yaml,
         # runtime knobs → runtime.yaml. Field tiering lives on
@@ -179,7 +193,15 @@ def preset_to_cartridge(
     # 3. tools — one subdir per tool with tool.yaml + execute.py
     tools_root = root / CartridgeLayout.TOOLS_DIR
     tools_root.mkdir(exist_ok=True)
+    _builtin_names = set(builtin_tool_names)
     for spec in _iter_tool_specs(preset.tools):
+        # Skip tools that are re-derived from declarative directives:
+        # builtin tools come back via ``builtin_tools:`` and MCP tools via
+        # ``mcp_servers:`` (their closure executors cannot round-trip).
+        if getattr(spec, "name", None) in _builtin_names:
+            continue
+        if _is_mcp_tool(spec):
+            continue
         _write_tool(spec, tools_root, warnings, strict)
 
     # 4. hooks — one subdir per hook, ordered by index for deterministic load
@@ -288,6 +310,85 @@ def preset_to_cartridge(
     workspace.serialization_warnings = warnings
     workspace.write_metadata()
     return workspace
+
+
+def _is_mcp_tool(spec: Any) -> bool:
+    """True when ``spec``'s executor is an MCP adapter closure.
+
+    MCP tool specs are produced by
+    :meth:`looplet.mcp.MCPToolAdapter.tools`, whose ``execute`` is a
+    per-tool closure (``MCPToolAdapter._make_executor.<locals>...``).
+    Such closures cannot serialise to disk, so the serialiser skips them
+    and relies on the re-emitted ``mcp_servers:`` directive to recreate
+    the tools on reload.
+    """
+    fn = getattr(spec, "execute", None)
+    qualname = getattr(fn, "__qualname__", "") or ""
+    return "MCPToolAdapter" in qualname and "_make_executor" in qualname
+
+
+def _relativise_mcp_servers(
+    mcp_servers: dict[str, Any],
+    preset: Any,
+    dest_root: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Re-template resolved ``mcp_servers`` commands back to
+    ``${runtime.cartridge_root}`` and vendor any bundled server files.
+
+    The loader resolves ``${runtime.cartridge_root}`` to the source
+    cartridge's absolute path before storing the block on the preset. To
+    make the round-tripped cartridge relocatable, we copy the referenced
+    bundle directory (e.g. ``_server/``) into ``dest_root`` and rewrite
+    the absolute origin path back to the ``${runtime.cartridge_root}``
+    placeholder. When the preset has no recorded origin (built in-process
+    from an absolute path), the command is emitted verbatim so reload
+    still re-spawns the server from its original location.
+    """
+    src_root = _preset_origin_root(preset)
+    out: dict[str, Any] = {}
+    for name, cfg in mcp_servers.items():
+        if not isinstance(cfg, dict) or src_root is None:
+            out[name] = cfg
+            continue
+        cfg = dict(cfg)
+        src_str = str(Path(src_root).resolve())
+        command = cfg.get("command")
+        if isinstance(command, str) and src_str in command:
+            _copy_mcp_bundle(command, src_str, Path(src_root), dest_root, warnings)
+            cfg["command"] = command.replace(src_str, "${runtime.cartridge_root}")
+        out[name] = cfg
+    return out
+
+
+def _copy_mcp_bundle(
+    command: str,
+    src_str: str,
+    src_root: Path,
+    dest_root: Path,
+    warnings: list[str],
+) -> None:
+    """Copy the top-level bundle component referenced by an MCP server
+    command (e.g. the ``_server/`` directory holding ``calc.py``) from
+    the source cartridge into ``dest_root``."""
+    for token in command.split():
+        if not token.startswith(src_str):
+            continue
+        rel = Path(token[len(src_str) :].lstrip("/\\"))
+        if not rel.parts:
+            continue
+        top = rel.parts[0]
+        src_path = src_root / top
+        dest_path = dest_root / top
+        if not src_path.exists() or dest_path.exists():
+            continue
+        try:
+            if src_path.is_dir():
+                shutil.copytree(src_path, dest_path)
+            else:
+                dest_path.write_bytes(src_path.read_bytes())
+        except OSError as exc:  # noqa: BLE001
+            warnings.append(f"mcp bundle copy: could not copy {top!r}: {exc}")
 
 
 def _copy_workspace_helpers(preset: Any, dest_root: Path, warnings: list[str]) -> None:
@@ -795,6 +896,52 @@ def _write_tool(spec: Any, tools_root: Path, warnings: list[str], strict: bool) 
 
 
 def _write_hook(hook: Any, hooks_root: Path, index: int, warnings: list[str], strict: bool) -> None:
+    # ── kind: lep — out-of-process hook serialises to declarative data ──
+    # An LEPHookAdapter carries no Python decision logic; its faithful
+    # cartridge form is the launch command + declared view + failure
+    # policy. Emitting that (instead of trying to pickle the adapter as a
+    # class hook) is what makes the library→cartridge direction lossless
+    # for out-of-process hooks (HOOK_CARTRIDGE_DESIGN.md §5.1).
+    from looplet.lep import LEPHookAdapter  # noqa: PLC0415
+
+    if isinstance(hook, LEPHookAdapter):
+        # The loader sets ``_cartridge_id`` to the source hook dir name,
+        # which already carries an ``NN_`` index prefix. Strip it before
+        # re-prefixing so the dir name does not compound (``01_NameGuard``
+        # → ``01_01_NameGuard`` → …) across successive round-trips.
+        base_id = re.sub(r"^\d+_", "", hook._cartridge_id or "lep") or "lep"
+        dir_name = f"{index:02d}_{_safe_filename(base_id)}"
+        hook_dir = hooks_root / dir_name
+        hook_dir.mkdir(parents=True, exist_ok=True)
+        # Make the snapshot self-contained: any argv token *after* the
+        # program/interpreter (argv[0]) that is an existing file (the
+        # server script + its local helpers) is copied into the hook dir
+        # and rewritten to a bare filename, which the loader resolves
+        # relative to the hook dir. argv[0] (the interpreter/executable)
+        # and non-file tokens (flags) pass through verbatim — copying the
+        # interpreter binary would break it outside its install tree.
+        emitted_cmd: list[str] = []
+        for idx, tok in enumerate(hook._argv):
+            src_path = Path(str(tok))
+            if idx > 0 and src_path.is_file():
+                dest = hook_dir / src_path.name
+                try:
+                    shutil.copy2(src_path, dest)
+                    emitted_cmd.append(src_path.name)
+                    continue
+                except OSError as exc:  # pragma: no cover - defensive
+                    warnings.append(f"lep hook server copy failed for {tok}: {exc}")
+            emitted_cmd.append(str(tok))
+        lep_cfg: dict[str, Any] = {
+            "kind": "lep",
+            "command": emitted_cmd,
+            "view": hook._view.to_dict(),
+            "on_failure": hook._on_failure,
+            "run_id": hook._run_id,
+        }
+        (hook_dir / "config.yaml").write_text(_dump_yaml(lep_cfg) + "\n", encoding="utf-8")
+        return
+
     cls = _hook_class(hook)
     cls_name = cls.__name__
     dir_name = f"{index:02d}_{_safe_filename(cls_name)}"

--- a/src/looplet/hook_contract.py
+++ b/src/looplet/hook_contract.py
@@ -1,0 +1,122 @@
+"""Portability classifier — label a hook ``portable`` or ``inprocess``.
+
+The honest version of "100% lossless cartridge⇄library" (see
+HOOK_CARTRIDGE_DESIGN.md §9.0) is: *every* library hook has a faithful
+cartridge representation, but only the **pure + declared-view** subset
+is portable across runtimes; the rest are faithfully pinned to the
+authoring runtime via ``kind: inprocess``. This module is the verifier
+that draws that line, so the label is enforced rather than asserted.
+
+It is deliberately conservative: static purity analysis of arbitrary
+Python is undecidable, so anything not *positively* known to be portable
+is labelled ``inprocess`` (faithful, Python-pinned). Positive evidence of
+portability is one of:
+
+* the hook is an :class:`looplet.lep.LEPHookAdapter` — already
+  out-of-process by construction, hence portable by definition;
+* the hook came from the stdlib archetype registry with a declared
+  view (``builtin_hooks``/``use: stdlib/*``);
+* the hook opts in explicitly via ``__lep_portable__ = True`` *and*
+  exposes a :class:`~looplet.hook_view.ViewSpec` as ``view_spec``.
+
+Negative evidence (forces ``inprocess`` even with an opt-in):
+
+* a ``bind`` method — the hook subscribes to live loop ``ctx`` and thus
+  reads outside any serialisable view (hazard H2/H3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from looplet.hook_view import ViewSpec
+
+__all__ = ["Classification", "classify", "classify_preset_hooks"]
+
+PORTABLE = "portable"
+INPROCESS = "inprocess"
+
+
+@dataclass(frozen=True)
+class Classification:
+    """Result of classifying one hook for cross-runtime portability."""
+
+    kind: str  # PORTABLE | INPROCESS
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+    view: ViewSpec | None = None
+
+    @property
+    def is_portable(self) -> bool:
+        return self.kind == PORTABLE
+
+
+def _has_bind(hook: Any) -> bool:
+    return callable(getattr(hook, "bind", None))
+
+
+def classify(
+    hook: Any,
+    *,
+    view: ViewSpec | None = None,
+    stdlib_name: str | None = None,
+) -> Classification:
+    """Classify ``hook`` as :data:`PORTABLE` or :data:`INPROCESS`.
+
+    Args:
+        hook: The instantiated hook object.
+        view: An externally-declared view (e.g. from a cartridge
+            ``view:`` block), if any.
+        stdlib_name: The stdlib archetype name this hook was built from,
+            if it came through ``use: stdlib/*`` / ``builtin_hooks``.
+    """
+    # Avoid an import cycle: looplet.lep imports nothing from here, but
+    # importing it at module scope would still be fine — keep it local
+    # for clarity.
+    from looplet.lep import LEPHookAdapter
+
+    declared_view = view or getattr(hook, "view_spec", None)
+
+    if isinstance(hook, LEPHookAdapter):
+        return Classification(
+            PORTABLE,
+            ("out-of-process LEP adapter",),
+            declared_view or getattr(hook, "_view", None),
+        )
+
+    if _has_bind(hook):
+        return Classification(
+            INPROCESS,
+            ("declares bind() — reads live loop ctx outside any serialisable view",),
+            declared_view,
+        )
+
+    if stdlib_name is not None and declared_view is not None:
+        return Classification(
+            PORTABLE,
+            (f"stdlib archetype '{stdlib_name}' with a declared view",),
+            declared_view,
+        )
+
+    if getattr(hook, "__lep_portable__", False) and declared_view is not None:
+        return Classification(
+            PORTABLE,
+            ("explicit __lep_portable__ opt-in with a declared view",),
+            declared_view,
+        )
+
+    reasons = ["arbitrary Python hook — no positive portability evidence"]
+    if declared_view is None:
+        reasons.append("no declared view")
+    return Classification(INPROCESS, tuple(reasons), declared_view)
+
+
+def classify_preset_hooks(preset: Any) -> list[tuple[str, Classification]]:
+    """Classify every hook on an :class:`~looplet.preset.AgentPreset`.
+
+    Returns a list of ``(hook_type_name, Classification)`` pairs in hook
+    order. Pure inspection — it does **not** mutate ``preset`` (so it is
+    safe to call inside round-trip / serialise tests).
+    """
+    hooks = list(getattr(preset, "hooks", None) or [])
+    return [(type(h).__name__, classify(h)) for h in hooks]

--- a/src/looplet/lep.py
+++ b/src/looplet/lep.py
@@ -1,0 +1,391 @@
+"""Loop Effect Protocol (LEP) — run a looplet hook in another process.
+
+This is the productionised host-side bridge first prototyped under
+``paper/experiments/cross_runtime_portability/lep_poc``. An
+:class:`LEPHookAdapter` is a perfectly ordinary :class:`looplet.loop.LoopHook`
+whose authority lives in a separate, possibly non-Python, process. For
+every lifecycle slot the adapter:
+
+  1. projects live loop state onto the hook's declared
+     :class:`~looplet.hook_view.ViewSpec` (the capability view, §4);
+  2. ships the slot tag + that view over line-delimited JSON-RPC;
+  3. reconstructs the returned *effect* into a
+     :class:`~looplet.hook_decision.HookDecision` via
+     :meth:`HookDecision.from_wire`, then maps it to the exact value the
+     loop expects from that slot.
+
+The adapter carries **zero decision logic** — it is pure transport plus
+the §3 fidelity map. That is what makes an out-of-process hook
+behaviourally indistinguishable from the same hook in-process, and hence
+what makes a ``kind: lep`` cartridge entry a lossless translation of a
+library hook (HOOK_CARTRIDGE_DESIGN.md §5).
+
+:class:`LEPServerBase` is the symmetric convenience for *writing* a
+Python policy server: subclass it, declare capabilities, implement
+``decide(slot, view) -> HookDecision | dict | None``, and call ``.serve()``.
+A server need not import anything else from looplet, mirroring how a Rust
+or Go server would speak only the wire protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from looplet.hook_decision import HookDecision
+from looplet.hook_view import ViewSpec, extract_view
+from looplet.types import ToolResult
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["LEPHookAdapter", "LEPServerBase", "LEPProtocolError"]
+
+LEP_VERSION = "0.1"
+
+#: Failure policies for an authority slot when the server errors or the
+#: stream dies. ``fail_closed`` denies/blocks; ``fail_open`` allows;
+#: ``continue`` is a no-opinion pass-through (the default for
+#: non-authority slots).
+_FAILURE_POLICIES = ("fail_closed", "fail_open", "continue")
+
+
+class LEPProtocolError(RuntimeError):
+    """Raised when the LEP transport breaks irrecoverably."""
+
+
+class LEPHookAdapter:
+    """A :class:`LoopHook` whose every slot's authority is a remote process.
+
+    Args:
+        server_argv: Command + args to launch the policy server.
+        view: The hook's declared capability view (§4). Defaults to the
+            ``{tool, args}`` digest view sufficient for permission-style
+            policies.
+        run_id: Correlation id sent in ``loop/initialize``.
+        on_failure: Default failure policy for authority slots when the
+            server errors. One of ``fail_closed``/``fail_open``/``continue``.
+    """
+
+    def __init__(
+        self,
+        server_argv: list[str],
+        *,
+        view: ViewSpec | None = None,
+        run_id: str = "lep-run",
+        on_failure: str = "fail_closed",
+        cartridge_id: str = "lep",
+    ) -> None:
+        if on_failure not in _FAILURE_POLICIES:
+            raise ValueError(f"on_failure must be one of {_FAILURE_POLICIES}, got {on_failure!r}")
+        self._argv = list(server_argv)
+        self._view = view or ViewSpec(fields=frozenset({"tool", "args"}))
+        self._run_id = run_id
+        self._on_failure = on_failure
+        self._cartridge_id = cartridge_id
+        self._proc: subprocess.Popen[str] | None = None
+        self._next_id = 0
+        self.capabilities: dict[str, Any] = {}
+
+    # ── transport ────────────────────────────────────────────────
+    def _rpc(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise LEPProtocolError("LEP server process is not running")
+        self._next_id += 1
+        req = {"id": self._next_id, "method": method, "params": params or {}}
+        try:
+            proc.stdin.write(json.dumps(req) + "\n")
+            proc.stdin.flush()
+            line = proc.stdout.readline()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            # Dead/half-closed server: surface as a protocol error so
+            # callers apply ``on_failure`` instead of crashing the host.
+            raise LEPProtocolError(f"LEP transport failed: {exc}") from exc
+        if not line:
+            raise LEPProtocolError("LEP server closed the stream unexpectedly")
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise LEPProtocolError(f"LEP server emitted non-JSON: {line!r}") from exc
+        return (parsed or {}).get("result") or {}
+
+    def _decision(
+        self,
+        slot: str,
+        *,
+        state: Any = None,
+        session_log: Any = None,
+        tool_call: Any = None,
+        tool_result: Any = None,
+        step: int | None = None,
+        usage: Any = None,
+    ) -> HookDecision | None:
+        """Run one slot remotely and reconstruct its effect.
+
+        On any transport/protocol failure, applies ``on_failure`` rather
+        than propagating — an out-of-process hook must never crash the
+        host loop.
+        """
+        if self._proc is None:
+            return self._failure_decision(slot)
+        view = extract_view(
+            self._view,
+            state=state,
+            session_log=session_log,
+            tool_call=tool_call,
+            tool_result=tool_result,
+            step=step,
+            usage=usage,
+        )
+        event = {"slot": slot, "type": slot, "step": step or 0, "payload": view}
+        try:
+            result = self._rpc("loop/event", event)
+        except LEPProtocolError:
+            logger.warning("LEP slot %s failed; applying on_failure=%s", slot, self._on_failure)
+            return self._failure_decision(slot)
+        effect = (result or {}).get("effect")
+        try:
+            return HookDecision.from_wire(effect)
+        except (TypeError, ValueError):
+            logger.warning("LEP slot %s returned malformed effect %r", slot, effect)
+            return self._failure_decision(slot)
+
+    def _failure_decision(self, slot: str) -> HookDecision | None:
+        if self._on_failure == "fail_open" or self._on_failure == "continue":
+            return None
+        # fail_closed: deny tool calls / block done; no-opinion elsewhere.
+        if slot in ("pre_dispatch", "check_permission"):
+            return HookDecision(permission="deny", block="policy server unavailable")
+        if slot == "check_done":
+            return HookDecision(block="policy server unavailable")
+        return None
+
+    # ── lifecycle: session open ──────────────────────────────────
+    @staticmethod
+    def _server_env() -> dict[str, str]:
+        """Child env that guarantees a Python LEP server can ``import looplet``.
+
+        A Python policy server typically does
+        ``from looplet.lep import LEPServerBase``. When looplet runs from a
+        source checkout (not pip-installed into the child's site-packages),
+        the package dir is only on the *host's* ``sys.path`` — the spawned
+        interpreter would not find it. We prepend the directory that
+        contains the ``looplet`` package to the child's ``PYTHONPATH`` so
+        the import resolves regardless of how the host obtained looplet.
+        Non-Python servers simply ignore the variable.
+        """
+        env = dict(os.environ)
+        pkg_parent = str(Path(__file__).resolve().parent.parent)
+        existing = env.get("PYTHONPATH", "")
+        parts = [pkg_parent] + ([existing] if existing else [])
+        env["PYTHONPATH"] = os.pathsep.join(parts)
+        return env
+
+    def pre_loop(self, state: Any, session_log: Any, context: Any) -> None:
+        self._proc = subprocess.Popen(  # noqa: S603 - argv is operator-supplied
+            self._argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            env=self._server_env(),
+        )
+        try:
+            self.capabilities = self._rpc(
+                "loop/initialize",
+                {
+                    "cartridge_id": self._cartridge_id,
+                    "run_id": self._run_id,
+                    "lep_version": LEP_VERSION,
+                    "view": self._view.to_dict(),
+                },
+            )
+        except LEPProtocolError:
+            logger.warning("LEP initialize failed; hook will apply on_failure")
+            self.capabilities = {}
+
+    # ── slot: pre_prompt → briefing injection ────────────────────
+    def pre_prompt(self, state: Any, session_log: Any, context: Any, step_num: int) -> str | None:
+        decision = self._decision("pre_prompt", state=state, session_log=session_log, step=step_num)
+        return decision.additional_context if decision else None
+
+    # ── slot: pre_dispatch → intercept / cache / deny ────────────
+    def pre_dispatch(
+        self, state: Any, session_log: Any, tool_call: Any, step_num: int
+    ) -> ToolResult | HookDecision | None:
+        decision = self._decision(
+            "pre_dispatch",
+            state=state,
+            session_log=session_log,
+            tool_call=tool_call,
+            step=step_num,
+        )
+        if decision is None:
+            return None
+        if decision.updated_result is not None:
+            return decision.updated_result
+        if decision.is_block():
+            return decision
+        return None
+
+    # ── slot: check_permission → allow / deny ────────────────────
+    def check_permission(self, tool_call: Any, state: Any) -> bool:
+        decision = self._decision("check_permission", state=state, tool_call=tool_call)
+        if decision is None:
+            return True
+        return not decision.is_block()
+
+    # ── slot: post_dispatch → follow-up context ──────────────────
+    def post_dispatch(
+        self, state: Any, session_log: Any, tool_call: Any, tool_result: Any, step_num: int
+    ) -> str | None:
+        decision = self._decision(
+            "post_dispatch",
+            state=state,
+            session_log=session_log,
+            tool_call=tool_call,
+            tool_result=tool_result,
+            step=step_num,
+        )
+        return decision.additional_context if decision else None
+
+    # ── slot: check_done → reject premature completion ───────────
+    def check_done(
+        self, state: Any, session_log: Any, context: Any, step_num: int, tool_call: Any = None
+    ) -> str | None:
+        decision = self._decision(
+            "check_done",
+            state=state,
+            session_log=session_log,
+            tool_call=tool_call,
+            step=step_num,
+        )
+        return decision.block if decision else None
+
+    # ── slot: should_stop → force early termination ──────────────
+    def should_stop(self, state: Any, step_num: int, new_entities: int) -> bool:
+        decision = self._decision("should_stop", state=state, step=step_num)
+        return bool(decision and decision.is_stop())
+
+    # ── lifecycle: session close ─────────────────────────────────
+    def on_loop_end(self, *args: Any, **kwargs: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            self._rpc("loop/shutdown", {"run_id": self._run_id, "outcome": "ok"})
+        except Exception:  # pragma: no cover - best effort
+            pass
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except Exception:  # pragma: no cover - best effort
+            pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:  # pragma: no cover - best effort
+            proc.kill()
+        self._proc = None
+
+
+def server_argv(server_path: str, *args: str) -> list[str]:
+    """Build argv to launch a Python LEP server with this interpreter."""
+    return [sys.executable, server_path, *args]
+
+
+class LEPServerBase:
+    """Base class for writing a Python LEP policy server.
+
+    Subclasses set :attr:`slots`/:attr:`effects` (for the
+    ``loop/initialize`` capability advertisement) and implement
+    :meth:`decide`. Call :meth:`serve` from ``__main__`` to run the
+    stdin/stdout JSON-RPC loop. Nothing else from looplet is required —
+    a subclass may import :class:`HookDecision` for convenience, or
+    return a raw effect dict to stay dependency-free like a Rust server.
+    """
+
+    slots: tuple[str, ...] = (
+        "pre_prompt",
+        "pre_dispatch",
+        "check_permission",
+        "post_dispatch",
+        "check_done",
+        "should_stop",
+    )
+    effects: tuple[str, ...] = (
+        "Continue",
+        "Allow",
+        "Deny",
+        "Block",
+        "Stop",
+        "InjectContext",
+        "UpdateArgs",
+        "UpdateResult",
+        "HookDecision",
+    )
+    view_fields: tuple[str, ...] = ("tool", "args")
+    view_fidelity: str = "digest"
+    defaults: dict[str, str] = {"check_permission": "fail_closed", "check_done": "fail_closed"}
+
+    def initialize(self, params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG002
+        return {
+            "server_capabilities": {"slots": list(self.slots), "effects": list(self.effects)},
+            "view_subscription": {"fields": list(self.view_fields), "fidelity": self.view_fidelity},
+            "defaults": dict(self.defaults),
+        }
+
+    def decide(self, slot: str, view: dict[str, Any]) -> Any:  # pragma: no cover - abstract
+        """Return a :class:`HookDecision`, an effect dict, or ``None``."""
+        raise NotImplementedError
+
+    def _effect_dict(self, decision: Any) -> dict[str, Any]:
+        if decision is None:
+            return {"kind": "Continue"}
+        if isinstance(decision, HookDecision):
+            return decision.to_wire()
+        if isinstance(decision, dict):
+            return decision
+        raise TypeError(
+            f"decide() returned {type(decision).__name__}; expected HookDecision|dict|None"
+        )
+
+    def serve(self, stdin: Any = None, stdout: Any = None) -> int:
+        stdin = stdin or sys.stdin
+        out = stdout or sys.stdout
+        for line in stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                req = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(req, dict):
+                continue
+            method = req.get("method")
+            rid = req.get("id")
+            params = req.get("params") or {}
+            if method == "loop/initialize":
+                result: dict[str, Any] = self.initialize(params)
+            elif method == "loop/event":
+                result = {
+                    "effect": self._effect_dict(
+                        self.decide(params.get("slot", ""), params.get("payload") or {})
+                    )
+                }
+            elif method == "loop/shutdown":
+                result = {"ok": True}
+            else:
+                result = {"error": f"unknown method {method!r}"}
+            out.write(json.dumps({"id": rid, "result": result}) + "\n")
+            out.flush()
+            if method == "loop/shutdown":
+                break
+        return 0

--- a/src/looplet/model_gateway.py
+++ b/src/looplet/model_gateway.py
@@ -1,0 +1,423 @@
+"""Model Gateway Protocol (MGP) — the portable host-LLM access primitive.
+
+``mcp_servers:`` makes *tools* portable (a tool body runs out-of-process
+over MCP). ``kind: lep`` makes *hooks* portable (a hook's policy runs
+out-of-process over LEP). ``state_services:`` (SSP) makes *shared mutable
+state* portable (a 1:N socket server both tools and hooks connect to).
+
+All three move a component out of the host's Python address space — and
+in doing so they sever the one ambient capability an in-process tool took
+for granted: **``ctx.llm``, the host's LLM backend.** An in-process tool
+that wants to summarise/classify/extract just calls
+``ctx.llm.generate(...)``; an out-of-process MCP tool has no such handle,
+so it silently degrades (``dep_doctor``'s ``find_alternatives`` returns an
+empty list, ``threat_intel``'s ``extract_iocs`` drops its severity field,
+etc.). That degradation is exactly the gap this primitive closes.
+
+A model gateway is the missing sibling: a **1:N server that owns the live
+LLM backend in the *host* process** and exposes ``generate`` over a Unix
+domain socket. Out-of-process tool servers (MCP) and hook servers (LEP)
+both *connect* to the same socket, so the LLM they share lives behind a
+protocol rather than in one Python address space. A portable tool can
+therefore call back into the *same* model the loop is driving — restoring
+functional and qualitative parity with the in-process original, with no
+Python pinned on the tool side (a Rust/Go/TS MCP server would speak only
+the wire).
+
+Unlike SSP/LEP/MCP servers — which the loader *spawns* as subprocesses —
+the gateway server runs **in the host process** (a daemon thread): the
+LLM backend is a host object that cannot be serialised across a fork. The
+loader allocates the socket path and exports it as ``LOOPLET_LLM_SOCKET``
+*before* spawning any out-of-process server, so every child inherits it
+and can connect lazily on its first ``generate`` call. The backend is
+bound at *run* time (``AgentPreset.run(llm)``), so until a run is active —
+or in a headless/test dispatch — the gateway reports "no backend" and the
+tool falls back to its documented ``ctx.llm is None`` branch.
+
+Three pieces, mirroring :mod:`looplet.state_service`:
+
+* :class:`ModelGatewayServer` — owns the backend, serves clients. Holds a
+  settable ``backend`` slot; nothing else from looplet is required to
+  re-implement it in another language (the wire is the contract).
+* :class:`ModelGatewayClient` — an in-process proxy. ``client.generate(
+  prompt, max_tokens=...)`` forwards over the socket. Portable MCP/LEP
+  servers that want to stay stdlib-only can inline an equivalent ~30-line
+  client instead of importing looplet.
+* :class:`ModelGatewayHandle` — allocates the socket, starts the host
+  daemon thread, exports ``LOOPLET_LLM_SOCKET``, and owns teardown.
+
+Wire format (line-delimited JSON over ``AF_UNIX`` ``SOCK_STREAM``):
+
+    → {"id": 1, "method": "llm/initialize"}
+    ← {"id": 1, "result": {"mgp_version": "0.1", "ready": true}}
+    → {"id": 2, "method": "llm/generate",
+       "params": {"prompt": "Classify ...", "kwargs": {"max_tokens": 20}}}
+    ← {"id": 2, "result": {"text": "HIGH"}}
+       (or {"id": 2, "error": {"message": "no LLM backend is bound"}})
+    → {"id": 3, "method": "llm/shutdown"}
+    ← {"id": 3, "result": {"ok": true}}
+
+The gateway bridges ``generate`` only — the documented ``ctx.llm`` surface
+for *tool-internal* single calls (summarise, classify, extract). The
+loop's own multi-turn ``generate_with_tools`` orchestration is not a tool
+concern and is intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MGP_VERSION",
+    "LLM_SOCKET_ENV_VAR",
+    "ModelGatewayError",
+    "ModelGatewayServer",
+    "ModelGatewayClient",
+    "ModelGatewayHandle",
+]
+
+MGP_VERSION = "0.1"
+
+#: Env var the loader sets so out-of-process MCP tool / LEP hook servers
+#: know where to connect to reach the host's LLM backend.
+LLM_SOCKET_ENV_VAR = "LOOPLET_LLM_SOCKET"
+
+
+class ModelGatewayError(RuntimeError):
+    """Raised when the model-gateway transport breaks or a call fails."""
+
+
+def _send_line(sock: socket.socket, obj: dict[str, Any]) -> None:
+    sock.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+
+class _LineReader:
+    """Buffered line reader over a stream socket (one per connection)."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._buf = b""
+
+    def readline(self) -> str | None:
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                if self._buf:
+                    line, self._buf = self._buf, b""
+                    return line.decode("utf-8")
+                return None
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return line.decode("utf-8")
+
+
+# ── server ────────────────────────────────────────────────────
+
+
+class ModelGatewayServer:
+    """Host-resident server exposing a (settable) LLM backend over a socket.
+
+    Unlike :class:`looplet.state_service.StateServiceBase`, this server is
+    not spawned as a subprocess — it runs in the *host* process (via
+    :class:`ModelGatewayHandle`), because the LLM backend is a live host
+    object. The :attr:`backend` slot is bound at run time; until then
+    ``llm/generate`` returns an error and out-of-process callers degrade
+    to their ``ctx.llm is None`` branch.
+
+    Every call is serialised under a single lock so concurrent clients
+    (multiple out-of-process tools) cannot interleave on a backend that
+    may not be re-entrant.
+    """
+
+    def __init__(self, backend: Any = None) -> None:
+        self._backend = backend
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._srv: socket.socket | None = None
+
+    @property
+    def backend(self) -> Any:
+        return self._backend
+
+    @backend.setter
+    def backend(self, value: Any) -> None:
+        self._backend = value
+
+    def set_backend(self, backend: Any) -> None:
+        """Bind (or replace) the live LLM backend the gateway exposes."""
+        self._backend = backend
+
+    # -- serving -------------------------------------------------------
+    def serve(self, socket_path: str) -> int:
+        """Bind a Unix domain socket and serve clients until shutdown."""
+        if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - non-POSIX
+            raise ModelGatewayError("model gateway requires AF_UNIX sockets")
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(socket_path)
+        srv.listen(16)
+        srv.settimeout(0.5)
+        self._srv = srv
+        try:
+            while not self._stop.is_set():
+                try:
+                    conn, _ = srv.accept()
+                except socket.timeout:
+                    continue
+                except OSError:  # pragma: no cover - socket closed on stop
+                    break
+                threading.Thread(target=self._serve_conn, args=(conn,), daemon=True).start()
+        finally:
+            srv.close()
+            self._srv = None
+            if os.path.exists(socket_path):
+                try:
+                    os.unlink(socket_path)
+                except OSError:  # pragma: no cover - best effort
+                    pass
+        return 0
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _serve_conn(self, conn: socket.socket) -> None:
+        reader = _LineReader(conn)
+        try:
+            while not self._stop.is_set():
+                line = reader.readline()
+                if line is None:
+                    return
+                line = line.strip()
+                if not line:
+                    continue
+                self._handle_line(conn, line)
+        except (OSError, ValueError):  # pragma: no cover - client gone
+            return
+        finally:
+            try:
+                conn.close()
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+    def _handle_line(self, conn: socket.socket, line: str) -> None:
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(req, dict):
+            return
+        rid = req.get("id")
+        method = req.get("method")
+        params = req.get("params") or {}
+        try:
+            if method == "llm/initialize":
+                result: dict[str, Any] = {
+                    "mgp_version": MGP_VERSION,
+                    "ready": self._backend is not None,
+                }
+            elif method == "llm/generate":
+                text = self._generate(
+                    str(params.get("prompt", "")),
+                    dict(params.get("kwargs") or {}),
+                )
+                result = {"text": text}
+            elif method == "llm/shutdown":
+                self._stop.set()
+                result = {"ok": True}
+            else:
+                _send_line(
+                    conn,
+                    {"id": rid, "error": {"message": f"unknown method {method!r}"}},
+                )
+                return
+        except Exception as exc:  # noqa: BLE001 — report, never crash the server
+            _send_line(conn, {"id": rid, "error": {"message": str(exc)}})
+            return
+        _send_line(conn, {"id": rid, "result": result})
+
+    def _generate(self, prompt: str, kwargs: dict[str, Any]) -> str:
+        with self._lock:
+            backend = self._backend
+            if backend is None:
+                raise ModelGatewayError("no LLM backend is bound")
+            out = backend.generate(prompt, **kwargs)
+        return out if isinstance(out, str) else str(out)
+
+
+# ── client ────────────────────────────────────────────────────
+
+
+class ModelGatewayClient:
+    """In-process proxy to a :class:`ModelGatewayServer` over a socket.
+
+    ``client.generate(prompt, max_tokens=20)`` forwards to the host
+    backend. Calls are serialised with an internal lock so a single
+    client can be shared across threads. Construct from an explicit path
+    or from the ``LOOPLET_LLM_SOCKET`` env var via :meth:`from_env`.
+    """
+
+    def __init__(self, socket_path: str, *, connect_timeout: float = 10.0) -> None:
+        self._path = socket_path
+        self._lock = threading.Lock()
+        self._next_id = 0
+        self._sock = self._connect(socket_path, connect_timeout)
+        self._reader = _LineReader(self._sock)
+        self.ready = False
+        try:
+            init = self._rpc("llm/initialize", {})
+            self.ready = bool(init.get("ready"))
+        except ModelGatewayError:  # pragma: no cover - tolerated
+            self.ready = False
+
+    @classmethod
+    def from_env(cls, *, connect_timeout: float = 10.0) -> "ModelGatewayClient | None":
+        """Build a client from ``$LOOPLET_LLM_SOCKET``; ``None`` if unset/down."""
+        path = os.environ.get(LLM_SOCKET_ENV_VAR)
+        if not path:
+            return None
+        try:
+            return cls(path, connect_timeout=connect_timeout)
+        except ModelGatewayError:
+            return None
+
+    @staticmethod
+    def _connect(path: str, timeout: float) -> socket.socket:
+        if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - non-POSIX
+            raise ModelGatewayError("model gateway requires AF_UNIX sockets")
+        deadline = time.monotonic() + timeout
+        last_exc: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(path)
+                return sock
+            except OSError as exc:
+                last_exc = exc
+                time.sleep(0.02)
+        raise ModelGatewayError(f"could not connect to model gateway at {path!r}: {last_exc}")
+
+    @property
+    def socket_path(self) -> str:
+        return self._path
+
+    def _rpc(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self._next_id += 1
+            rid = self._next_id
+            try:
+                _send_line(self._sock, {"id": rid, "method": method, "params": params})
+                line = self._reader.readline()
+            except OSError as exc:
+                raise ModelGatewayError(f"gateway transport failed: {exc}") from exc
+            if line is None:
+                raise ModelGatewayError("model gateway closed the connection")
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise ModelGatewayError(f"model gateway emitted non-JSON: {line!r}") from exc
+            if not isinstance(parsed, dict):  # pragma: no cover - defensive
+                raise ModelGatewayError("malformed model-gateway response")
+            if parsed.get("error"):
+                raise ModelGatewayError(str(parsed["error"].get("message", "error")))
+            return parsed.get("result") or {}
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Forward a single-call generation to the host backend."""
+        result = self._rpc("llm/generate", {"prompt": prompt, "kwargs": kwargs})
+        return str(result.get("text", ""))
+
+    def close(self) -> None:
+        try:
+            self._sock.close()
+        except OSError:  # pragma: no cover - best effort
+            pass
+
+
+# ── launcher / handle ─────────────────────────────────────────
+
+
+class ModelGatewayHandle:
+    """Owns a host-resident gateway server thread plus its socket.
+
+    The loader creates one of these (via :meth:`start`) when a cartridge
+    declares out-of-process tool servers, *before* spawning them, so the
+    socket path is exported as ``LOOPLET_LLM_SOCKET`` and inherited by
+    every child. The backend is bound later — at run time — via
+    :meth:`set_backend`.
+    """
+
+    def __init__(
+        self,
+        server: ModelGatewayServer,
+        socket_path: str,
+        socket_dir: str,
+        thread: threading.Thread,
+    ) -> None:
+        self.server = server
+        self.socket_path = socket_path
+        self._socket_dir = socket_dir
+        self._thread = thread
+
+    @classmethod
+    def start(cls, *, backend: Any = None, export_env: bool = True) -> "ModelGatewayHandle":
+        """Allocate a socket, start the host server thread, export the env var.
+
+        Args:
+            backend: Optional initial LLM backend (usually ``None``; bound
+                later at run time).
+            export_env: When true (default), set ``LOOPLET_LLM_SOCKET`` in
+                ``os.environ`` so subsequently-spawned children inherit it.
+        """
+        if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - non-POSIX
+            raise ModelGatewayError("model gateway requires AF_UNIX sockets")
+        socket_dir = tempfile.mkdtemp(prefix="looplet-llm-")
+        socket_path = os.path.join(socket_dir, "gateway.sock")
+        server = ModelGatewayServer(backend=backend)
+        thread = threading.Thread(target=server.serve, args=(socket_path,), daemon=True)
+        thread.start()
+        # Wait briefly for the socket to appear so children that spawn
+        # immediately can connect on first use.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not os.path.exists(socket_path):
+            time.sleep(0.01)
+        if export_env:
+            os.environ[LLM_SOCKET_ENV_VAR] = socket_path
+        return cls(server, socket_path, socket_dir, thread)
+
+    def set_backend(self, backend: Any) -> None:
+        """Bind the live LLM backend the gateway exposes to its clients."""
+        self.server.set_backend(backend)
+
+    def close(self) -> None:
+        self.server.stop()
+        try:
+            self._thread.join(timeout=2.0)
+        except Exception:  # pragma: no cover - best effort
+            pass
+        # Drop the env var if it still points at our socket.
+        if os.environ.get(LLM_SOCKET_ENV_VAR) == self.socket_path:
+            os.environ.pop(LLM_SOCKET_ENV_VAR, None)
+        for p in (self.socket_path, self._socket_dir):
+            try:
+                if os.path.isdir(p):
+                    os.rmdir(p)
+                elif os.path.exists(p):
+                    os.unlink(p)
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+
+def _pkg_parent() -> str:  # pragma: no cover - parity helper with SSP
+    """Return the directory to add to PYTHONPATH for a source checkout."""
+    return str(Path(__file__).resolve().parent.parent)

--- a/src/looplet/presets.py
+++ b/src/looplet/presets.py
@@ -94,11 +94,69 @@ class AgentPreset:
     and for presets constructed directly in code.
     """
 
-    def close(self) -> None:
-        """Terminate all MCP server subprocesses owned by this preset.
+    builtin_tool_names: list[str] = field(default_factory=list)
+    """Names of looplet-shipped tools enabled via ``builtin_tools:`` in
+    ``config.yaml`` (e.g. ``subagent``).
 
-        Safe to call multiple times. Exceptions during close are logged
-        and swallowed so one misbehaving server cannot block the rest.
+    Recorded so :func:`looplet.cartridge.preset_to_cartridge` can
+    re-emit the ``builtin_tools:`` directive instead of trying to
+    serialise the builtin's source (which would lose its loader-provided
+    resources like ``workspace_config``). Empty for presets built in
+    code or cartridges that declare no builtin tools.
+    """
+
+    mcp_servers: dict[str, Any] = field(default_factory=dict)
+    """The ``mcp_servers:`` block (server name → config) from
+    ``config.yaml``, with ``${runtime.*}`` placeholders already resolved.
+
+    Recorded so :func:`looplet.cartridge.preset_to_cartridge` can
+    re-emit the directive (and skip the MCP-discovered tools, whose
+    executors are closures that cannot round-trip to disk). Empty for
+    presets built in code or cartridges that declare no MCP servers.
+    """
+
+    state_service_handles: list[Any] = field(default_factory=list)
+    """Live :class:`looplet.state_service.StateServiceHandle` instances
+    spawned by the cartridge loader, one per ``state_services:`` entry in
+    ``config.yaml``.
+
+    Each handle owns a shared-mutable-state server subprocess (behind a
+    Unix socket). Call :meth:`close` (or use the preset as a context
+    manager) to terminate them cleanly. Empty for cartridges that declare
+    no state services and for presets constructed directly in code.
+    """
+
+    state_services: dict[str, Any] = field(default_factory=dict)
+    """The ``state_services:`` block (service name → config) from
+    ``config.yaml``, with ``${runtime.*}`` placeholders already resolved.
+
+    Recorded so :func:`looplet.cartridge.preset_to_cartridge` can re-emit
+    the directive (the injected :class:`StateServiceClient` is a live
+    socket proxy that cannot round-trip to disk). Empty for presets built
+    in code or cartridges that declare no state services.
+    """
+
+    model_gateway: Any = None
+    """Live :class:`looplet.model_gateway.ModelGatewayHandle` started by
+    the cartridge loader when the cartridge declares out-of-process tool
+    servers (``mcp_servers:``) and ``llm_gateway`` is not disabled.
+
+    The gateway exposes the loop's LLM backend to those out-of-process
+    tools (and LEP hooks) over a Unix socket so they can call
+    ``ctx.llm.generate(...)`` instead of degrading. The backend is bound
+    at run time by :meth:`run` (``set_backend(llm)``); until then the
+    gateway reports "no backend" and tools fall back gracefully. ``None``
+    for cartridges with no out-of-process tools, presets built in code,
+    or when ``llm_gateway: false`` is set.
+    """
+
+    def close(self) -> None:
+        """Terminate all subprocesses owned by this preset.
+
+        Covers both ``mcp_servers:`` adapters and ``state_services:``
+        handles. Safe to call multiple times. Exceptions during close are
+        logged and swallowed so one misbehaving server cannot block the
+        rest.
         """
         for adapter in self.mcp_adapters:
             try:
@@ -108,6 +166,24 @@ class AgentPreset:
 
                 logging.getLogger(__name__).warning("error closing MCP adapter", exc_info=True)
         self.mcp_adapters = []
+        for handle in self.state_service_handles:
+            try:
+                handle.close()
+            except Exception:  # pragma: no cover - defensive
+                import logging  # noqa: PLC0415
+
+                logging.getLogger(__name__).warning(
+                    "error closing state service handle", exc_info=True
+                )
+        self.state_service_handles = []
+        if self.model_gateway is not None:
+            try:
+                self.model_gateway.close()
+            except Exception:  # pragma: no cover - defensive
+                import logging  # noqa: PLC0415
+
+                logging.getLogger(__name__).warning("error closing model gateway", exc_info=True)
+            self.model_gateway = None
 
     def __enter__(self) -> "AgentPreset":
         return self
@@ -137,6 +213,19 @@ class AgentPreset:
         Returns the loop generator — iterate to drive the agent.
         """
         from looplet.loop import composable_loop  # noqa: PLC0415
+
+        # Bind the live LLM backend to the model gateway (if any) so
+        # out-of-process MCP tools / LEP hooks can reach the same model
+        # this run is driving, instead of degrading ``ctx.llm`` to None.
+        if self.model_gateway is not None:
+            try:
+                self.model_gateway.set_backend(llm)
+            except Exception:  # pragma: no cover - defensive
+                import logging  # noqa: PLC0415
+
+                logging.getLogger(__name__).warning(
+                    "error binding LLM backend to model gateway", exc_info=True
+                )
 
         return composable_loop(
             llm=llm,

--- a/src/looplet/state_service.py
+++ b/src/looplet/state_service.py
@@ -1,0 +1,433 @@
+"""State Service Protocol (SSP) — the portable shared-mutable-state primitive.
+
+``mcp_servers:`` makes *tools* portable (a tool body runs out-of-process
+over MCP). ``kind: lep`` makes *hooks* portable (a hook's policy runs
+out-of-process over LEP). Both are **1:1** stdio bridges: one parent, one
+child. Neither can express the last in-process coupling the portability
+report flags — **shared mutable state** that two *different* components
+read and write (e.g. ``hello``'s greeting log, which the ``greet`` tool
+appends to and the ``PolitenessGate`` hook reads to gate ``done()``).
+
+A state service is the missing sibling: a **1:N** server that owns a piece
+of mutable state in its own process and exposes named methods over a Unix
+domain socket. The (now out-of-process) tool server and hook server both
+*connect* to the same socket, so the state they share lives behind a
+protocol rather than in one Python address space. That is exactly what
+flips a ``@ref`` shared object from the ``inprocess`` tier (Python-pinned)
+to the ``protocol`` tier (any conforming loader can spawn the server and
+point its own tools/hooks at the socket).
+
+Three pieces, mirroring :mod:`looplet.lep`:
+
+* :class:`StateServiceBase` — subclass, define public methods, call
+  :meth:`StateServiceBase.serve`. Holds the state; nothing else from
+  looplet is required (a Rust/Go server would speak only the wire).
+* :class:`StateServiceClient` — an in-process proxy. ``client.record(...)``
+  forwards to the server over the socket; the loader injects one into the
+  resource registry under the service's name, so existing ``@ref`` /
+  ``requires:`` wiring resolves to it unchanged.
+* :class:`StateServiceHandle` — spawns a server, waits for its socket,
+  and owns the client + teardown.
+
+Wire format (line-delimited JSON over ``AF_UNIX`` ``SOCK_STREAM``):
+
+    → {"id": 1, "method": "state/initialize"}
+    ← {"id": 1, "result": {"methods": ["record", "names", "entries"]}}
+    → {"id": 2, "method": "state/call",
+       "params": {"name": "record", "args": ["Ada"], "kwargs": {"text": "Hi"}}}
+    ← {"id": 2, "result": {"value": null}}
+    → {"id": 3, "method": "state/shutdown"}
+    ← {"id": 3, "result": {"ok": true}}
+
+The server reads its socket path from the ``LOOPLET_STATE_SOCKET`` env var
+(set by the launcher) so the same ``command:`` works regardless of where
+the loader places the socket.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SSP_VERSION",
+    "StateServiceBase",
+    "StateServiceClient",
+    "StateServiceError",
+    "StateServiceHandle",
+    "SOCKET_ENV_VAR",
+]
+
+SSP_VERSION = "0.1"
+
+#: Env var the launcher sets so a spawned server knows where to bind and
+#: so out-of-process tool/hook servers know where to connect.
+SOCKET_ENV_VAR = "LOOPLET_STATE_SOCKET"
+
+#: Per-service env var prefix: ``LOOPLET_STATE_<NAME>`` carries the socket
+#: path for service ``<name>`` to clients that share several services.
+PER_SERVICE_ENV_PREFIX = "LOOPLET_STATE_"
+
+
+class StateServiceError(RuntimeError):
+    """Raised when the state-service transport breaks or a call fails."""
+
+
+def _send_line(sock: socket.socket, obj: dict[str, Any]) -> None:
+    sock.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+
+class _LineReader:
+    """Buffered line reader over a stream socket (one per connection)."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._buf = b""
+
+    def readline(self) -> str | None:
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                if self._buf:
+                    line, self._buf = self._buf, b""
+                    return line.decode("utf-8")
+                return None
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return line.decode("utf-8")
+
+
+# ── server ────────────────────────────────────────────────────
+
+
+class StateServiceBase:
+    """Base class for a shared-mutable-state server.
+
+    Subclass it, define public methods (any callable not starting with
+    ``_`` and not one of the framework methods), and call :meth:`serve`
+    from ``__main__``. Every method call is serialized under a single
+    lock, so subclasses may keep ordinary (non-thread-safe) Python state
+    — the lock makes concurrent client access safe by construction.
+    """
+
+    #: Method names that belong to the framework and are never exposed
+    #: as callable state operations.
+    _RESERVED = frozenset({"serve", "shutdown_requested"})
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+
+    # -- introspection -------------------------------------------------
+    def _public_methods(self) -> list[str]:
+        out = []
+        for name in dir(self):
+            if name.startswith("_") or name in self._RESERVED:
+                continue
+            if callable(getattr(self, name, None)):
+                out.append(name)
+        return sorted(out)
+
+    def _dispatch(self, name: str, args: list[Any], kwargs: dict[str, Any]) -> Any:
+        if name.startswith("_") or name in self._RESERVED:
+            raise StateServiceError(f"method {name!r} is not callable")
+        fn: Callable[..., Any] | None = getattr(self, name, None)
+        if not callable(fn):
+            raise StateServiceError(f"unknown state method {name!r}")
+        with self._lock:
+            return fn(*args, **kwargs)
+
+    # -- serving -------------------------------------------------------
+    def serve(self, socket_path: str | None = None) -> int:
+        """Bind a Unix domain socket and serve clients until shutdown.
+
+        Args:
+            socket_path: Where to bind. Defaults to ``$LOOPLET_STATE_SOCKET``.
+        """
+        if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - non-POSIX
+            raise StateServiceError("state services require AF_UNIX sockets")
+        path = socket_path or os.environ.get(SOCKET_ENV_VAR)
+        if not path:
+            raise StateServiceError(f"no socket path given and {SOCKET_ENV_VAR} is unset")
+        if os.path.exists(path):
+            os.unlink(path)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(path)
+        srv.listen(16)
+        srv.settimeout(0.5)
+        try:
+            while not self._stop.is_set():
+                try:
+                    conn, _ = srv.accept()
+                except socket.timeout:
+                    continue
+                threading.Thread(target=self._serve_conn, args=(conn,), daemon=True).start()
+        finally:
+            srv.close()
+            if os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except OSError:  # pragma: no cover - best effort
+                    pass
+        return 0
+
+    def _serve_conn(self, conn: socket.socket) -> None:
+        reader = _LineReader(conn)
+        try:
+            while not self._stop.is_set():
+                line = reader.readline()
+                if line is None:
+                    return
+                line = line.strip()
+                if not line:
+                    continue
+                self._handle_line(conn, line)
+        except (OSError, ValueError):  # pragma: no cover - client gone
+            return
+        finally:
+            try:
+                conn.close()
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+    def _handle_line(self, conn: socket.socket, line: str) -> None:
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(req, dict):
+            return
+        rid = req.get("id")
+        method = req.get("method")
+        params = req.get("params") or {}
+        try:
+            if method == "state/initialize":
+                result: dict[str, Any] = {
+                    "ssp_version": SSP_VERSION,
+                    "methods": self._public_methods(),
+                }
+            elif method == "state/call":
+                value = self._dispatch(
+                    str(params.get("name", "")),
+                    list(params.get("args") or []),
+                    dict(params.get("kwargs") or {}),
+                )
+                result = {"value": value}
+            elif method == "state/shutdown":
+                self._stop.set()
+                result = {"ok": True}
+            else:
+                _send_line(
+                    conn,
+                    {"id": rid, "error": {"message": f"unknown method {method!r}"}},
+                )
+                return
+        except Exception as exc:  # noqa: BLE001 — report, never crash the server
+            _send_line(conn, {"id": rid, "error": {"message": str(exc)}})
+            return
+        _send_line(conn, {"id": rid, "result": result})
+
+
+# ── client ────────────────────────────────────────────────────
+
+
+class StateServiceClient:
+    """In-process proxy to a :class:`StateServiceBase` over a socket.
+
+    ``client.record("Ada", text="Hi")`` forwards to the server's
+    ``record`` method. Calls are serialized with an internal lock so a
+    single client instance can be shared across loop threads (e.g. under
+    ``concurrent_dispatch``).
+    """
+
+    def __init__(self, socket_path: str, *, connect_timeout: float = 10.0) -> None:
+        self._path = socket_path
+        self._lock = threading.Lock()
+        self._next_id = 0
+        self._sock = self._connect(socket_path, connect_timeout)
+        self._reader = _LineReader(self._sock)
+        self.methods: list[str] = []
+        try:
+            init = self._rpc("state/initialize", {})
+            self.methods = list(init.get("methods") or [])
+        except StateServiceError:  # pragma: no cover - tolerated
+            self.methods = []
+
+    @staticmethod
+    def _connect(path: str, timeout: float) -> socket.socket:
+        if not hasattr(socket, "AF_UNIX"):  # pragma: no cover - non-POSIX
+            raise StateServiceError("state services require AF_UNIX sockets")
+        deadline = time.monotonic() + timeout
+        last_exc: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(path)
+                return sock
+            except OSError as exc:
+                last_exc = exc
+                time.sleep(0.02)
+        raise StateServiceError(f"could not connect to state service at {path!r}: {last_exc}")
+
+    @property
+    def socket_path(self) -> str:
+        return self._path
+
+    def _rpc(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self._next_id += 1
+            rid = self._next_id
+            try:
+                _send_line(self._sock, {"id": rid, "method": method, "params": params})
+                line = self._reader.readline()
+            except OSError as exc:
+                raise StateServiceError(f"state transport failed: {exc}") from exc
+            if line is None:
+                raise StateServiceError("state service closed the connection")
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise StateServiceError(f"state service emitted non-JSON: {line!r}") from exc
+            if not isinstance(parsed, dict):  # pragma: no cover - defensive
+                raise StateServiceError("malformed state-service response")
+            if parsed.get("error"):
+                raise StateServiceError(str(parsed["error"].get("message", "error")))
+            return parsed.get("result") or {}
+
+    def call(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        """Invoke a server method by name; return its value."""
+        result = self._rpc("state/call", {"name": name, "args": list(args), "kwargs": kwargs})
+        return result.get("value")
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        # Only reached for attributes not found normally; expose every
+        # server method as ``client.<method>(...)``.
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def _method(*args: Any, **kwargs: Any) -> Any:
+            return self.call(name, *args, **kwargs)
+
+        return _method
+
+    def close(self) -> None:
+        try:
+            self._sock.close()
+        except OSError:  # pragma: no cover - best effort
+            pass
+
+
+# ── launcher / handle ─────────────────────────────────────────
+
+
+class StateServiceHandle:
+    """Owns a spawned state-service process plus a connected client."""
+
+    def __init__(
+        self,
+        name: str,
+        proc: subprocess.Popen[bytes],
+        client: StateServiceClient,
+        socket_path: str,
+        socket_dir: str,
+    ) -> None:
+        self.name = name
+        self.proc = proc
+        self.client = client
+        self.socket_path = socket_path
+        self._socket_dir = socket_dir
+
+    @staticmethod
+    def _server_env(socket_path: str, extra: dict[str, str] | None = None) -> dict[str, str]:
+        env = dict(os.environ)
+        # Guarantee a Python SSP server can ``import looplet`` from a
+        # source checkout (mirrors LEPHookAdapter._server_env).
+        pkg_parent = str(Path(__file__).resolve().parent.parent)
+        existing = env.get("PYTHONPATH", "")
+        parts = [pkg_parent] + ([existing] if existing else [])
+        env["PYTHONPATH"] = os.pathsep.join(parts)
+        env[SOCKET_ENV_VAR] = socket_path
+        if extra:
+            env.update(extra)
+        return env
+
+    @classmethod
+    def spawn(
+        cls,
+        command: str | list[str],
+        *,
+        name: str,
+        timeout_s: float = 10.0,
+        env: dict[str, str] | None = None,
+    ) -> "StateServiceHandle":
+        """Spawn a state-service server and connect a client to it.
+
+        Args:
+            command: argv (list) or a shell-style string to launch the
+                server. The server binds ``$LOOPLET_STATE_SOCKET``.
+            name: The service name (used for the socket filename + the
+                per-service env var passed to other servers).
+            timeout_s: How long to wait for the socket to come up.
+            env: Extra environment for the server process.
+        """
+        argv = shlex.split(command) if isinstance(command, str) else list(command)
+        if not argv:
+            raise StateServiceError(f"state service {name!r} has an empty command")
+        socket_dir = tempfile.mkdtemp(prefix=f"looplet-state-{name}-")
+        socket_path = os.path.join(socket_dir, f"{name}.sock")
+        proc = subprocess.Popen(  # noqa: S603 — argv is operator-supplied
+            argv,
+            stdin=subprocess.DEVNULL,
+            env=cls._server_env(socket_path, env),
+        )
+        try:
+            client = StateServiceClient(socket_path, connect_timeout=timeout_s)
+        except StateServiceError:
+            proc.terminate()
+            raise
+        return cls(name, proc, client, socket_path, socket_dir)
+
+    def close(self) -> None:
+        try:
+            self.client.call  # noqa: B018 — touch to ensure attr exists
+            self.client._rpc("state/shutdown", {})  # noqa: SLF001
+        except Exception:  # pragma: no cover - best effort
+            pass
+        try:
+            self.client.close()
+        except Exception:  # pragma: no cover - best effort
+            pass
+        proc = self.proc
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:  # pragma: no cover - best effort
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        for p in (self.socket_path, self._socket_dir):
+            try:
+                if os.path.isdir(p):
+                    os.rmdir(p)
+                elif os.path.exists(p):
+                    os.unlink(p)
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+
+def state_server_argv(server_path: str, *args: str) -> list[str]:
+    """Build argv to launch a Python SSP server with this interpreter."""
+    return [sys.executable, server_path, *args]

--- a/tests/test_cartridge.py
+++ b/tests/test_cartridge.py
@@ -413,10 +413,15 @@ def test_hello_workspace_loads_and_runs_end_to_end() -> None:
 
     assert preset.config.max_steps == 5
     assert "polite assistant" in preset.config.system_prompt.lower()
-    assert {type(h).__name__ for h in preset.hooks} == {"PolitenessGate"}
+    # PolitenessGate is the in-process @ref hook; NameGuard is the
+    # portable ``kind: lep`` out-of-process permission policy.
+    assert {type(h).__name__ for h in preset.hooks} == {
+        "PolitenessGate",
+        "LEPHookAdapter",
+    }
     assert sorted(preset.tools._tools.keys()) == ["done", "greet"]
 
-    hook = preset.hooks[0]
+    hook = next(h for h in preset.hooks if type(h).__name__ == "PolitenessGate")
     assert hasattr(hook, "log") and hasattr(hook.log, "entries")
     assert hook.log.entries == []
 
@@ -483,12 +488,15 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
     # Order: directory hooks (sorted by ``order:``) first, then
     # ``builtin_hooks:`` entries in declaration order, then the
     # auto-installed ``permissions:`` PermissionHook (v1.0 spec slot).
+    # ``08_ShellSafetyGate`` is the portable ``kind: lep`` guardrail and
+    # lands last among the directory hooks (after EvalHook).
     assert hook_names == [
         "TestGuardHook",
         "FileCacheHook",
         "StaleFileHook",
         "LinterHook",
         "EvalHook",
+        "LEPHookAdapter",
         "StagnationHook",
         "ThresholdCompactHook",
         "PerToolLimitHook",
@@ -563,6 +571,7 @@ def test_threat_intel_workspace_loads() -> None:
         "think",
     ]
     assert [type(h).__name__ for h in preset.hooks] == [
+        "LEPHookAdapter",
         "StagnationHook",
         "PerToolLimitHook",
     ]
@@ -586,6 +595,7 @@ def test_dep_doctor_workspace_loads() -> None:
         "think",
     ]
     assert [type(h).__name__ for h in preset.hooks] == [
+        "LEPHookAdapter",
         "StagnationHook",
         "PerToolLimitHook",
     ]
@@ -612,6 +622,7 @@ def test_git_detective_workspace_loads() -> None:
         "think",
     ]
     assert [type(h).__name__ for h in preset.hooks] == [
+        "LEPHookAdapter",
         "StagnationHook",
         "PerToolLimitHook",
     ]
@@ -754,12 +765,15 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
     # The 3 generic guards (Stagnation, ThresholdCompact, PerToolLimit)
     # are wired via ``builtin_hooks:`` and land at the end of the list.
     reloaded_names = [type(h).__name__ for h in reloaded.hooks]
+    # The portable ``kind: lep`` ShellSafetyGate round-trips too and
+    # keeps its position after EvalHook among the directory hooks.
     assert reloaded_names == [
         "TestGuardHook",
         "FileCacheHook",
         "StaleFileHook",
         "LinterHook",
         "EvalHook",
+        "LEPHookAdapter",
         "StagnationHook",
         "ThresholdCompactHook",
         "PerToolLimitHook",

--- a/tests/test_cartridge_hook_roundtrip.py
+++ b/tests/test_cartridge_hook_roundtrip.py
@@ -1,0 +1,127 @@
+"""Dogfood test for lossless cartridge⇄library round-trip of hooks.
+
+The "100% lossless" claim (HOOK_CARTRIDGE_DESIGN.md §9.0) means: a
+cartridge → library (preset) → cartridge → library round-trip preserves
+hook *behaviour*. This test exercises the linchpin case — a declarative
+``kind: lep`` hook — and asserts:
+
+* the serialiser emits a self-contained ``kind: lep`` config (server
+  script copied in, command rewritten relative);
+* reloading the serialised cartridge reproduces an ``LEPHookAdapter``
+  that enforces the *same* policy (rm denied, ls allowed);
+* the portability classifier labels it ``portable``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import looplet
+from looplet.cartridge import cartridge_to_preset, preset_to_cartridge
+from looplet.hook_contract import classify_preset_hooks
+from looplet.lep import LEPHookAdapter
+from looplet.types import ToolCall
+
+_SRC = str(Path(looplet.__file__).resolve().parent.parent)
+
+
+def _make_lep_cartridge(root: Path) -> Path:
+    """Author a minimal cartridge whose only hook is a ``kind: lep`` policy."""
+    import json
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "cartridge.json").write_text(
+        json.dumps({"name": "lep-rt", "schema_version": 2}), encoding="utf-8"
+    )
+    (root / "config.yaml").write_text("max_steps: 5\n", encoding="utf-8")
+    hook_dir = root / "hooks" / "00_policy"
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    (hook_dir / "config.yaml").write_text(
+        "kind: lep\n"
+        "server: server.py\n"
+        "view:\n"
+        "  fields: [tool, args]\n"
+        "  fidelity: digest\n"
+        "on_failure: fail_closed\n",
+        encoding="utf-8",
+    )
+    (hook_dir / "server.py").write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {_SRC!r})\n"
+        "from looplet.lep import LEPServerBase\n"
+        "\n"
+        "class PolicyServer(LEPServerBase):\n"
+        "    def decide(self, slot, view):\n"
+        "        if slot == 'check_permission' and view.get('tool') == 'rm':\n"
+        "            return {'kind': 'Deny', 'block': 'rm denied'}\n"
+        "        return {'kind': 'Continue'}\n"
+        "\n"
+        'if __name__ == "__main__":\n'
+        "    raise SystemExit(PolicyServer().serve())\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _assert_policy(hook: LEPHookAdapter) -> None:
+    hook.pre_loop(None, None, None)
+    try:
+        assert hook.check_permission(ToolCall(tool="rm", args={}), None) is False
+        assert hook.check_permission(ToolCall(tool="ls", args={}), None) is True
+    finally:
+        hook.close()
+
+
+def test_lep_hook_cartridge_roundtrip(tmp_path):
+    cart = _make_lep_cartridge(tmp_path / "src.cartridge")
+
+    # cartridge → library
+    preset1 = cartridge_to_preset(cart, strict=True)
+    lep1 = [h for h in preset1.hooks if isinstance(h, LEPHookAdapter)]
+    assert len(lep1) == 1
+    _assert_policy(lep1[0])
+
+    # library → cartridge (the lossless direction under test)
+    out = tmp_path / "out.cartridge"
+    preset_to_cartridge(preset1, out, strict=True)
+
+    # serialised form is a self-contained declarative kind: lep block
+    cfgs = list(out.glob("hooks/*/config.yaml"))
+    lep_cfgs = [p for p in cfgs if "kind: lep" in p.read_text()]
+    assert len(lep_cfgs) == 1
+    lep_dir = lep_cfgs[0].parent
+    assert (lep_dir / "server.py").is_file(), "server not copied into snapshot"
+    cfg_text = lep_cfgs[0].read_text()
+    assert "- server.py" in cfg_text, cfg_text  # command rewritten relative
+
+    # cartridge → library again; behaviour must be identical
+    preset2 = cartridge_to_preset(out, strict=True)
+    lep2 = [h for h in preset2.hooks if isinstance(h, LEPHookAdapter)]
+    assert len(lep2) == 1
+    _assert_policy(lep2[0])
+
+    # the classifier labels the LEP hook portable
+    labels = dict((name, cls.kind) for name, cls in classify_preset_hooks(preset2))
+    assert labels.get("LEPHookAdapter") == "portable"
+
+
+def test_lep_hook_dir_prefix_does_not_compound(tmp_path):
+    """Repeated round-trips must not stack ``NN_`` index prefixes.
+
+    The loader sets ``LEPHookAdapter._cartridge_id`` to the source hook
+    dir name (which already carries an index prefix). A naive serialiser
+    re-prefixes it, so ``00_policy`` would drift to ``00_00_policy`` and
+    then ``00_00_00_policy`` on each cartridge→library→cartridge cycle.
+    """
+    cart = _make_lep_cartridge(tmp_path / "src.cartridge")
+    current = cart
+    for i in range(3):
+        preset = cartridge_to_preset(current, strict=True)
+        out = tmp_path / f"rt_{i}.cartridge"
+        preset_to_cartridge(preset, out, strict=True)
+        lep_dirs = [
+            p.parent.name for p in out.glob("hooks/*/config.yaml") if "kind: lep" in p.read_text()
+        ]
+        assert lep_dirs == ["00_policy"], lep_dirs
+        current = out

--- a/tests/test_cartridge_package_layout.py
+++ b/tests/test_cartridge_package_layout.py
@@ -106,12 +106,16 @@ ALLOWED_LOOPLET_DEPS = frozenset(
         "looplet.compact",  # public CompactService types
         "looplet.hook_decision",  # public HookDecision factories
         "looplet.hook_view",  # public ViewSpec (capability-scoped hook views)
+        "looplet.hook_contract",  # public portability classifier
+        "looplet.lep",  # public LEPHookAdapter (out-of-process hooks)
         "looplet.loop",  # public LoopConfig / hook protocol
         "looplet.memory",  # public MemorySource types
         "looplet.mcp",  # public MCPToolAdapter (mcp_servers: in config.yaml)
         "looplet.permissions",  # public PermissionEngine etc.
         "looplet.presets",  # public AgentPreset
         "looplet.refs",  # resource ref registry
+        "looplet.state_service",  # public StateServiceHandle (state_services: in config.yaml)
+        "looplet.model_gateway",  # public ModelGatewayHandle (host-LLM bridge for out-of-process tools)
         "looplet.tools",  # public ToolSpec / BaseToolRegistry
         "looplet.types",  # public DefaultState etc.
         "looplet.validation",  # public OutputSchema / FieldSpec

--- a/tests/test_lep_hooks.py
+++ b/tests/test_lep_hooks.py
@@ -1,0 +1,220 @@
+"""Dogfood tests for out-of-process hooks (``looplet.lep``).
+
+These tests witness the two hazards the cross-runtime design must
+survive (HOOK_CARTRIDGE_DESIGN.md):
+
+* **H4 composition** — an in-process hook and an out-of-process LEP hook
+  run in the *same* loop and their authority composes (AND semantics on
+  permission; both denials are honoured).
+* **H2 wide view** — an LEP hook that declares a ``transcript`` view can
+  read conversation history across the process boundary and decide on it.
+
+It also pins the failure-policy contract (fail_closed denies on a broken
+server; fail_open allows) and the basic authority slots
+(``check_permission`` / ``pre_prompt``).
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import looplet
+from looplet import (
+    BaseToolRegistry,
+    DefaultState,
+    Deny,
+    LoopConfig,
+    composable_loop,
+)
+from looplet.hook_view import ViewSpec
+from looplet.lep import LEPHookAdapter, server_argv
+from looplet.testing import MockLLMBackend
+from looplet.tools import ToolSpec
+from looplet.types import ToolCall
+
+_SRC = str(Path(looplet.__file__).resolve().parent.parent)
+
+
+def _write_server(tmp_path: Path, body: str, name: str = "server.py") -> Path:
+    """Write a LEPServerBase policy server that can import looplet.
+
+    ``body`` is the source of a ``decide`` method (with a 4-space class-body
+    indent already applied by the caller via dedent here).
+    """
+    method_src = textwrap.indent(textwrap.dedent(body).strip("\n"), "    ")
+    src = (
+        "import sys\n"
+        f"sys.path.insert(0, {_SRC!r})\n"
+        "from looplet.lep import LEPServerBase\n"
+        "\n"
+        "class PolicyServer(LEPServerBase):\n"
+        f"{method_src}\n"
+        "\n"
+        'if __name__ == "__main__":\n'
+        "    raise SystemExit(PolicyServer().serve())\n"
+    )
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def _adapter(tmp_path: Path, body: str, **kwargs) -> LEPHookAdapter:
+    server = _write_server(tmp_path, body)
+    return LEPHookAdapter(server_argv(str(server)), **kwargs)
+
+
+class TestLEPAuthoritySlots:
+    def test_check_permission_denies_out_of_process(self, tmp_path):
+        adapter = _adapter(
+            tmp_path,
+            """
+            def decide(self, slot, view):
+                if slot == "check_permission" and view.get("tool") == "rm":
+                    return {"kind": "Deny", "block": "rm denied by policy"}
+                return {"kind": "Continue"}
+            """,
+            view=ViewSpec(fields=frozenset({"tool", "args"})),
+        )
+        adapter.pre_loop(None, None, None)
+        try:
+            assert adapter.check_permission(ToolCall(tool="rm", args={}), None) is False
+            assert adapter.check_permission(ToolCall(tool="ls", args={}), None) is True
+        finally:
+            adapter.close()
+
+    def test_pre_prompt_injects_context(self, tmp_path):
+        adapter = _adapter(
+            tmp_path,
+            """
+            def decide(self, slot, view):
+                if slot == "pre_prompt":
+                    return {"kind": "InjectContext", "text": "[audited]"}
+                return {"kind": "Continue"}
+            """,
+        )
+        adapter.pre_loop(None, None, None)
+        try:
+            assert adapter.pre_prompt(None, None, None, 0) == "[audited]"
+        finally:
+            adapter.close()
+
+
+class TestFailurePolicy:
+    def test_fail_closed_denies_on_broken_server(self, tmp_path):
+        # Server exits immediately → every RPC fails. fail_closed must deny.
+        bad = tmp_path / "bad.py"
+        bad.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+        adapter = LEPHookAdapter(server_argv(str(bad)), on_failure="fail_closed")
+        adapter.pre_loop(None, None, None)
+        try:
+            assert adapter.check_permission(ToolCall(tool="x", args={}), None) is False
+        finally:
+            adapter.close()
+
+    def test_fail_open_allows_on_broken_server(self, tmp_path):
+        bad = tmp_path / "bad.py"
+        bad.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+        adapter = LEPHookAdapter(server_argv(str(bad)), on_failure="fail_open")
+        adapter.pre_loop(None, None, None)
+        try:
+            assert adapter.check_permission(ToolCall(tool="x", args={}), None) is True
+        finally:
+            adapter.close()
+
+
+def _tools() -> BaseToolRegistry:
+    reg = BaseToolRegistry()
+    reg.register(
+        ToolSpec(
+            name="add",
+            description="add",
+            parameters={"a": "int", "b": "int"},
+            execute=lambda *, a, b: {"sum": a + b},
+        )
+    )
+    reg.register(
+        ToolSpec(
+            name="rm",
+            description="rm",
+            parameters={"path": "str"},
+            execute=lambda *, path: {"removed": path},
+        )
+    )
+    reg.register(
+        ToolSpec(
+            name="done",
+            description="done",
+            parameters={"answer": "str"},
+            execute=lambda *, answer: {"answer": answer},
+        )
+    )
+    return reg
+
+
+class TestH4Composition:
+    def test_inprocess_and_lep_hook_compose(self, tmp_path):
+        """An in-process hook denying ``add`` and an LEP hook denying ``rm``
+        compose: both calls are blocked in the same loop run."""
+        lep = _adapter(
+            tmp_path,
+            """
+            def decide(self, slot, view):
+                if slot == "check_permission" and view.get("tool") == "rm":
+                    return {"kind": "Deny", "block": "rm denied by lep"}
+                return {"kind": "Continue"}
+            """,
+            view=ViewSpec(fields=frozenset({"tool", "args"})),
+        )
+
+        class DenyAdd:
+            def check_permission(self, tool_call, state):
+                return tool_call.tool != "add"
+
+        llm = MockLLMBackend(
+            responses=[
+                '{"tool":"add","args":{"a":1,"b":2},"reasoning":""}',
+                '{"tool":"rm","args":{"path":"/x"},"reasoning":""}',
+                '{"tool":"done","args":{"answer":"ok"},"reasoning":""}',
+            ]
+        )
+        steps = list(
+            composable_loop(
+                llm=llm,
+                tools=_tools(),
+                state=DefaultState(max_steps=6),
+                hooks=[DenyAdd(), lep],
+                config=LoopConfig(max_steps=6),
+            )
+        )
+        add_step = next(s for s in steps if s.tool_call.tool == "add")
+        rm_step = next(s for s in steps if s.tool_call.tool == "rm")
+        # In-process hook blocked add; LEP hook blocked rm. Both honoured.
+        assert add_step.tool_result.error is not None
+        assert rm_step.tool_result.error is not None
+
+
+class TestH2WideView:
+    def test_lep_hook_reads_transcript_view(self, tmp_path):
+        """A hook declaring a ``transcript`` view receives conversation
+        history across the process boundary and can decide on it."""
+        adapter = _adapter(
+            tmp_path,
+            """
+            def decide(self, slot, view):
+                if slot == "pre_prompt":
+                    t = view.get("transcript") or []
+                    return {"kind": "InjectContext",
+                            "text": f"[transcript_len={len(t)}]"}
+                return {"kind": "Continue"}
+            """,
+            view=ViewSpec(fields=frozenset({"transcript"}), fidelity="full"),
+        )
+        adapter.pre_loop(None, None, None)
+        try:
+            out = adapter.pre_prompt(None, None, None, 0)
+            assert out is not None
+            assert out.startswith("[transcript_len=")
+        finally:
+            adapter.close()

--- a/tests/test_model_gateway.py
+++ b/tests/test_model_gateway.py
@@ -1,0 +1,169 @@
+"""Unit tests for the Model Gateway Protocol (MGP) primitive.
+
+The model gateway is the host-side sibling of SSP: a 1:N ``AF_UNIX``
+server that exposes the loop's LLM backend to out-of-process MCP tool /
+LEP hook servers so they can call ``ctx.llm.generate(...)`` instead of
+degrading. These tests exercise the in-host server, the in-process
+client proxy, the handle lifecycle, and the late-binding / no-backend
+semantics that let a headless dispatch fall back gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+
+import pytest
+
+from looplet.model_gateway import (
+    LLM_SOCKET_ENV_VAR,
+    MGP_VERSION,
+    ModelGatewayClient,
+    ModelGatewayError,
+    ModelGatewayHandle,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"), reason="model gateway requires AF_UNIX sockets"
+)
+
+
+class _ScriptedLLM:
+    """A backend that records prompts and returns canned replies in order."""
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self.prompts: list[str] = []
+        self.kwargs: list[dict] = []
+
+    def generate(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        self.kwargs.append(kwargs)
+        return self._replies.pop(0) if self._replies else "DONE"
+
+
+def test_handle_exports_socket_env_var():
+    prior = os.environ.get(LLM_SOCKET_ENV_VAR)
+    handle = ModelGatewayHandle.start()
+    try:
+        assert os.environ[LLM_SOCKET_ENV_VAR] == handle.socket_path
+        assert os.path.exists(handle.socket_path)
+    finally:
+        handle.close()
+    # close() removes the env var it owned and the socket.
+    assert os.environ.get(LLM_SOCKET_ENV_VAR) == prior
+    assert not os.path.exists(handle.socket_path)
+
+
+def test_generate_round_trip_with_backend():
+    backend = _ScriptedLLM(["HIGH"])
+    handle = ModelGatewayHandle.start(backend=backend)
+    try:
+        client = ModelGatewayClient(handle.socket_path)
+        assert client.ready is True
+        out = client.generate("classify this", max_tokens=20)
+        assert out == "HIGH"
+        # kwargs are forwarded verbatim to the backend.
+        assert backend.prompts == ["classify this"]
+        assert backend.kwargs == [{"max_tokens": 20}]
+        client.close()
+    finally:
+        handle.close()
+
+
+def test_no_backend_raises_so_callers_degrade():
+    # Started without a backend (the load-time default): generate must
+    # surface an error so out-of-process tools fall back to ctx.llm-None.
+    handle = ModelGatewayHandle.start()
+    try:
+        client = ModelGatewayClient(handle.socket_path)
+        assert client.ready is False
+        with pytest.raises(ModelGatewayError):
+            client.generate("anything")
+        client.close()
+    finally:
+        handle.close()
+
+
+def test_late_binding_backend():
+    # The loader starts the gateway with no backend (before any run); the
+    # backend is bound later at run time. A client that connected early
+    # must see the backend once it is set.
+    handle = ModelGatewayHandle.start()
+    try:
+        client = ModelGatewayClient(handle.socket_path)
+        with pytest.raises(ModelGatewayError):
+            client.generate("before")
+        handle.set_backend(_ScriptedLLM(["AFTER"]))
+        assert client.generate("after") == "AFTER"
+        client.close()
+    finally:
+        handle.close()
+
+
+def test_from_env_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv(LLM_SOCKET_ENV_VAR, raising=False)
+    assert ModelGatewayClient.from_env() is None
+
+
+def test_from_env_connects_when_set():
+    handle = ModelGatewayHandle.start(backend=_ScriptedLLM(["X"]))
+    try:
+        client = ModelGatewayClient.from_env()
+        assert client is not None
+        assert client.generate("p") == "X"
+        client.close()
+    finally:
+        handle.close()
+
+
+def test_multiple_concurrent_clients_share_backend():
+    backend = _ScriptedLLM(["A", "B", "C"])
+    handle = ModelGatewayHandle.start(backend=backend)
+    try:
+        c1 = ModelGatewayClient(handle.socket_path)
+        c2 = ModelGatewayClient(handle.socket_path)
+        assert c1.generate("p1") == "A"
+        assert c2.generate("p2") == "B"
+        assert c1.generate("p3") == "C"
+        c1.close()
+        c2.close()
+    finally:
+        handle.close()
+
+
+def test_initialize_reports_version():
+    handle = ModelGatewayHandle.start(backend=_ScriptedLLM([]))
+    try:
+        # Talk the raw wire protocol to confirm the documented shape.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(handle.socket_path)
+        sock.sendall((json.dumps({"id": 1, "method": "llm/initialize"}) + "\n").encode())
+        data = b""
+        while b"\n" not in data:
+            data += sock.recv(4096)
+        reply = json.loads(data.split(b"\n", 1)[0].decode())
+        assert reply["id"] == 1
+        assert reply["result"]["mgp_version"] == MGP_VERSION
+        assert reply["result"]["ready"] is True
+        sock.close()
+    finally:
+        handle.close()
+
+
+def test_unknown_method_returns_error():
+    handle = ModelGatewayHandle.start()
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(handle.socket_path)
+        sock.sendall((json.dumps({"id": 9, "method": "llm/bogus"}) + "\n").encode())
+        data = b""
+        while b"\n" not in data:
+            data += sock.recv(4096)
+        reply = json.loads(data.split(b"\n", 1)[0].decode())
+        assert reply["id"] == 9
+        assert "error" in reply
+        sock.close()
+    finally:
+        handle.close()

--- a/tests/test_skill_builtins.py
+++ b/tests/test_skill_builtins.py
@@ -68,10 +68,6 @@ def test_skillful_analyst_workspace_loads_without_setup_py() -> None:
     """The shipped example workspace must be 100% declarative."""
     ws = Path(__file__).resolve().parents[1] / "examples" / "skillful_analyst.cartridge"
     assert not (ws / "setup.py").exists(), "skillful_analyst should not need setup.py"
-    assert not (ws / "hooks").exists(), (
-        "skillful_analyst should not need hooks/ — the skill_activation built-in "
-        "hook covers the SkillActivationHook wiring."
-    )
     assert not (ws / "resources" / "project_root.py").exists(), (
         "skillful_analyst should not need resources/project_root.py — tools read "
         "ctx.resources['runtime'] which the loader auto-injects."

--- a/tests/test_state_service.py
+++ b/tests/test_state_service.py
@@ -1,0 +1,150 @@
+"""Dogfood tests for the State Service Protocol (``looplet.state_service``).
+
+The State Service is the out-of-process replacement for the in-process
+``@ref`` shared-resource pattern: a small server owns a piece of shared
+mutable state behind a Unix-domain socket, and any number of clients —
+each potentially in a *separate* process — read and mutate the SAME
+state through a :class:`StateServiceClient` proxy.
+
+These tests witness the two properties the primitive must guarantee:
+
+* **round-trip** — a client can call the server's public methods and get
+  results back over the wire (method discovery, mutation, query).
+* **1:N sharing** — two independent clients connected to the same socket
+  observe each other's writes (the cross-process shared-state contract
+  that makes the ``@ref`` pattern portable).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import looplet
+from looplet.state_service import (
+    StateServiceClient,
+    StateServiceError,
+    StateServiceHandle,
+    state_server_argv,
+)
+
+_SRC = str(Path(looplet.__file__).resolve().parent.parent)
+
+
+def _write_server(tmp_path: Path, body: str, name: str = "server.py") -> Path:
+    """Write a StateServiceBase server that can import looplet.
+
+    ``body`` is the source of the class body (methods), dedented and
+    re-indented under the class.
+    """
+    class_body = textwrap.indent(textwrap.dedent(body).strip("\n"), "    ")
+    src = (
+        "import sys\n"
+        f"sys.path.insert(0, {_SRC!r})\n"
+        "from looplet.state_service import StateServiceBase\n"
+        "\n"
+        "class Service(StateServiceBase):\n"
+        f"{class_body}\n"
+        "\n"
+        'if __name__ == "__main__":\n'
+        "    raise SystemExit(Service().serve())\n"
+    )
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+_COUNTER_BODY = """
+    def __init__(self):
+        super().__init__()
+        self._n = 0
+        self._log = []
+
+    def incr(self, by=1):
+        self._n += int(by)
+        return self._n
+
+    def value(self):
+        return self._n
+
+    def append(self, item):
+        self._log.append(item)
+
+    def items(self):
+        return list(self._log)
+"""
+
+
+def test_round_trip_method_discovery_and_calls(tmp_path: Path) -> None:
+    server = _write_server(tmp_path, _COUNTER_BODY)
+    handle = StateServiceHandle.spawn(state_server_argv(str(server)), name="counter")
+    try:
+        client = handle.client
+        # Public methods are discovered at initialize time.
+        assert set(client.methods) == {"incr", "value", "append", "items"}
+        assert client.value() == 0
+        assert client.incr() == 1
+        assert client.incr(by=4) == 5
+        assert client.value() == 5
+        client.append("a")
+        client.append("b")
+        assert client.items() == ["a", "b"]
+    finally:
+        handle.close()
+
+
+def test_two_clients_share_state_one_to_n(tmp_path: Path) -> None:
+    """A second independent client sees the first client's writes."""
+    server = _write_server(tmp_path, _COUNTER_BODY)
+    handle = StateServiceHandle.spawn(state_server_argv(str(server)), name="counter")
+    try:
+        c1 = handle.client
+        c1.incr(by=3)
+        c1.append("hello")
+
+        # A *separate* client process-handle, same socket → same state.
+        c2 = StateServiceClient(handle.socket_path)
+        try:
+            assert c2.value() == 3
+            assert c2.items() == ["hello"]
+            # And a write through c2 is visible to c1.
+            c2.incr(by=10)
+            assert c1.value() == 13
+        finally:
+            c2.close()
+    finally:
+        handle.close()
+
+
+def test_unknown_method_raises_state_service_error(tmp_path: Path) -> None:
+    server = _write_server(tmp_path, _COUNTER_BODY)
+    handle = StateServiceHandle.spawn(state_server_argv(str(server)), name="counter")
+    try:
+        with pytest.raises(StateServiceError):
+            handle.client.call("does_not_exist")
+    finally:
+        handle.close()
+
+
+def test_reserved_methods_are_not_exposed(tmp_path: Path) -> None:
+    server = _write_server(tmp_path, _COUNTER_BODY)
+    handle = StateServiceHandle.spawn(state_server_argv(str(server)), name="counter")
+    try:
+        # ``serve`` is a framework method and must never be callable state.
+        assert "serve" not in handle.client.methods
+        with pytest.raises(StateServiceError):
+            handle.client.call("serve")
+    finally:
+        handle.close()
+
+
+def test_close_terminates_server_and_cleans_socket(tmp_path: Path) -> None:
+    server = _write_server(tmp_path, _COUNTER_BODY)
+    handle = StateServiceHandle.spawn(state_server_argv(str(server)), name="counter")
+    socket_path = handle.socket_path
+    assert Path(socket_path).exists()
+    handle.close()
+    # Socket file is removed on close.
+    assert not Path(socket_path).exists()


### PR DESCRIPTION
Stacked on #85. Adds out-of-process protocol surfaces:

- **LEP** (Loop Extension Protocol): `lep.py` + `hook_contract.py` — out-of-process hook adapter that lets cartridge hooks run as standalone MCP-style servers (config.yaml + server.py), classified via `LEPHookAdapter`.
- **SSP** (State Service Protocol): `state_service.py` — pluggable external state backend surface.
- **MGP** (Model Gateway Protocol): `model_gateway.py` — pluggable external model gateway surface.
- Loader wiring in `cartridge/_load.py`, `cartridge/_serialise.py`, `presets.py`, package exports in `__init__.py`.
- 8 example cartridges gain a portable out-of-process hook (config.yaml + server.py).
- Tests: `test_lep_hooks.py`, `test_state_service.py`, `test_model_gateway.py`, `test_cartridge_hook_roundtrip.py`, plus package-layout allowlist updates.

Additive only. Full suite green (2038 passed, 2 skipped); ruff + pyright clean.