### PR TITLE
feat: cartridge portability analyzer and report CLI

### DIFF
--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,0 +1,145 @@
+# Cross-runtime portability
+
+A looplet cartridge is just a directory of declarative files plus
+(optionally) some Python. The **portability analyser** answers one
+question about any cartridge:
+
+> Can this agent package run on a non-Python loader (Rust / Go /
+> TypeScript), and if not, *exactly which components* pin it to a Python
+> host?
+
+```python
+from looplet.cartridge import analyse_cartridge
+
+report = analyse_cartridge("examples/dep_doctor_portable.cartridge")
+print(report.render())
+print(report.profile)   # "portable" | "python-host"
+print(report.blockers)  # the INPROCESS components, if any
+```
+
+The analyser is **static**: it reads the cartridge directory and its
+`config.yaml` / `runtime.yaml` rather than importing any Python bodies,
+so it can grade cartridges whose code can't even be imported in the
+current environment.
+
+## The four tiers
+
+Every component is classified into one of four tiers (best → worst for
+portability). A cartridge is in the **portable profile** when it has
+*zero* `INPROCESS` components; otherwise it is **python-host** and the
+`INPROCESS` components are the exact blockers.
+
+| Tier | Symbol | Meaning | Blocker? |
+|------|--------|---------|----------|
+| `PROTOCOL` | ● | Pure data or out-of-process protocol — `config.yaml`, `prompts/`, `mcp_servers:` tools, `kind: lep` hooks. Runs on any conforming loader with no shared code. | no |
+| `STDLIB` | ◐ | Declarative reference to a looplet-shipped archetype (`builtin_tools:` / `builtin_hooks:`). No Python body in the cartridge. | no |
+| `RUNTIME` | ◈ | A `resources/*.py` whose only job is to wrap a host-provided *service* (compaction, the skill manager) via a looplet factory like `default_compact_service`. The service is a host responsibility every loader ships its own equivalent of. | no |
+| `INPROCESS` | ○ | A Python body or author-owned shared object that pins the cartridge to a Python host — `tools/<n>/execute.py`, single-file `tools/<n>.py`, `hooks/<n>/` class hooks, author-owned `resources/*.py` (`@ref` shared mutable state). | **yes** |
+
+`extends:` is resolved transitively: a child cartridge inherits its
+parent's components (and therefore its parent's blockers), tagged
+`(inherited)` in the report.
+
+## The three protocol surfaces
+
+A fully-portable cartridge moves every author-owned capability onto one
+of looplet's three out-of-process protocol surfaces:
+
+| Surface | Carries | Transport | Cardinality |
+|---------|---------|-----------|-------------|
+| **MCP** | tools | stdio JSON-RPC | 1 server : N tools |
+| **LEP** (Loop Effect Protocol) | hooks (permission / done policies) | stdio JSON-RPC | 1 server : 1 hook |
+| **SSP** (State Service Protocol) | shared mutable state | `AF_UNIX` SOCK_STREAM | 1 service : N clients |
+
+The host ships only a declared **view** to a hook; the hook returns a
+decision. The host spawns an MCP server and calls its tools. Neither
+requires the host to execute any author Python.
+
+## Portable example cartridges
+
+Each non-trivial example ships a `*_portable` twin that is byte-for-byte
+behaviour-faithful to its in-process original, but classifies as
+`portable`. Every twin has an end-to-end *cross-process* dogfood test in
+`tests/test_example_*_portable_cartridge.py`.
+
+| Portable twin | Original | What moved | Notes |
+|---------------|----------|------------|-------|
+| `hello_portable` | `hello` | greet/done → MCP | smallest demo |
+| `mcp_demo_portable` | `mcp_demo` | add + done → MCP, CalcGuard → LEP | both tools served by one MCP server |
+| `planner_portable` | `planner` | done → MCP; nested `planner_child` twin | `subagent` builtin tool + LEP guard |
+| `skillful_analyst_portable` | `skillful_analyst` | done/read_text/write_text → MCP, WriteScopeGuard → LEP | skill system via `search_skills`/`activate_skill` builtins + RUNTIME `skill_manager` |
+| `dep_doctor_portable` | `dep_doctor` | 7 audit tools → MCP, RegistryGuard → LEP | `find_alternatives` degrades to empty (no host LLM in the MCP subprocess) |
+| `threat_intel_portable` | `threat_intel` | 7 tools → MCP, FeedAllowlistGuard → LEP | regex IOC extraction preserved; LLM severity/risk degrade gracefully |
+| `git_detective_portable` | `git_detective` | 10 tools → MCP, CouplingGuard → LEP | INPROCESS `repo_config` replaced by `$LOOPLET_PROJECT_ROOT` resolution; the server only needs `git` |
+
+### The mechanical port recipe
+
+Porting an in-process cartridge to a portable twin is a fixed procedure:
+
+1. **Fold every `tools/<n>/execute.py` body into one `_mcp/tools_server.py`** —
+   a stdlib-only stdio MCP server. Vendor any data tables (package DBs,
+   threat feeds) into the server. Wire it in `config.yaml`:
+
+   ```yaml
+   mcp_servers:
+     my_tools:
+       command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+   ```
+
+2. **Keep `kind: lep` hooks verbatim** — they are already PROTOCOL-tier.
+
+3. **Keep `builtin_tools:` / `builtin_hooks:`** — already STDLIB-tier.
+
+4. **Keep `resources/compact_service.py` (and similar)** — already
+   RUNTIME-tier (host service), not a blocker.
+
+5. **Replace author-owned INPROCESS resources** — e.g.
+   `git_detective`'s `repo_config` (a shared path) becomes a
+   `$LOOPLET_PROJECT_ROOT` env lookup inside the server; genuine shared
+   *mutable* state would move to an SSP service instead.
+
+6. **Anchor relative paths to the host root** — the MCP subprocess
+   resolves relative paths against `os.getcwd()` (the host project
+   root), the portable equivalent of `resolve_project_root(runtime)`.
+
+!!! note "LLM-backed tools degrade, they don't break"
+    A tool that calls the host LLM (`ctx.llm`) can't reach it from a
+    separate MCP process. The faithful port returns the same fallback
+    the original takes when `ctx.llm is None` (e.g.
+    `find_alternatives` → empty list, `assess_risk` → severity-only
+    summary). Deterministic logic (regex extraction, git statistics) is
+    preserved in full. True host-LLM access from a server would require
+    MCP `sampling/createMessage` callbacks — out of scope for v1.x.
+
+## Inherently python-host cartridges
+
+Two shipped cartridges are **deliberately** python-host. They are not
+ported; their whole purpose is to host and execute Python.
+
+### `coder`
+
+A general software-engineering agent: ~16 substantial tools
+(`bash`, `edit_file`, `grep`, `subagent`, `worktree`, …), 5 class
+hooks, and 7 resources. Several resources (`file_cache`,
+`workspace_config`, `eval_*`) are **genuine** `INPROCESS` shared
+mutable state, and the tools execute arbitrary code in the host
+environment. The mechanical recipe above *would* apply tool-by-tool
+(bodies → an MCP server, class hooks → LEP, shared state → SSP), but the
+result would still need a host that can run a shell and edit a live
+workspace — the very thing that makes it useful. Porting it buys no
+portability; it stays python-host by design.
+
+### `agent_factory`
+
+`agent_factory` does `extends: ../coder.cartridge`, so the analyser
+reports its blockers as **its own** (`validate_workspace`) **plus all of
+`coder`'s** (tagged `(inherited)`). Its one bespoke tool,
+`validate_workspace`, exists to *import and validate a Python workspace*
+— it is python-host by definition. Like `coder`, it is documented as
+inherently python-host rather than ported.
+
+```python
+report = analyse_cartridge("examples/agent_factory.cartridge")
+assert report.profile == "python-host"
+# blockers = validate_workspace + every coder component, via extends
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - Build:
       - Hooks: hooks.md
       - Skills: skills.md
+      - Portability: portability.md
       - Evals: evals.md
       - Provenance: provenance.md
       - Pitfalls: pitfalls.md

--- a/src/looplet/cartridge/__init__.py
+++ b/src/looplet/cartridge/__init__.py
@@ -168,6 +168,9 @@ __all__ = [
     "CartridgeSerializationError",
     "preset_to_cartridge",
     "cartridge_to_preset",
+    "CartridgePortabilityReport",
+    "ComponentReport",
+    "analyse_cartridge",
 ]
 
 logger = logging.getLogger(__name__)
@@ -211,6 +214,13 @@ from looplet.cartridge._serialise import preset_to_cartridge  # noqa: E402
 # would be overkill. Re-imported here so existing callers can still
 # use ``looplet.cartridge._load_yaml``.
 from looplet.cartridge._yaml import _dump_yaml, _load_yaml  # noqa: E402, F401
+
+# Whole-cartridge portability report (static analyser).
+from looplet.cartridge.portability import (  # noqa: E402, F401
+    CartridgePortabilityReport,
+    ComponentReport,
+    analyse_cartridge,
+)
 
 # ``resource_ref_for`` is the public entry; the underlying registry
 # (``_REF_PREFIX``, ``_register_resource_origin``, ``_resource_origin``)

--- a/src/looplet/cartridge/portability.py
+++ b/src/looplet/cartridge/portability.py
@@ -1,0 +1,537 @@
+"""Whole-cartridge portability report.
+
+``looplet.hook_contract.classify`` answers the question *"is this one
+hook portable across runtimes?"*. This module lifts that question to the
+**whole cartridge**: *"can this agent package run on a non-Python loader
+(Rust/Go/TypeScript), and if not, exactly which components pin it to a
+Python host?"*
+
+It is a **static** analyser — it reads the cartridge directory and its
+``config.yaml`` / ``runtime.yaml`` rather than importing any Python
+bodies. That keeps it dependency-free and lets it grade cartridges whose
+tool/resource code can't even be imported in the current environment
+(e.g. ``looplet-tax`` with its own deps).
+
+Four portability tiers, mirroring the conformance model in
+``HOOK_CARTRIDGE_DESIGN.md``:
+
+* :data:`PROTOCOL` — pure data or out-of-process protocol. Runs on *any*
+  conforming loader with no shared code: ``config.yaml``, ``prompts/``,
+  ``mcp_servers:`` tools, ``kind: lep`` hooks.
+* :data:`STDLIB` — declarative reference to a looplet-shipped archetype
+  (``builtin_tools:`` / ``builtin_hooks:``). No Python body lives in the
+  cartridge; portable to any runtime that ships the same named stdlib.
+* :data:`RUNTIME` — a ``resources/*.py`` whose only job is to wrap a
+  host-provided builtin *service* (compaction, the skill manager, …) via
+  a looplet factory such as ``default_compact_service``. The service is a
+  host responsibility every conforming loader ships its own equivalent
+  of, so it does NOT pin the cartridge to Python — not a blocker.
+* :data:`INPROCESS` — a Python body or shared in-process object that
+  pins the cartridge to a Python host: ``tools/<n>/execute.py``,
+  single-file ``tools/<n>.py``, ``hooks/<n>/`` class hooks, and
+  author-owned ``resources/*.py`` (``@ref`` shared mutable state).
+
+A cartridge is in the **portable profile** when it has *no* INPROCESS
+components (everything is PROTOCOL, STDLIB, or RUNTIME host services);
+otherwise it is in the **python-host profile** and the INPROCESS
+components are the exact blockers.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from looplet.cartridge._yaml import _load_yaml
+
+__all__ = [
+    "INPROCESS",
+    "PROTOCOL",
+    "RUNTIME",
+    "STDLIB",
+    "ComponentReport",
+    "CartridgePortabilityReport",
+    "analyse_cartridge",
+]
+
+# Portability tiers (best → worst for cross-runtime portability).
+PROTOCOL = "protocol"
+STDLIB = "stdlib"
+# RUNTIME: a host-provided builtin service (compaction, skill manager, …)
+# wrapped declaratively. Any conforming loader ships its own equivalent,
+# so it does NOT pin the cartridge to a Python host — not a blocker.
+RUNTIME = "runtime"
+INPROCESS = "inprocess"
+
+# Builtin host-service factories. A resource whose only job is to call
+# one of these is a RUNTIME-tier component (host responsibility), not an
+# author-owned shared-state blocker.
+_RUNTIME_SERVICE_FACTORIES = frozenset(
+    {
+        "default_compact_service",
+        "build_skill_manager_for_workspace",
+    }
+)
+
+# Profile verdicts.
+PROFILE_PORTABLE = "portable"
+PROFILE_PYTHON_HOST = "python-host"
+
+
+@dataclass(frozen=True)
+class ComponentReport:
+    """Portability classification of one cartridge component."""
+
+    kind: str  # "tool" | "hook" | "resource" | "config" | "prompts"
+    name: str
+    tier: str  # PROTOCOL | STDLIB | INPROCESS
+    detail: str = ""  # e.g. "mcp", "lep", "python-execute", "class", "shared-ref"
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_blocker(self) -> bool:
+        """True when this component pins the cartridge to a Python host."""
+        return self.tier == INPROCESS
+
+
+@dataclass(frozen=True)
+class CartridgePortabilityReport:
+    """Whole-cartridge portability verdict + per-component breakdown."""
+
+    root: Path
+    name: str
+    components: tuple[ComponentReport, ...] = field(default_factory=tuple)
+
+    @property
+    def profile(self) -> str:
+        """``portable`` if nothing pins it to Python, else ``python-host``."""
+        return (
+            PROFILE_PYTHON_HOST if any(c.is_blocker for c in self.components) else PROFILE_PORTABLE
+        )
+
+    @property
+    def blockers(self) -> tuple[ComponentReport, ...]:
+        """The INPROCESS components that force the python-host profile."""
+        return tuple(c for c in self.components if c.is_blocker)
+
+    def by_tier(self, tier: str) -> tuple[ComponentReport, ...]:
+        return tuple(c for c in self.components if c.tier == tier)
+
+    def counts(self) -> dict[str, int]:
+        out = {PROTOCOL: 0, STDLIB: 0, RUNTIME: 0, INPROCESS: 0}
+        for c in self.components:
+            out[c.tier] = out.get(c.tier, 0) + 1
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "root": str(self.root),
+            "profile": self.profile,
+            "counts": self.counts(),
+            "components": [
+                {
+                    "kind": c.kind,
+                    "name": c.name,
+                    "tier": c.tier,
+                    "detail": c.detail,
+                    "reasons": list(c.reasons),
+                }
+                for c in self.components
+            ],
+        }
+
+    def render(self) -> str:
+        """Human-readable multi-line report."""
+        counts = self.counts()
+        lines = [
+            f"Cartridge: {self.name}  ({self.root})",
+            f"Profile:   {self.profile.upper()}",
+            (
+                f"Tiers:     protocol={counts[PROTOCOL]}  "
+                f"stdlib={counts[STDLIB]}  runtime={counts[RUNTIME]}  "
+                f"inprocess={counts[INPROCESS]}"
+            ),
+            "",
+        ]
+        if self.profile == PROFILE_PORTABLE:
+            lines.append(
+                "  ✔ No Python-pinned components — runs on any conforming loader (Rust/Go/TS)."
+            )
+        else:
+            lines.append("  Python-host blockers (pin the cartridge to Python):")
+            for c in self.blockers:
+                why = f" — {c.reasons[0]}" if c.reasons else ""
+                lines.append(f"    ✗ {c.kind}:{c.name} [{c.detail}]{why}")
+        lines.append("")
+        lines.append("  Components:")
+        symbol = {PROTOCOL: "●", STDLIB: "◐", RUNTIME: "◈", INPROCESS: "○"}
+        for c in self.components:
+            lines.append(
+                f"    {symbol.get(c.tier, '?')} {c.tier:<9} {c.kind}:{c.name} [{c.detail}]"
+            )
+        return "\n".join(lines)
+
+
+# ── Static walkers ────────────────────────────────────────────
+
+
+def _read_yaml_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        loaded = _load_yaml(path.read_text(encoding="utf-8"), source_path=path)
+    except Exception:  # noqa: BLE001 — malformed config shouldn't crash analysis
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _analyse_tools(root: Path, mcp_servers: dict[str, Any]) -> list[ComponentReport]:
+    out: list[ComponentReport] = []
+
+    # MCP servers → protocol-tier tool providers (out-of-process, any runtime).
+    for srv_name in mcp_servers:
+        out.append(
+            ComponentReport(
+                kind="tool",
+                name=f"mcp:{srv_name}",
+                tier=PROTOCOL,
+                detail="mcp",
+                reasons=(
+                    "out-of-process MCP server — tool body runs over the "
+                    "stdio protocol, no Python required by the loader",
+                ),
+            )
+        )
+
+    tools_dir = root / "tools"
+    if tools_dir.is_dir():
+        # Single-file tools: tools/<name>.py (Python body → inprocess).
+        for p in sorted(tools_dir.iterdir()):
+            if p.is_file() and p.suffix == ".py" and not p.name.startswith("_"):
+                out.append(
+                    ComponentReport(
+                        kind="tool",
+                        name=p.stem,
+                        tier=INPROCESS,
+                        detail="python-single-file",
+                        reasons=(
+                            "single-file Python tool body — pinned to a "
+                            "Python host (port to an MCP server for "
+                            "cross-runtime portability)",
+                        ),
+                    )
+                )
+        # Multi-file tools: tools/<name>/execute.py (Python body → inprocess).
+        for d in sorted(tools_dir.iterdir()):
+            if d.is_dir() and (d / "execute.py").is_file():
+                out.append(
+                    ComponentReport(
+                        kind="tool",
+                        name=d.name,
+                        tier=INPROCESS,
+                        detail="python-execute",
+                        reasons=(
+                            "Python execute.py tool body — pinned to a "
+                            "Python host (port to an MCP server for "
+                            "cross-runtime portability)",
+                        ),
+                    )
+                )
+    return out
+
+
+def _analyse_hooks(root: Path, builtin_hooks: list[Any]) -> list[ComponentReport]:
+    out: list[ComponentReport] = []
+
+    # builtin_hooks: declarative stdlib references → stdlib tier.
+    for entry in builtin_hooks:
+        if isinstance(entry, str):
+            hook_name = entry
+        elif isinstance(entry, dict) and entry:
+            hook_name = next(iter(entry))
+        else:
+            hook_name = str(entry)
+        out.append(
+            ComponentReport(
+                kind="hook",
+                name=hook_name,
+                tier=STDLIB,
+                detail="builtin",
+                reasons=(
+                    "declarative looplet stdlib hook — portable to any "
+                    "runtime that ships the same named archetype",
+                ),
+            )
+        )
+
+    hooks_dir = root / "hooks"
+    if hooks_dir.is_dir():
+        for d in sorted(hooks_dir.iterdir()):
+            if not d.is_dir():
+                continue
+            cfg = _read_yaml_file(d / "config.yaml")
+            kind = str(cfg.get("kind", "")).lower()
+            if kind == "lep":
+                out.append(
+                    ComponentReport(
+                        kind="hook",
+                        name=d.name,
+                        tier=PROTOCOL,
+                        detail="lep",
+                        reasons=(
+                            "out-of-process LEP hook — portable by "
+                            "construction over line-delimited JSON-RPC",
+                        ),
+                    )
+                )
+            else:
+                detail = "class" if kind in ("", "class", "inprocess") else kind
+                out.append(
+                    ComponentReport(
+                        kind="hook",
+                        name=d.name,
+                        tier=INPROCESS,
+                        detail=detail,
+                        reasons=(
+                            "in-process Python hook class — reads live loop "
+                            "state; port to a kind: lep hook for portability",
+                        ),
+                    )
+                )
+    return out
+
+
+def _resource_is_runtime_builtin(path: Path) -> bool:
+    """True if a resource only wraps a looplet builtin host service.
+
+    Such resources (e.g. ``compact_service.py`` → ``default_compact_service``)
+    are a host responsibility, not author-owned shared state: any conforming
+    loader provides its own equivalent, so they do not pin the cartridge to a
+    Python host.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("looplet"):
+            for alias in node.names:
+                if alias.name in _RUNTIME_SERVICE_FACTORIES:
+                    return True
+    return False
+
+
+def _analyse_resources(
+    root: Path, state_services: dict[str, Any] | None = None
+) -> list[ComponentReport]:
+    out: list[ComponentReport] = []
+    state_services = state_services or {}
+    resources_dir = root / "resources"
+    if resources_dir.is_dir():
+        for p in sorted(resources_dir.iterdir()):
+            if p.is_file() and p.suffix == ".py" and not p.name.startswith("_"):
+                if p.stem in state_services:
+                    # A resource whose name matches a declared state
+                    # service is backed by the out-of-process
+                    # StateServiceClient the loader injects — portable.
+                    out.append(
+                        ComponentReport(
+                            kind="resource",
+                            name=p.stem,
+                            tier=PROTOCOL,
+                            detail="state-service",
+                            reasons=(
+                                "shared state served out-of-process by a "
+                                "state_services: entry — the loader injects a "
+                                "StateServiceClient proxy, so no Python body "
+                                "is required by the host",
+                            ),
+                        )
+                    )
+                    continue
+                if _resource_is_runtime_builtin(p):
+                    # A thin declarative wrapper around a looplet builtin
+                    # host service (compaction, skill manager, …). Any
+                    # conforming loader ships its own equivalent, so this
+                    # does not pin the cartridge to a Python host.
+                    out.append(
+                        ComponentReport(
+                            kind="resource",
+                            name=p.stem,
+                            tier=RUNTIME,
+                            detail="host-service",
+                            reasons=(
+                                "builtin host service (compaction / skill "
+                                "manager / …) — a host responsibility, not "
+                                "author-owned state; any conforming loader "
+                                "provides its own equivalent",
+                            ),
+                        )
+                    )
+                    continue
+                out.append(
+                    ComponentReport(
+                        kind="resource",
+                        name=p.stem,
+                        tier=INPROCESS,
+                        detail="shared-ref",
+                        reasons=(
+                            "Python resource (@ref shared object) — shared "
+                            "mutable state in one address space; port to a "
+                            "state_services: entry for cross-runtime "
+                            "portability",
+                        ),
+                    )
+                )
+    return out
+
+
+def _analyse_state_services(
+    state_services: dict[str, Any],
+) -> list[ComponentReport]:
+    """State Service Protocol servers → protocol-tier shared state.
+
+    Each ``state_services:`` entry is an out-of-process server that owns
+    a piece of shared mutable state behind a Unix socket. Portable by
+    construction: any conforming loader can spawn the ``command:`` and
+    speak the line-delimited JSON wire protocol.
+    """
+    out: list[ComponentReport] = []
+    for svc_name, svc_cfg in state_services.items():
+        out.append(
+            ComponentReport(
+                kind="resource",
+                name=f"state:{svc_name}",
+                tier=PROTOCOL,
+                detail="ssp",
+                reasons=(
+                    "out-of-process state service (SSP) — shared mutable "
+                    "state lives behind a Unix socket, addressable by any "
+                    "runtime over line-delimited JSON; no Python required "
+                    "by the loader",
+                ),
+            )
+        )
+    return out
+
+
+def analyse_cartridge(path: str | Path) -> CartridgePortabilityReport:
+    """Statically classify a cartridge directory's portability.
+
+    Args:
+        path: Path to the cartridge root (the directory containing
+            ``config.yaml`` / ``cartridge.json``).
+
+    Returns:
+        A :class:`CartridgePortabilityReport` with a per-component
+        breakdown and an overall ``portable`` / ``python-host`` verdict.
+    """
+    return _analyse_cartridge(path)
+
+
+def _analyse_cartridge(
+    path: str | Path, *, _seen: set[Path] | None = None
+) -> CartridgePortabilityReport:
+    root = Path(path).resolve()
+    if not root.is_dir():
+        raise NotADirectoryError(f"cartridge root is not a directory: {root}")
+
+    config = _read_yaml_file(root / "config.yaml")
+    mcp_servers = config.get("mcp_servers")
+    mcp_servers = mcp_servers if isinstance(mcp_servers, dict) else {}
+    builtin_hooks = config.get("builtin_hooks")
+    builtin_hooks = builtin_hooks if isinstance(builtin_hooks, list) else []
+    builtin_tools = config.get("builtin_tools")
+    builtin_tools = builtin_tools if isinstance(builtin_tools, list) else []
+    state_services = config.get("state_services")
+    state_services = state_services if isinstance(state_services, dict) else {}
+
+    components: list[ComponentReport] = []
+
+    # config + prompts are always pure portable data.
+    components.append(
+        ComponentReport(
+            kind="config",
+            name="config.yaml",
+            tier=PROTOCOL,
+            detail="data",
+            reasons=("declarative configuration — pure data",),
+        )
+    )
+    if (root / "prompts").is_dir():
+        components.append(
+            ComponentReport(
+                kind="prompts",
+                name="prompts/",
+                tier=PROTOCOL,
+                detail="text",
+                reasons=("prompt text — pure data",),
+            )
+        )
+
+    # builtin_tools: declarative stdlib references → stdlib tier.
+    for entry in builtin_tools:
+        tool_name = entry if isinstance(entry, str) else str(entry)
+        components.append(
+            ComponentReport(
+                kind="tool",
+                name=tool_name,
+                tier=STDLIB,
+                detail="builtin",
+                reasons=(
+                    "declarative looplet stdlib tool — portable to any "
+                    "runtime that ships the same named archetype",
+                ),
+            )
+        )
+
+    components.extend(_analyse_tools(root, mcp_servers))
+    components.extend(_analyse_hooks(root, builtin_hooks))
+    components.extend(_analyse_state_services(state_services))
+    components.extend(_analyse_resources(root, state_services))
+
+    # ``extends:`` inheritance — the loader merges the parent workspace
+    # under the child, so the child inherits every parent component. A
+    # report that ignored this would silently under-count blockers (e.g.
+    # a one-tool child that ``extends:`` a 27-blocker parent). Resolve the
+    # parent recursively and fold in its components, tagged ``inherited``.
+    extends_val = config.get("extends")
+    if isinstance(extends_val, str) and extends_val.strip():
+        parent = Path(extends_val)
+        if not parent.is_absolute():
+            parent = (root / parent).resolve()
+        parent = parent.resolve()
+        if parent.is_dir() and parent not in (_seen or set()):
+            seen = set(_seen or set())
+            seen.add(root)
+            parent_report = _analyse_cartridge(parent, _seen=seen)
+            own_names = {(c.kind, c.name) for c in components}
+            for c in parent_report.components:
+                # The child always supplies its own config/prompts; skip
+                # the parent's so they aren't double-counted.
+                if c.kind in ("config", "prompts"):
+                    continue
+                if (c.kind, c.name) in own_names:
+                    continue  # child overlay wins for same-named components
+                components.append(
+                    ComponentReport(
+                        kind=c.kind,
+                        name=f"{c.name} (inherited)",
+                        tier=c.tier,
+                        detail=c.detail,
+                        reasons=(
+                            f"inherited via extends: {extends_val} — "
+                            + (c.reasons[0] if c.reasons else ""),
+                        ),
+                    )
+                )
+
+    name = root.name
+    return CartridgePortabilityReport(
+        root=root,
+        name=name,
+        components=tuple(components),
+    )

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -306,15 +306,20 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
         print()
 
+    project_root = getattr(args, "project_root", None)
+    runtime: dict | None = None
+    if project_root is not None:
+        runtime = {"project_root": str(project_root.expanduser().resolve())}
+
     try:
         backend = _build_backend()
-        preset = cartridge_to_preset(
-            str(workspace_path), runtime={"workspace": str(workspace_path.parent)}
-        )
+        preset = cartridge_to_preset(str(workspace_path), runtime=runtime)
     except Exception as exc:
         print(_red(f"error: workspace load failed: {exc}"), file=sys.stderr)
         return 1
 
+    if args.max_steps:
+        preset.config.max_steps = args.max_steps
     state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
     pretty = None
     if getattr(args, "pretty", False) and not args.quiet:
@@ -377,6 +382,40 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     elif final_data:
         print(_bold("result:"))
         print(json.dumps(final_data, indent=2, default=str)[:2000])
+    return 0
+
+
+def cmd_portability(args: argparse.Namespace) -> int:
+    """Statically report a cartridge's cross-runtime portability."""
+    cartridge_path: Path = args.cartridge.resolve()
+    if not cartridge_path.is_dir():
+        print(
+            _red(f"error: cartridge not found at {cartridge_path}"),
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        from looplet.cartridge import analyse_cartridge  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001
+        print(_red(f"error: {exc}"), file=sys.stderr)
+        return 1
+
+    try:
+        report = analyse_cartridge(cartridge_path)
+    except Exception as exc:  # noqa: BLE001
+        print(_red(f"error: analysis failed: {exc}"), file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(report.render())
+
+    # Non-zero exit when the cartridge is NOT fully portable and the
+    # caller asked us to enforce it (useful in CI conformance gates).
+    if getattr(args, "require_portable", False) and report.profile != "portable":
+        return 2
     return 0
 
 
@@ -446,6 +485,16 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         type=int,
         help="Override the cartridge's default max_steps",
     )
+    run_p.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help=(
+            "Directory the agent operates on (its tools' working directory). "
+            "Defaults to $LOOPLET_PROJECT_ROOT, then the current git repo, "
+            "then the current working directory."
+        ),
+    )
     run_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
     run_p.add_argument(
         "--pretty",
@@ -454,5 +503,27 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
     )
     run_p.set_defaults(_handler=cmd_run_workspace)
 
+    portab_p = sub.add_parser(
+        "portability",
+        help="Report a cartridge's cross-runtime portability (static analysis)",
+        description=(
+            "Statically classify every component of a cartridge as "
+            "protocol-portable (config/prompts/MCP tools/LEP hooks), "
+            "stdlib-declarative (builtin_tools/builtin_hooks), or "
+            "Python-pinned (Python tool bodies, class hooks, resources). "
+            "Prints an overall portable / python-host profile verdict and "
+            "names the exact components that pin the cartridge to a Python "
+            "host. No env vars required — reads the cartridge directory only."
+        ),
+    )
+    portab_p.add_argument("cartridge", type=Path, help="Path to a cartridge directory")
+    portab_p.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    portab_p.add_argument(
+        "--require-portable",
+        action="store_true",
+        help="Exit non-zero (2) if the cartridge is not in the portable profile (CI gate).",
+    )
+    portab_p.set_defaults(_handler=cmd_portability)
 
-__all__ = ["add_subparsers", "cmd_new", "cmd_run_workspace"]
+
+__all__ = ["add_subparsers", "cmd_new", "cmd_portability", "cmd_run_workspace"]

--- a/tests/test_cartridge_portability.py
+++ b/tests/test_cartridge_portability.py
@@ -1,0 +1,372 @@
+"""Tests for the whole-cartridge portability report.
+
+``looplet.cartridge.portability.analyse_cartridge`` is a *static*
+analyser: it reads a cartridge directory (no Python bodies imported) and
+classifies every component into one of three portability tiers —
+``protocol`` (config/prompts/MCP tools/LEP hooks), ``stdlib``
+(``builtin_tools``/``builtin_hooks`` declarative references), or
+``inprocess`` (Python tool bodies, class hooks, ``resources/*.py``).
+
+These tests author tiny synthetic cartridges so the assertions are
+hermetic, plus a parametrised smoke test over the shipped
+``examples/*.cartridge`` so a regression in any real cartridge's
+component shape is caught.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge
+from looplet.cartridge.portability import INPROCESS, PROTOCOL, RUNTIME, STDLIB
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+# ── synthetic cartridges ──────────────────────────────────────
+
+
+def test_fully_portable_cartridge_has_portable_profile(tmp_path: Path) -> None:
+    """config + prompts + MCP tool + LEP hook → no Python pins."""
+    root = tmp_path / "portable.cartridge"
+    _write(
+        root / "config.yaml",
+        """
+        max_steps: 5
+        mcp_servers:
+          calc:
+            command: "python3 ${runtime.cartridge_root}/_server/calc.py"
+        """,
+    )
+    _write(root / "prompts" / "system.md", "You are a calculator.\n")
+    _write(
+        root / "hooks" / "00_guard" / "config.yaml",
+        """
+        kind: lep
+        server: server.py
+        """,
+    )
+
+    report = analyse_cartridge(root)
+
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    tiers = {(c.kind, c.name): c.tier for c in report.components}
+    assert tiers[("tool", "mcp:calc")] == PROTOCOL
+    assert tiers[("hook", "00_guard")] == PROTOCOL
+    assert tiers[("config", "config.yaml")] == PROTOCOL
+    assert tiers[("prompts", "prompts/")] == PROTOCOL
+
+
+def test_python_tool_body_pins_to_python_host(tmp_path: Path) -> None:
+    root = tmp_path / "pinned.cartridge"
+    _write(root / "config.yaml", "max_steps: 5\n")
+    _write(root / "tools" / "greet" / "tool.yaml", "name: greet\n")
+    _write(root / "tools" / "greet" / "execute.py", "def execute():\n    return {}\n")
+
+    report = analyse_cartridge(root)
+
+    assert report.profile == "python-host"
+    blockers = {c.name for c in report.blockers}
+    assert "greet" in blockers
+    greet = next(c for c in report.components if c.name == "greet")
+    assert greet.tier == INPROCESS
+    assert greet.detail == "python-execute"
+
+
+def test_single_file_tool_is_inprocess(tmp_path: Path) -> None:
+    root = tmp_path / "single.cartridge"
+    _write(root / "config.yaml", "max_steps: 5\n")
+    _write(root / "tools" / "ping.py", "def execute():\n    return {}\n")
+
+    report = analyse_cartridge(root)
+
+    ping = next(c for c in report.components if c.name == "ping")
+    assert ping.tier == INPROCESS
+    assert ping.detail == "python-single-file"
+    assert report.profile == "python-host"
+
+
+def test_class_hook_is_inprocess_lep_hook_is_protocol(tmp_path: Path) -> None:
+    root = tmp_path / "hooks.cartridge"
+    _write(root / "config.yaml", "max_steps: 5\n")
+    _write(
+        root / "hooks" / "00_policy" / "config.yaml",
+        "kind: class\nclass_name: Policy\n",
+    )
+    _write(root / "hooks" / "00_policy" / "hook.py", "class Policy:\n    pass\n")
+    _write(
+        root / "hooks" / "01_lep" / "config.yaml",
+        "kind: lep\nserver: server.py\n",
+    )
+
+    report = analyse_cartridge(root)
+
+    by_name = {c.name: c for c in report.components}
+    assert by_name["00_policy"].tier == INPROCESS
+    assert by_name["01_lep"].tier == PROTOCOL
+    assert report.profile == "python-host"
+
+
+def test_builtin_hooks_and_tools_are_stdlib_tier(tmp_path: Path) -> None:
+    root = tmp_path / "stdlib.cartridge"
+    _write(
+        root / "config.yaml",
+        """
+        max_steps: 5
+        builtin_tools:
+          - done
+        builtin_hooks:
+          - stagnation
+          -
+            per_tool_limit:
+              default_limit: 5
+        """,
+    )
+
+    report = analyse_cartridge(root)
+
+    by_name = {(c.kind, c.name): c for c in report.components}
+    assert by_name[("tool", "done")].tier == STDLIB
+    assert by_name[("hook", "stagnation")].tier == STDLIB
+    assert by_name[("hook", "per_tool_limit")].tier == STDLIB
+    # stdlib-only (no Python bodies) → still portable profile.
+    assert report.profile == "portable"
+
+
+def test_resource_is_inprocess_shared_ref(tmp_path: Path) -> None:
+    root = tmp_path / "res.cartridge"
+    _write(root / "config.yaml", "max_steps: 5\n")
+    _write(root / "resources" / "store.py", "def build():\n    return {}\n")
+
+    report = analyse_cartridge(root)
+
+    store = next(c for c in report.components if c.name == "store")
+    assert store.tier == INPROCESS
+    assert store.detail == "shared-ref"
+    assert report.profile == "python-host"
+
+
+def test_state_service_is_protocol_tier(tmp_path: Path) -> None:
+    """A ``state_services:`` entry is out-of-process shared state → protocol."""
+    root = tmp_path / "ssp.cartridge"
+    _write(
+        root / "config.yaml",
+        """
+        max_steps: 5
+        state_services:
+          log:
+            command: "python3 ${runtime.cartridge_root}/_state/log.py"
+        """,
+    )
+
+    report = analyse_cartridge(root)
+
+    svc = next(c for c in report.components if c.name == "state:log")
+    assert svc.kind == "resource"
+    assert svc.tier == PROTOCOL
+    assert svc.detail == "ssp"
+    assert report.profile == "portable"
+
+
+def test_resource_backed_by_state_service_is_protocol(tmp_path: Path) -> None:
+    """A ``resources/<n>.py`` whose name matches a declared state service is
+    served out-of-process (the loader injects a client) → protocol, not a
+    Python pin."""
+    root = tmp_path / "ssp_res.cartridge"
+    _write(
+        root / "config.yaml",
+        """
+        max_steps: 5
+        state_services:
+          greeting_log:
+            command: "python3 ${runtime.cartridge_root}/_state/greeting_log.py"
+        """,
+    )
+    # A same-named resource file is overridden by the injected client.
+    _write(
+        root / "resources" / "greeting_log.py",
+        "def build():\n    return {}\n",
+    )
+
+    report = analyse_cartridge(root)
+
+    res = next(c for c in report.components if c.kind == "resource" and c.name == "greeting_log")
+    assert res.tier == PROTOCOL
+    assert res.detail == "state-service"
+    # The declared service still emits its own protocol component too.
+    assert any(c.name == "state:greeting_log" for c in report.components)
+    assert report.profile == "portable"
+
+
+def test_to_dict_is_json_serialisable(tmp_path: Path) -> None:
+    import json
+
+    root = tmp_path / "x.cartridge"
+    _write(root / "config.yaml", "max_steps: 5\n")
+    report = analyse_cartridge(root)
+    blob = json.dumps(report.to_dict())
+    assert '"profile"' in blob
+    assert report.counts()[PROTOCOL] >= 1
+
+
+def test_non_directory_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    with pytest.raises(NotADirectoryError):
+        analyse_cartridge(missing)
+
+
+# ── shipped examples smoke test ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cartridge_dir",
+    sorted(p for p in _EXAMPLES.glob("*.cartridge") if p.is_dir()),
+    ids=lambda p: p.name,
+)
+def test_example_cartridges_analyse_without_error(cartridge_dir: Path) -> None:
+    report = analyse_cartridge(cartridge_dir)
+    # Every cartridge has at least the config component.
+    assert any(c.kind == "config" for c in report.components)
+    # Profile is always one of the two known verdicts.
+    assert report.profile in ("portable", "python-host")
+    # Render never raises and mentions the cartridge name.
+    rendered = report.render()
+    assert cartridge_dir.name in rendered
+
+
+def test_mcp_demo_calc_tool_is_protocol_portable() -> None:
+    """The mcp_demo cartridge's `calc` tool comes from an MCP server."""
+    report = analyse_cartridge(_EXAMPLES / "mcp_demo.cartridge")
+    mcp_tools = [c for c in report.components if c.detail == "mcp"]
+    assert mcp_tools, "expected at least one MCP-provided tool"
+    assert all(c.tier == PROTOCOL for c in mcp_tools)
+
+
+def test_hello_portable_example_is_fully_portable() -> None:
+    """The ``hello_portable`` cartridge has zero Python-pinned components.
+
+    It is the cross-runtime twin of ``hello`` (which is python-host): the
+    greet/done tools are an MCP server, the shared greeting log is a
+    state service, and both hooks are ``kind: lep``.
+    """
+    portable = _EXAMPLES / "hello_portable.cartridge"
+    if not portable.is_dir():
+        pytest.skip("hello_portable example cartridge not present")
+    report = analyse_cartridge(portable)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # greet/done tools
+    assert "lep" in details  # PolitenessGate + NameGuard
+    assert "ssp" in details  # greeting_log state service
+
+
+def test_hello_example_is_python_host() -> None:
+    """The original ``hello`` cartridge stays python-host (in-process tools,
+    class hook, and @ref resource) — the portable twin lives alongside it."""
+    report = analyse_cartridge(_EXAMPLES / "hello.cartridge")
+    assert report.profile == "python-host"
+
+
+def test_builtin_runtime_service_resource_is_runtime_tier(tmp_path: Path) -> None:
+    """A resource that only wraps a looplet builtin host service (compaction,
+    skill manager, …) is RUNTIME tier — a host responsibility, not an
+    author-owned shared-state blocker."""
+    root = tmp_path / "svc.cartridge"
+    (root / "resources").mkdir(parents=True)
+    (root / "config.yaml").write_text("max_steps: 3\n", encoding="utf-8")
+    (root / "resources" / "compact_service.py").write_text(
+        textwrap.dedent(
+            """\
+            from __future__ import annotations
+
+            from looplet.compact import default_compact_service
+
+            def build(runtime=None):
+                return default_compact_service(keep_recent=3)
+            """
+        ),
+        encoding="utf-8",
+    )
+    report = analyse_cartridge(root)
+    by_name = {c.name: c for c in report.components}
+    assert by_name["compact_service"].tier == RUNTIME
+    # RUNTIME components are not blockers.
+    assert by_name["compact_service"] not in report.blockers
+
+
+def test_author_state_resource_stays_inprocess(tmp_path: Path) -> None:
+    """A resource with author-owned mutable state (no builtin-service factory)
+    is still an INPROCESS blocker."""
+    root = tmp_path / "state.cartridge"
+    (root / "resources").mkdir(parents=True)
+    (root / "config.yaml").write_text("max_steps: 3\n", encoding="utf-8")
+    (root / "resources" / "file_cache.py").write_text(
+        textwrap.dedent(
+            """\
+            from __future__ import annotations
+
+            def build(runtime=None):
+                return {}
+            """
+        ),
+        encoding="utf-8",
+    )
+    report = analyse_cartridge(root)
+    by_name = {c.name: c for c in report.components}
+    assert by_name["file_cache"].tier == INPROCESS
+    assert by_name["file_cache"] in report.blockers
+
+
+def test_compact_service_examples_are_runtime_not_blockers() -> None:
+    """The real example cartridges' ``compact_service`` resource is a builtin
+    host service, so it must not count as a python-host blocker."""
+    for name in ("dep_doctor", "threat_intel", "git_detective", "coder"):
+        report = analyse_cartridge(_EXAMPLES / f"{name}.cartridge")
+        compact = next(c for c in report.components if c.name == "compact_service")
+        assert compact.tier == RUNTIME, name
+        assert compact not in report.blockers, name
+
+
+def test_extends_inheritance_folds_in_parent_blockers(tmp_path: Path) -> None:
+    """A child that ``extends:`` a python-host parent inherits its blockers.
+
+    Without resolving ``extends:`` the analyzer would silently under-count
+    (e.g. a one-tool child extending a many-blocker parent would look almost
+    portable). Inherited components are tagged ``(inherited)``.
+    """
+    parent = tmp_path / "parent.cartridge"
+    _write(parent / "config.yaml", "max_steps: 5\n")
+    _write(parent / "tools" / "heavy" / "execute.py", "def execute():\n    return {}\n")
+    _write(parent / "tools" / "heavy" / "tool.yaml", "name: heavy\n")
+
+    child = tmp_path / "child.cartridge"
+    _write(child / "config.yaml", "extends: ../parent.cartridge\nmax_steps: 5\n")
+    _write(child / "tools" / "own" / "execute.py", "def execute():\n    return {}\n")
+    _write(child / "tools" / "own" / "tool.yaml", "name: own\n")
+
+    report = analyse_cartridge(child)
+    names = {c.name for c in report.components}
+    assert "own" in names  # child's own tool
+    assert "heavy (inherited)" in names  # parent's tool, folded in
+    # Both are python-host blockers.
+    assert report.profile == "python-host"
+    assert any(b.name == "heavy (inherited)" for b in report.blockers)
+
+
+def test_agent_factory_inherits_coder_blockers() -> None:
+    """``agent_factory`` extends ``coder``; the report must reflect coder's
+    inherited Python-pinned components, not just its own one tool."""
+    report = analyse_cartridge(_EXAMPLES / "agent_factory.cartridge")
+    assert report.profile == "python-host"
+    inherited = [b for b in report.blockers if b.name.endswith("(inherited)")]
+    assert len(inherited) >= 10  # coder contributes many blockers


### PR DESCRIPTION
Stacked on #86. Adds a static cross-runtime portability analyzer:

- `cartridge/portability.py` — `analyse_cartridge()` classifies every cartridge component into tiers (stdlib / runtime / protocol / in-process) and produces an overall **portable** vs **python-host** verdict with a list of Python-pinned blockers. Resolves `extends:` inheritance so child cartridges fold in parent blockers.
- `cartridge/__init__.py` exports `analyse_cartridge`.
- `cli/factory_commands.py` — new `looplet portability <cartridge>` subcommand (`--json`, `--require-portable` CI gate); also threads `project_root`/`max_steps` into `cmd_run_workspace`.
- `docs/portability.md` + `mkdocs.yml` nav entry.
- Tests: `test_cartridge_portability.py` (tier classification, builtin-service detection, extends folding, JSON serialisation, shipped-example smoke).

Additive only. Full suite green (2064 passed, 3 skipped); ruff + pyright clean. The `hello_portable` example assertion is skip-guarded until its twin lands in the next PR.