### PR TITLE
feat: portable cross-runtime twins for all 8 example cartridges

### DIFF
--- a/examples/coder_portable.cartridge/_lep/coder_lib_hooks.py
+++ b/examples/coder_portable.cartridge/_lep/coder_lib_hooks.py
@@ -1,0 +1,228 @@
+"""Observability hooks for the coder example.
+
+These four hooks are domain-specific (they know what a Python test
+runner or a ruff lint failure looks like) but framework-generic:
+each one implements the standard :class:`looplet.loop.LoopHook`
+protocol and returns ``HookDecision``/``InjectContext`` values, so
+they compose with the rest of the looplet ecosystem.
+
+Design intent — *steer, don't restrict*:
+
+* :class:`TestGuardHook` defaults to **observe-only** mode.
+  Failures emit a briefing nudge; ``done()`` is never blocked.
+  Outcome verification happens after the run via the eval hook
+  built in :func:`examples.coder.wiring.build_eval_hook`. Pass
+  ``strict=True`` to opt into a hard block on done() until tests pass.
+* :class:`StaleFileHook` injects a re-read nudge when bash modifies
+  a previously-read file (it does not block edits).
+* :class:`LinterHook` runs ``ruff check`` after Python file edits
+  and surfaces diagnostics; it does not refuse to dispatch.
+* :class:`FileCacheHook` re-injects the file cache into the
+  briefing after compaction kicks in.
+
+See ``docs/evals.md`` ("Trajectory-blind evals") for the rationale
+and ``docs/hooks.md`` for the broader contract.
+"""
+
+from __future__ import annotations
+
+import os
+import os as _os
+import shutil
+import subprocess
+import sys as _sys
+from pathlib import Path
+
+_sys.path.insert(0, _os.path.join(_os.path.dirname(__file__), "..", "_mcp"))
+from coder_lib_tools import FileCache
+
+from looplet.hook_decision import HookDecision, InjectContext
+
+__all__ = [
+    "TestGuardHook",
+    "FileCacheHook",
+    "StaleFileHook",
+    "LinterHook",
+]
+
+
+class TestGuardHook:
+    """Watches for test runs and nudges the model on failures.
+
+    By default (``strict=False``), the hook only **observes**:
+    it injects a briefing nudge after each test invocation
+    ("Tests passed" / "Tests FAILED — read the traceback…") and
+    surfaces the outcome to evaluators via ``state``. It does NOT
+    block ``done()``: the model may have a legitimate reason to
+    finish without running tests (docs change, no test runner,
+    flaky suite). Outcome-grading happens after the run via an
+    ``EvalHook`` collector that re-checks the test suite.
+
+    Pass ``strict=True`` to recover the old hard-block behavior
+    (refuse ``done()`` if files were written but tests didn't pass).
+    Use sparingly — see ``docs/evals.md`` "Trajectory-blind evals"
+    for the rationale.
+    """
+
+    def __init__(self, *, strict: bool = False) -> None:
+        self._tests_passed = False
+        self._files_written: set[str] = set()
+        self._strict = strict
+
+    @property
+    def tests_passed(self) -> bool:
+        return self._tests_passed
+
+    @property
+    def files_written(self) -> set[str]:
+        return set(self._files_written)
+
+    def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+        if tool_call.tool == "bash":
+            cmd = tool_call.args.get("command", "")
+            data = tool_result.data or {}
+            if any(
+                t in cmd
+                for t in ["pytest", "python -m pytest", "npm test", "cargo test", "go test"]
+            ):
+                self._tests_passed = data.get("exit_code", 1) == 0
+                if not self._tests_passed:
+                    return InjectContext(
+                        "⚠ Tests FAILED. Read the traceback. Find the exact file:line. Read that code. Fix the issue. Re-run tests."
+                    )
+                return InjectContext("✓ Tests passed.")
+        if tool_call.tool in ("write_file", "edit_file"):
+            self._files_written.add(tool_call.args.get("file_path", ""))
+        return None
+
+    def check_done(self, state, session_log, context, step_num):
+        if not self._strict:
+            # Observe-only: surface a nudge but allow `done()` to proceed.
+            # Outcome is graded post-run via the EvalHook collector.
+            if not self._tests_passed and self._files_written:
+                return InjectContext(
+                    "⚠ Finishing without a passing test run. "
+                    "An eval will re-check the suite after the run."
+                )
+            return None
+        # Strict mode: hard block on done() until tests pass.
+        if not self._tests_passed and self._files_written:
+            return HookDecision(block="Run tests first. If no tests exist, create them.")
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False
+
+
+class StaleFileHook:
+    """Detects when bash commands modify files the model previously read.
+
+    Mirrors Claude Code's staleReadFileStateHint: after each bash step,
+    checks cached file mtimes and warns the model to re-read before editing.
+    """
+
+    def __init__(self, cache: FileCache):
+        self._cache = cache
+
+    def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+        if tool_call.tool != "bash":
+            return None
+        # Check for stale files even on failed commands — a partial
+        # build or interrupted write can still modify files.
+        stale = self._cache.stale_files()
+        if stale:
+            return InjectContext(
+                f"⚠ Stale files: {', '.join(stale)} were modified by this command. "
+                f"Re-read them with read_file before editing."
+            )
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False
+
+
+class LinterHook:
+    """Runs ruff check after Python file edits, injects diagnostics.
+
+    Mirrors Claude Code's automatic LSP error reporting after file edits.
+    Only runs when ruff is available in the workspace.
+    """
+
+    def __init__(self, workspace: str):
+        self._workspace = workspace
+        self._ruff_available: bool | None = None
+        self._ruff_cmd: list[str] | None = None
+
+    def _find_ruff(self) -> list[str] | None:
+        workspace_path = Path(self._workspace)
+        for candidate in (
+            workspace_path / ".venv" / "bin" / "ruff",
+            workspace_path / "venv" / "bin" / "ruff",
+        ):
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return [str(candidate)]
+        path_ruff = shutil.which("ruff")
+        if path_ruff:
+            return [path_ruff]
+        uv = shutil.which("uv")
+        if uv and (
+            (workspace_path / "pyproject.toml").exists() or (workspace_path / "uv.lock").exists()
+        ):
+            return [uv, "run", "ruff"]
+        return None
+
+    def _check_ruff(self) -> bool:
+        if self._ruff_available is None:
+            self._ruff_cmd = self._find_ruff()
+            if self._ruff_cmd is None:
+                self._ruff_available = False
+                return False
+            try:
+                r = subprocess.run(self._ruff_cmd + ["--version"], capture_output=True, timeout=5)
+                self._ruff_available = r.returncode == 0
+            except Exception:
+                self._ruff_available = False
+        return self._ruff_available
+
+    def post_dispatch(self, state, session_log, tool_call, tool_result, step_num):
+        if tool_call.tool not in ("edit_file", "write_file"):
+            return None
+        file_path = tool_call.args.get("file_path", "")
+        if not file_path.endswith(".py"):
+            return None
+        if tool_result.error:
+            return None
+        if not self._check_ruff():
+            return None
+        try:
+            r = subprocess.run(
+                (self._ruff_cmd or ["ruff"]) + ["check", "--no-fix", file_path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=self._workspace,
+            )
+            if r.returncode != 0 and r.stdout.strip():
+                lines = r.stdout.strip().splitlines()
+                if len(lines) > 10:
+                    lines = lines[:10] + [f"... and {len(lines) - 10} more issues"]
+                return InjectContext(f"⚠ Lint issues in {file_path}:\n" + "\n".join(lines))
+        except Exception:
+            pass
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False
+
+
+class FileCacheHook:
+    def __init__(self, cache: FileCache):
+        self._cache = cache
+
+    def pre_prompt(self, state, session_log, context, step_num):
+        if step_num > 3:
+            return self._cache.render() or None
+        return None
+
+    def should_stop(self, state, step_num, new_entities):
+        return False

--- a/examples/coder_portable.cartridge/_lep/lep_common.py
+++ b/examples/coder_portable.cartridge/_lep/lep_common.py
@@ -1,0 +1,77 @@
+"""Shared helpers for the portable coder LEP hook servers.
+
+Two pieces the in-process hooks took for granted now cross process
+boundaries:
+
+* ``FileCacheProxy`` — the StaleFile/FileCache hooks were constructed
+  with the shared ``@file_cache`` instance. Here that cache lives in a
+  State Service; this proxy forwards the two methods those hooks call
+  (``stale_files`` / ``render``) over the socket the loader exported as
+  ``LOOPLET_STATE_FILE_CACHE`` — the SAME socket the MCP file tools use,
+  so hook and tool processes observe one cache.
+
+* ``view_to_call`` — the LEP adapter ships a declared *view* dict; the
+  vendored hook methods expect ``tool_call`` / ``tool_result`` objects.
+  This rebuilds the minimal duck-typed objects those methods read.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any
+
+from looplet.hook_decision import HookDecision, InjectContext
+from looplet.state_service import StateServiceClient
+
+
+class FileCacheProxy:
+    """SSP-backed stand-in for the shared FileCache (hook surface only)."""
+
+    def __init__(self) -> None:
+        self._c: StateServiceClient | None = None
+        socket_path = os.environ.get("LOOPLET_STATE_FILE_CACHE")
+        if socket_path:
+            try:
+                self._c = StateServiceClient(socket_path)
+            except Exception:  # noqa: BLE001 - degrade gracefully
+                self._c = None
+
+    def stale_files(self) -> list:
+        if self._c is None:
+            return []
+        return list(self._c.stale_files() or [])
+
+    def render(self) -> str:
+        if self._c is None:
+            return ""
+        return str(self._c.render() or "")
+
+
+def view_to_call(view: dict[str, Any]) -> SimpleNamespace:
+    """Rebuild a ``tool_call``-shaped object from a LEP view."""
+    return SimpleNamespace(tool=view.get("tool"), args=view.get("args") or {})
+
+
+def view_to_result(view: dict[str, Any]) -> SimpleNamespace:
+    """Rebuild a ``tool_result``-shaped object from a LEP view."""
+    tr = view.get("tool_result") or {}
+    return SimpleNamespace(data=tr.get("data") or {}, error=tr.get("error"))
+
+
+def normalize(decision: Any) -> Any:
+    """Coerce a vendored hook return into a LEP-acceptable effect.
+
+    The in-process hook slots return ``HookDecision``/``InjectContext``
+    (already fine) — but ``pre_prompt`` returns a bare ``str`` briefing.
+    LEP's ``_effect_dict`` only accepts ``HookDecision|dict|None``, so a
+    plain string is wrapped as an ``InjectContext`` (the adapter then
+    surfaces it via ``decision.additional_context``).
+    """
+    if decision is None:
+        return None
+    if isinstance(decision, HookDecision):
+        return decision
+    if isinstance(decision, str):
+        return InjectContext(decision) if decision else None
+    return decision

--- a/examples/coder_portable.cartridge/_mcp/_tools/bash.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/bash.py
@@ -1,0 +1,134 @@
+"""bash tool — execute a shell command in the workspace root.
+
+Receives the workspace_config resource through ``ctx.resources``
+(workspace tool DI; ``tool.yaml`` declares ``requires:
+[workspace_config]``). Top-level function (no closures) so it
+round-trips losslessly through ``preset_to_cartridge``.
+
+Pre-dispatch checks (model-actionable, fail-loud rather than silent):
+
+* **Destructive command detection.** A small allow-list of
+  patterns (``rm -rf``, ``git push --force``, ``dd``, ``mkfs``,
+  process killers) refuses execution and points at the safer
+  alternative. Novel commands flow through unchanged — the
+  permission engine is the principled gate.
+* **sed -i refusal.** ``sed`` in-place edits bypass the file_cache,
+  causing the next ``read_file`` to return stale content. Refuses
+  with a pointer at ``edit_file``.
+* **cd-outside-workspace warning.** Surfaces (does not block) a
+  ``cd`` whose target escapes the project root.
+
+The actual command-execution logic lives in ``coder_lib_tools._run``
+so this file stays a thin adapter and all tools share one
+battle-tested implementation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from coder_lib_tools import (
+    _is_path_inside,
+    _run,
+    classify_bash_command,
+    classify_sed_command,
+    classify_view_command,
+)
+
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, command: str) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+
+    # Destructive-command pre-flight. Returns model-actionable error
+    # naming each reason so the model can adjust the next call.
+    classification = classify_bash_command(command)
+    if classification["destructive"]:
+        return {
+            "error": (
+                "Refused: destructive command pattern detected. "
+                + " ".join(classification["reasons"])
+                + ". If this is intentional, ask the user to confirm."
+            ),
+            "first_token": classification["first_token"],
+            "reasons": classification["reasons"],
+            "recovery": (
+                "Pick a safer alternative (e.g. remove specific files instead "
+                "of `rm -rf`; create a NEW commit instead of `git reset --hard`)."
+            ),
+        }
+
+    # sed -i refusal: route in-place edits through edit_file so the
+    # file_cache stays coherent.
+    sed = classify_sed_command(command)
+    if sed["in_place_edit"]:
+        return {
+            "error": (
+                "Refused: `sed -i` in-place file edits bypass the file_cache. "
+                + sed["recommendation"]
+            ),
+            "recovery": "edit_file(file_path=..., old_string=..., new_string=...)",
+        }
+
+    # cat/head/tail/less on a source file refusal: route file viewing
+    # through read_file so the file_cache records the read and the
+    # next edit_file can succeed.
+    view = classify_view_command(command)
+    if view["viewing_file"]:
+        return {
+            "error": (
+                f"Refused: `{view['first_token']}` on a source file bypasses "
+                "the file_cache. " + view["recommendation"]
+            ),
+            "first_token": view["first_token"],
+            "recovery": "read_file(file_path=...)",
+        }
+
+    # Repeated-command refusal: if the model has already issued this
+    # exact command twice in a row, it's almost certainly stuck in a
+    # loop on a failing step. Refuse so the model is forced to try
+    # something different (read the file, change the args, ask for help).
+    if cache is not None:
+        repeats = cache.recent_bash_repeats(command)
+        if repeats >= 2:
+            return {
+                "error": (
+                    f"Refused: this exact bash command has been run "
+                    f"{repeats + 1} times in a row with no progress. "
+                    f"Repeating the same command will produce the same "
+                    f"result. Try a different approach: read the failing "
+                    f"file, change the command, or use a different tool."
+                ),
+                "repeats": repeats + 1,
+                "recovery": (
+                    "Inspect what's failing with read_file or grep, then "
+                    "issue a NEW command that addresses the root cause."
+                ),
+            }
+        cache.record_bash(command)
+
+    result = _run(command, workspace)
+
+    # Detect cd outside workspace and surface a warning so the model
+    # doesn't silently lose track of where commands run.
+    parts = re.split(r"&&|\|\||;|\n", command)
+    for part in parts:
+        part = part.strip()
+        if part.startswith("cd "):
+            target = part[3:].strip().strip("'\"")
+            resolved = Path(workspace) / target
+            try:
+                resolved = resolved.resolve()
+                ws_resolved = Path(workspace).resolve()
+                if not _is_path_inside(resolved, ws_resolved):
+                    result["cwd_warning"] = (
+                        f"Warning: 'cd {target}' points outside the project directory. "
+                        f"All commands run in the project root. Use relative paths."
+                    )
+            except Exception:
+                pass
+    return result

--- a/examples/coder_portable.cartridge/_mcp/_tools/bash.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/bash.yaml
@@ -1,0 +1,30 @@
+name: bash
+description: |-
+  Execute a bash command in the project directory and return stdout, stderr, and exit code.
+
+  Usage:
+  - Use this for system commands and terminal operations that don't have a dedicated tool.
+  - Prefer the dedicated tools (read_file, write_file, edit_file, grep, glob, list_dir) over equivalent shell commands so the user / observers can review your work consistently. Only fall back on bash when no dedicated tool fits.
+  - All commands run with cwd = the project root. Use relative paths.
+  - Each call is independent: state set by `cd`, `export`, etc. does NOT carry across calls. Chain with `&&`, `;`, or `|` if you need shared state inside one call.
+  - Output is captured into the result. Long output may be truncated; for very large outputs prefer grep/head/tail to filter at source.
+  - Default timeout: 600s. Long-running commands that exceed it are terminated.
+
+  Refusals (model-actionable, fail-loud):
+  - **Destructive commands** are refused: `rm -rf`, `git push --force`, `git reset --hard`, `dd`, `mkfs`, `kill`, `shutdown`. The error names the matched pattern; pick a safer alternative (delete specific files, create a NEW commit, etc.) or ask the user to authorize the action.
+  - **`sed -i`** is refused: in-place sed bypasses the file_cache so the next read_file would return stale content. Use `edit_file` for in-place file edits.
+  - **`cat` / `cat -n` / `head` / `tail` / `less` / `more` on a single source file** is refused: viewing files through bash bypasses the file_cache, which then refuses your next `edit_file` because the file "wasn't read" in this session. Use `read_file` to view file contents. (`cat`/`head`/`tail` are still allowed when piping output of another command, e.g. `grep ... | head`.)
+  - **`cd` outside the project root** is allowed but produces a warning so you don't lose track of where commands run.
+
+  Examples:
+  - `pytest -xvs` (stop on first failure, verbose)
+  - `git status && git diff --stat`
+  - `ls -la src/ | head -20`
+parameters:
+  command:
+    type: string
+    description: Shell command to execute. Single string, may contain pipes / && / ;.
+timeout_s: 600
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/_tools/done.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/done.py
@@ -1,0 +1,5 @@
+"""done tool — completion sentinel."""
+
+
+def execute(*, summary: str) -> dict:
+    return {"status": "completed", "summary": summary}

--- a/examples/coder_portable.cartridge/_mcp/_tools/done.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/done.yaml
@@ -1,0 +1,14 @@
+name: done
+description: Signal that the coding task is complete. Provide a brief summary.
+parameters:
+  summary:
+    type: string
+    description: One-line summary of what was accomplished.
+# v1.0 output_schema: validated by the loop before termination.
+output_schema:
+  type: object
+  required: [summary]
+  properties:
+    summary:
+      type: string
+      description: Free-form summary of the task outcome.

--- a/examples/coder_portable.cartridge/_mcp/_tools/edit_file.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/edit_file.py
@@ -1,0 +1,81 @@
+"""edit_file tool — exact-string replacement with fuzzy fallback hints.
+
+Receives ``workspace_config`` and ``file_cache`` through
+``ctx.resources``; ``tool.yaml`` declares
+``requires: [workspace_config, file_cache]``.
+"""
+
+from __future__ import annotations
+
+import difflib
+
+from coder_lib_tools import _fuzzy_find, _resolve_safe_path
+
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, file_path: str, old_string: str, new_string: str) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, file_path)
+    if p is None:
+        return {"error": f"Path '{file_path}' is outside the project directory."}
+    if not p.exists():
+        return {"error": f"File not found: {file_path}"}
+    # Read-before-edit enforcement. Editing a file the model hasn't
+    # read in this session is almost always a sign that the model is
+    # guessing at content — the resulting old_string usually doesn't
+    # match and the call wastes a turn. Refuse early with a message
+    # that names the read tool so the model self-corrects.
+    if cache is not None and not cache.was_read(file_path):
+        return {
+            "error": (
+                f"Cannot edit {file_path!r}: this file has not been read in "
+                f"the current session. Call read_file({file_path!r}) first so "
+                f"you can copy old_string verbatim from its content. Editing "
+                f"without reading first usually fails because the file's "
+                f"actual contents differ from what was assumed."
+            ),
+            "missing": "prior_read",
+            "recovery": f"read_file(file_path={file_path!r})",
+        }
+    if old_string == new_string:
+        return {"error": "old_string and new_string are identical. No change needed."}
+    text = p.read_text()
+    count = text.count(old_string)
+    if count == 1:
+        new_text = text.replace(old_string, new_string, 1)
+        p.write_text(new_text)
+        if cache is not None:
+            cache.invalidate(file_path)
+        diff = difflib.unified_diff(
+            text.splitlines(keepends=True),
+            new_text.splitlines(keepends=True),
+            fromfile=f"a/{file_path}",
+            tofile=f"b/{file_path}",
+            n=3,
+        )
+        diff_text = "".join(diff)
+        if len(diff_text) > 2000:
+            diff_text = diff_text[:2000] + "\n... [diff truncated]"
+        return {"edited": file_path, "replacements": 1, "diff": diff_text}
+    if count > 1:
+        return {
+            "error": (
+                f"Matches {count} locations. Include more surrounding context for a unique match."
+            ),
+            "matches": count,
+        }
+    fuzzy = _fuzzy_find(text, old_string)
+    if fuzzy:
+        hints = [f"  line {n} ({r:.0%}): {t.strip()[:80]}" for n, r, t in fuzzy[:3]]
+        return {
+            "error": (
+                "Exact match not found. Similar lines:\n"
+                + "\n".join(hints)
+                + "\n\nRECOVERY: read_file at those lines, then retry with exact text."
+            ),
+            "similar_lines": [f[0] for f in fuzzy[:3]],
+        }
+    return {"error": f"Not found in {file_path}. Use read_file to see exact content."}

--- a/examples/coder_portable.cartridge/_mcp/_tools/edit_file.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/edit_file.yaml
@@ -1,0 +1,30 @@
+name: edit_file
+description: |-
+  Perform an exact-string replacement in an existing file.
+
+  Usage:
+  - **You must call `read_file` on the same path first in the current session.** edit_file refuses with a clear error otherwise — editing without reading first usually fails because the file's actual content differs from what was assumed.
+  - `old_string` must match the file contents EXACTLY, character for character (whitespace, indentation, newlines all matter). Copy from read_file's output, removing only the `   N | ` line-number prefix.
+  - `old_string` must appear EXACTLY ONCE in the file. If it matches multiple locations, the call returns the match count and you should add more surrounding context (3+ lines) to make it unique.
+  - If `old_string` doesn't match, the response includes "Similar lines:" with line numbers + similarity scores. Re-read those lines and retry with the exact text.
+  - Use `write_file` (not edit_file) for creating new files. Use multiple edit_file calls for multiple separate changes — one edit per call so each step is reviewable.
+  - Returns a unified diff so you can verify the change applied correctly.
+
+  Recovery:
+  - "not been read" → call `read_file(file_path)` first
+  - "Matches N locations" → add more context lines around old_string
+  - "Exact match not found" → re-read the suggested similar lines, copy text exactly
+parameters:
+  file_path:
+    type: string
+    description: Path to edit (relative to project root).
+  old_string:
+    type: string
+    description: |-
+      Exact text to replace. Must match the file content character-for-character and appear exactly once. Copy from a prior read_file's output, dropping the `   N | ` line-number prefix.
+  new_string:
+    type: string
+    description: Replacement text. May be longer or shorter than old_string.
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/_tools/git_inspect.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/git_inspect.py
@@ -1,0 +1,63 @@
+"""git_inspect tool — safe read-only git helpers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from looplet.types import ToolContext
+
+
+def _run(workspace: str, args: list[str]) -> dict:
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, capture_output=True, text=True, timeout=30
+    )
+    return {
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def execute(
+    ctx: ToolContext, *, operation: str = "status", pathspec: str = "", max_count: int = 10
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    probe = _run(workspace, ["rev-parse", "--is-inside-work-tree"])
+    if probe["exit_code"] != 0:
+        return {"error": "Not inside a git worktree", "stderr": probe["stderr"]}
+    op = operation.strip().lower() or "status"
+    if op == "status":
+        args = ["status", "--short", "--branch"]
+    elif op == "diff":
+        args = ["diff"] + (["--", pathspec] if pathspec else [])
+    elif op == "diff_stat":
+        args = ["diff", "--stat"] + (["--", pathspec] if pathspec else [])
+    elif op == "branch":
+        args = ["branch", "--show-current"]
+    elif op == "recent":
+        args = ["log", "--oneline", "--decorate", "-n", str(max(1, int(max_count or 10)))]
+    elif op == "changed_files":
+        args = ["diff", "--name-only"] + (["--", pathspec] if pathspec else [])
+    else:
+        return {
+            "error": f"unknown operation {operation!r}",
+            "valid_operations": [
+                "status",
+                "diff",
+                "diff_stat",
+                "branch",
+                "recent",
+                "changed_files",
+            ],
+        }
+    result = _run(workspace, args)
+    result.update({"operation": op, "command": "git " + " ".join(args)})
+    if len(result["stdout"]) > 20000:
+        result["stdout"] = (
+            result["stdout"][:10000]
+            + "\n... [git output truncated] ...\n"
+            + result["stdout"][-10000:]
+        )
+        result["truncated"] = True
+    return result

--- a/examples/coder_portable.cartridge/_mcp/_tools/git_inspect.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/git_inspect.yaml
@@ -1,0 +1,29 @@
+name: git_inspect
+description: |-
+  Inspect git repository state with safe, read-only git commands.
+
+  Usage:
+  - Prefer this over ad-hoc `bash` for git status, diffs, changed files, current branch, and recent commits.
+  - This tool never commits, pushes, checks out, resets, or modifies files.
+  - Use `pathspec` to scope `diff`, `diff_stat`, or `changed_files` to one file or directory.
+
+  Examples:
+  - `git_inspect(operation="status")`
+  - `git_inspect(operation="diff", pathspec="src/")`
+  - `git_inspect(operation="recent", max_count=5)`
+parameters:
+  operation:
+    type: string
+    description: status, diff, diff_stat, branch, recent, or changed_files.
+    default: status
+  pathspec:
+    type: string
+    description: Optional git pathspec for diff operations.
+    default: ""
+  max_count:
+    type: integer
+    description: Maximum recent commits for operation=recent.
+    default: 10
+concurrent_safe: true
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/glob.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/glob.py
@@ -1,0 +1,24 @@
+"""glob tool — match files by glob pattern, return relative paths.
+
+Receives the workspace_config resource through ``ctx.resources``;
+``tool.yaml`` declares ``requires: [workspace_config]``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, pattern: str) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    return {
+        "pattern": pattern,
+        "matches": sorted(
+            str(path.relative_to(workspace))
+            for path in Path(workspace).glob(pattern)
+            if path.is_file()
+        )[:100],
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/glob.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/glob.yaml
@@ -1,0 +1,21 @@
+name: glob
+description: |-
+  Find files in the project by glob pattern.
+
+  Usage:
+  - Use Python `pathlib.Path.glob` syntax: `*` matches any chars in a name, `**` matches any number of directories, `?` matches a single char.
+  - Path patterns are rooted at the project root: `src/**/*.py` finds every Python file under src/.
+  - Returns paths relative to the project root, sorted, capped at 100 results.
+  - Use this to find files by NAME pattern. Use `grep` to find files by CONTENT.
+
+  Examples:
+  - `glob(pattern="**/*.py")` — every Python file in the project
+  - `glob(pattern="tests/test_*.py")` — every test file
+  - `glob(pattern="src/**/cli.*")` — any cli.* under src/
+parameters:
+  pattern:
+    type: string
+    description: Glob pattern. Use ** for recursive directory match.
+concurrent_safe: true
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/grep.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/grep.py
@@ -1,0 +1,157 @@
+"""grep tool — rg-first recursive search with workspace-relative output paths.
+
+Receives the workspace_config resource through ``ctx.resources``;
+``tool.yaml`` declares ``requires: [workspace_config]``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from coder_lib_tools import _resolve_safe_path
+
+from looplet.types import ToolContext
+
+
+def _relativize(lines: list[str], workspace: str) -> list[str]:
+    workspace_prefix = str(Path(workspace).resolve()) + os.sep
+    return [
+        line.removeprefix(workspace_prefix) if line.startswith(workspace_prefix) else line
+        for line in lines
+    ]
+
+
+def _page(items: list[str], head_limit: int, offset: int) -> tuple[list[str], bool]:
+    safe_offset = max(0, int(offset or 0))
+    if head_limit == 0:
+        return items[safe_offset:], False
+    limit = max(1, int(head_limit or 250))
+    sliced = items[safe_offset : safe_offset + limit]
+    return sliced, len(items) - safe_offset > limit
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    pattern: str,
+    path: str = ".",
+    include: str = "",
+    glob: str = "",
+    output_mode: str = "content",
+    type: str = "",
+    context: int = 0,
+    before: int = 0,
+    after: int = 0,
+    case_insensitive: bool = False,
+    head_limit: int = 250,
+    offset: int = 0,
+    multiline: bool = False,
+    max_count: int = 0,
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    target = _resolve_safe_path(workspace, path)
+    if target is None:
+        return {"error": f"Path '{path}' is outside the project directory."}
+    if not target.exists():
+        return {"error": f"Path not found: {path}", "matches": [], "count": 0}
+
+    mode = (output_mode or "content").strip().lower()
+    if mode not in {"content", "files_with_matches", "count"}:
+        return {
+            "error": f"unknown output_mode {output_mode!r}",
+            "valid_modes": ["content", "files_with_matches", "count"],
+        }
+
+    rg = shutil.which("rg")
+    file_glob = glob or include
+    if rg:
+        cmd = [rg, "--color", "never"]
+        if mode == "content":
+            cmd.append("--line-number")
+            if context > 0:
+                cmd.extend(["-C", str(context)])
+            else:
+                if before > 0:
+                    cmd.extend(["-B", str(before)])
+                if after > 0:
+                    cmd.extend(["-A", str(after)])
+        elif mode == "files_with_matches":
+            cmd.append("--files-with-matches")
+        else:
+            cmd.append("--count-matches")
+        if case_insensitive:
+            cmd.append("-i")
+        if multiline:
+            cmd.extend(["-U", "--multiline-dotall"])
+        if file_glob:
+            cmd.extend(["--glob", file_glob])
+        if type:
+            cmd.extend(["--type", type])
+        if max_count > 0:
+            cmd.extend(["--max-count", str(max_count)])
+        cmd.extend(["--", pattern, str(target)])
+        engine = "rg"
+    else:
+        cmd = ["grep", "-rn"]
+        if case_insensitive:
+            cmd.append("-i")
+        if mode == "files_with_matches":
+            cmd.append("-l")
+        elif mode == "count":
+            cmd.append("-c")
+        elif context > 0:
+            cmd.extend(["-C", str(context)])
+        else:
+            if before > 0:
+                cmd.extend(["-B", str(before)])
+            if after > 0:
+                cmd.extend(["-A", str(after)])
+        if file_glob:
+            cmd.append(f"--include={file_glob}")
+        cmd.extend(["--", pattern, str(target)])
+        engine = "grep"
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=workspace,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "error": "Search timed out",
+            "pattern": pattern,
+            "matches": [],
+            "count": 0,
+            "engine": engine,
+        }
+    lines = _relativize(result.stdout.splitlines() if result.stdout else [], workspace)
+    paged, truncated = _page(lines, head_limit=head_limit, offset=offset)
+    data = {
+        "pattern": pattern,
+        "path": path,
+        "mode": mode,
+        "engine": engine,
+        "matches": paged,
+        "count": len(lines),
+        "truncated": truncated,
+        "offset": max(0, int(offset or 0)),
+    }
+    if mode == "files_with_matches":
+        data["filenames"] = paged
+    elif mode == "count":
+        data["counts"] = paged
+    else:
+        data["content"] = "\n".join(paged)
+    if result.returncode not in (0, 1):
+        data["error"] = result.stderr.strip() or f"grep exited {result.returncode}"
+    if truncated:
+        data["recovery"] = (
+            "Use a narrower path/glob/type, increase offset, or set head_limit=0 only when the result is known to be small."
+        )
+    return data

--- a/examples/coder_portable.cartridge/_mcp/_tools/grep.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/grep.yaml
@@ -1,0 +1,76 @@
+name: grep
+description: |-
+  Recursively search file contents using `rg` when available, with a `grep -rn` fallback. Returns paginated, workspace-relative matches.
+
+  Usage:
+  - Use this to find files by CONTENT (e.g. "where is function foo defined?", "which files import X?"). Use `glob` to find files by NAME pattern.
+  - The pattern is passed to ripgrep/grep directly so you get regex syntax. Quote or escape special chars when needed.
+  - `path` defaults to the project root; pass a subdir to narrow the search.
+  - Use `glob` or legacy `include` to scope by file pattern (e.g. `glob="*.py"` or `glob="*.{js,ts}"`).
+  - `output_mode="content"` returns matching lines; `files_with_matches` returns only file paths; `count` returns per-file counts.
+  - Use `context`, `before`, or `after` to include neighboring lines in content mode.
+  - Use `head_limit` and `offset` to page through large results. Default cap is 250 results.
+
+  Examples:
+  - `grep(pattern="def authenticate", glob="*.py", output_mode="content")` — find Python defs of authenticate
+  - `grep(pattern="TODO|FIXME", path="src/", output_mode="files_with_matches")` — find files with TODOs in src/
+  - `grep(pattern="class User", type="py", context=2)` — show matches with two lines of context
+parameters:
+  pattern:
+    type: string
+    description: Regex pattern to search for.
+  path:
+    type: string
+    description: Directory to search in, relative to project root.
+    default: "."
+  include:
+    type: string
+    description: Legacy file glob filter. Prefer `glob` for new calls.
+    default: ""
+  glob:
+    type: string
+    description: File glob filter (e.g. "*.py", "*.{js,ts}").
+    default: ""
+  output_mode:
+    type: string
+    description: One of content, files_with_matches, count.
+    default: content
+  type:
+    type: string
+    description: Ripgrep file type filter such as py, js, rust, go. Ignored by grep fallback.
+    default: ""
+  context:
+    type: integer
+    description: Lines before and after each match in content mode.
+    default: 0
+  before:
+    type: integer
+    description: Lines before each match in content mode.
+    default: 0
+  after:
+    type: integer
+    description: Lines after each match in content mode.
+    default: 0
+  case_insensitive:
+    type: boolean
+    description: Case-insensitive search.
+    default: false
+  head_limit:
+    type: integer
+    description: Maximum result lines/items to return. Use 0 for unlimited.
+    default: 250
+  offset:
+    type: integer
+    description: Number of result lines/items to skip before applying head_limit.
+    default: 0
+  multiline:
+    type: boolean
+    description: Enable ripgrep multiline mode when rg is available.
+    default: false
+  max_count:
+    type: integer
+    description: Stop after this many matches per file when rg is available. 0 means no per-file cap.
+    default: 0
+concurrent_safe: true
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/list_dir.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/list_dir.py
@@ -1,0 +1,53 @@
+"""list_dir tool — tree view of a workspace path.
+
+Receives the workspace_config resource through ``ctx.resources``;
+``tool.yaml`` declares ``requires: [workspace_config]``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet.types import ToolContext
+
+_SKIP = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    ".tox",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+}
+
+
+def execute(ctx: ToolContext, *, path: str = ".", depth: int = 2) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    target = Path(workspace) / path
+    if not target.exists():
+        return {"error": f"Not found: {path}"}
+    if not target.is_dir():
+        return {"error": f"Not a directory: {path}"}
+    entries: list[str] = []
+
+    def _walk(p: Path, prefix: str, d: int) -> None:
+        if d > depth:
+            return
+        try:
+            items = sorted(p.iterdir(), key=lambda x: (not x.is_dir(), x.name))
+        except PermissionError:
+            return
+        for item in items:
+            if item.name in _SKIP:
+                continue
+            if item.is_dir():
+                entries.append(f"{prefix}{item.name}/")
+                _walk(item, prefix + "  ", d + 1)
+            elif len(entries) < 200:
+                entries.append(f"{prefix}{item.name}")
+
+    _walk(target, "", 0)
+    return {"path": path, "entries": entries, "count": len(entries)}

--- a/examples/coder_portable.cartridge/_mcp/_tools/list_dir.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/list_dir.yaml
@@ -1,0 +1,25 @@
+name: list_dir
+description: |-
+  Render a tree view of a directory in the project.
+
+  Usage:
+  - Call this **first** on a new task to understand project layout (file/dir count, language, top-level structure).
+  - Default `depth=2` shows the project skeleton without overwhelming detail. Increase for deep dives, decrease (depth=1) for a quick scan.
+  - Common scratch / cache directories are skipped automatically: `.git`, `__pycache__`, `node_modules`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`.
+  - Capped at 200 entries per call to keep the response readable. If output is truncated, narrow the path or use `glob` for targeted file matching.
+
+  When to prefer other tools:
+  - Looking for files matching a name pattern → `glob`
+  - Looking for files containing some text → `grep`
+parameters:
+  path:
+    type: string
+    description: Directory to list, relative to project root.
+    default: "."
+  depth:
+    type: integer
+    description: Tree depth. depth=1 lists immediate children only; depth=2 (default) descends one level into each subdir.
+    default: 2
+concurrent_safe: true
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/multi_edit.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/multi_edit.py
@@ -1,0 +1,136 @@
+"""multi_edit tool — atomic batch of exact-string replacements on one file.
+
+Many real edits to a single file (e.g. updating an import, changing a
+function signature, and tweaking a call site) are naturally a batch.
+Doing them as N separate ``edit_file`` calls means N×(read + edit +
+verify) round-trips. ``multi_edit`` applies all edits in order
+against an in-memory copy of the file and writes the result
+atomically — either every edit succeeds or none do.
+
+Receives ``workspace_config`` and ``file_cache`` through
+``ctx.resources``; ``tool.yaml`` declares
+``requires: [workspace_config, file_cache]``.
+"""
+
+from __future__ import annotations
+
+import difflib
+
+from coder_lib_tools import (
+    _fuzzy_find,
+    _resolve_safe_path,
+    atomic_write_text,
+    is_binary_file,
+    read_text_with_fallback,
+)
+
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, file_path: str, edits: list) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, file_path)
+    if p is None:
+        return {"error": f"Path '{file_path}' is outside the project directory."}
+    if not p.exists():
+        return {"error": f"File not found: {file_path}"}
+    if p.is_dir():
+        return {"error": f"{file_path!r} is a directory, not a file."}
+    is_binary, reason = is_binary_file(p)
+    if is_binary:
+        return {"error": f"Refused: {file_path!r} is binary ({reason})."}
+    # Same read-required-first discipline as edit_file.
+    if cache is not None and not cache.was_read(file_path):
+        return {
+            "error": (
+                f"Cannot edit {file_path!r}: file has not been read in "
+                f"the current session. Call read_file({file_path!r}) first."
+            ),
+            "missing": "prior_read",
+            "recovery": f"read_file(file_path={file_path!r})",
+        }
+    if not isinstance(edits, list) or not edits:
+        return {
+            "error": "edits must be a non-empty list of {old_string, new_string} dicts.",
+        }
+    # Validate edit shapes up front.
+    for i, edit in enumerate(edits):
+        if not isinstance(edit, dict):
+            return {"error": f"edit #{i + 1} must be a dict, got {type(edit).__name__}"}
+        if "old_string" not in edit or "new_string" not in edit:
+            return {
+                "error": (
+                    f"edit #{i + 1} missing required keys; need "
+                    "{old_string, new_string} (replace_all is optional)."
+                ),
+                "missing_keys": [k for k in ("old_string", "new_string") if k not in edit],
+            }
+    text, encoding = read_text_with_fallback(p)
+    if text is None:
+        return {"error": f"Could not read {file_path!r}: {encoding}"}
+    original = text
+    applied: list[dict] = []
+    for i, edit in enumerate(edits):
+        old = edit["old_string"]
+        new = edit["new_string"]
+        replace_all = bool(edit.get("replace_all", False))
+        if old == new:
+            return {
+                "error": f"edit #{i + 1}: old_string and new_string are identical.",
+                "applied_so_far": applied,
+            }
+        if old not in text:
+            fuzzy = _fuzzy_find(text, old)
+            hints = (
+                "\n".join(f"  line {n} ({r:.0%}): {t.strip()[:80]}" for n, r, t in fuzzy[:3])
+                if fuzzy
+                else "  (no similar lines found)"
+            )
+            return {
+                "error": (
+                    f"edit #{i + 1} not found in {file_path!r}. "
+                    f"Similar lines:\n{hints}\n\nNo edits applied (atomic)."
+                ),
+                "failed_edit_index": i,
+                "applied_so_far": applied,
+                "similar_lines": [f[0] for f in fuzzy[:3]] if fuzzy else [],
+            }
+        count = text.count(old)
+        if count > 1 and not replace_all:
+            return {
+                "error": (
+                    f"edit #{i + 1} matches {count} locations in {file_path!r}. "
+                    "Add more context for uniqueness, or pass replace_all=true."
+                ),
+                "failed_edit_index": i,
+                "matches": count,
+                "applied_so_far": applied,
+            }
+        if replace_all:
+            text = text.replace(old, new)
+            applied.append({"index": i, "replacements": count})
+        else:
+            text = text.replace(old, new, 1)
+            applied.append({"index": i, "replacements": 1})
+    # All edits succeeded — write atomically.
+    atomic_write_text(p, text, encoding=encoding if encoding != "could not decode" else "utf-8")
+    if cache is not None:
+        cache.invalidate(file_path)
+    diff = difflib.unified_diff(
+        original.splitlines(keepends=True),
+        text.splitlines(keepends=True),
+        fromfile=f"a/{file_path}",
+        tofile=f"b/{file_path}",
+        n=3,
+    )
+    diff_text = "".join(diff)
+    if len(diff_text) > 4000:
+        diff_text = diff_text[:4000] + "\n... [diff truncated]"
+    return {
+        "edited": file_path,
+        "edits_applied": len(applied),
+        "total_replacements": sum(a["replacements"] for a in applied),
+        "diff": diff_text,
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/multi_edit.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/multi_edit.yaml
@@ -1,0 +1,34 @@
+name: multi_edit
+description: |-
+  Apply a batch of exact-string replacements to a single file atomically.
+
+  Usage:
+  - Use this when you have **2+ edits to make on the same file**. Doing them as separate `edit_file` calls means N×(read + edit + verify) round-trips; multi_edit applies them all in one shot.
+  - **Atomic**: all edits succeed and the file is written, or none are applied. If edit #3 of 5 fails, the file is unchanged.
+  - Same read-required-first discipline as `edit_file`: you must have called `read_file` on the path in the current session.
+  - Edits are applied **in order** against an in-memory copy. So later edits see the effect of earlier edits — handy for staged renames.
+  - Each edit must include `old_string` and `new_string` (exact match, like `edit_file`). Optional `replace_all: true` allows multiple-match replacement (default refuses with the match count).
+  - Atomic write to disk via tmp + os.replace.
+
+  Examples:
+  - Rename a function and its 3 call sites in one file:
+    `multi_edit(file_path="src/api.py", edits=[
+        {"old_string": "def old_name(", "new_string": "def new_name("},
+        {"old_string": "old_name(x, y)", "new_string": "new_name(x, y)", "replace_all": true},
+    ])`
+
+  Recovery:
+  - "not been read" → call `read_file` first
+  - "edit #N not found" → no edits were applied; re-read the file, fix the failing edit
+  - "matches N locations" → add more context OR pass `replace_all: true` for that edit
+parameters:
+  file_path:
+    type: string
+    description: Path to edit (relative to project root).
+  edits:
+    type: array
+    description: |-
+      Ordered list of {old_string, new_string, replace_all?} dicts. Applied left-to-right; later edits see the effect of earlier ones.
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/_tools/notebook_edit.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/notebook_edit.py
@@ -1,0 +1,130 @@
+"""notebook_edit tool — structural JSON edits for .ipynb files."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from coder_lib_tools import _resolve_safe_path, atomic_write_text
+
+from looplet.types import ToolContext
+
+
+def _as_source(value: str, like: Any | None = None) -> str | list[str]:
+    if isinstance(like, list):
+        if not value:
+            return []
+        return value.splitlines(keepends=True)
+    return value
+
+
+def _make_cell(cell_type: str, source: str) -> dict[str, Any]:
+    cell_id = uuid.uuid4().hex[:8]
+    cell: dict[str, Any] = {
+        "cell_type": cell_type,
+        "id": cell_id,
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+    }
+    if cell_type == "code":
+        cell["execution_count"] = None
+        cell["outputs"] = []
+    return cell
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    notebook_path: str,
+    cell_id: str = "",
+    new_source: str = "",
+    cell_type: str = "",
+    edit_mode: str = "replace",
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, notebook_path)
+    if p is None:
+        return {"error": f"Path '{notebook_path}' is outside the project directory."}
+    if p.suffix != ".ipynb":
+        return {"error": "notebook_edit only edits .ipynb files"}
+    if not p.exists():
+        return {"error": f"Notebook not found: {notebook_path}"}
+    if cache is not None:
+        if not cache.was_read(notebook_path):
+            return {
+                "error": f"Cannot edit {notebook_path!r}: notebook has not been read in this session.",
+                "missing": "prior_read",
+                "recovery": f"read_file(file_path={notebook_path!r})",
+            }
+        if not cache.is_unchanged(notebook_path):
+            return {
+                "error": f"Cannot edit {notebook_path!r}: notebook changed since last read.",
+                "stale": True,
+                "recovery": f"read_file(file_path={notebook_path!r})",
+            }
+    try:
+        notebook = json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        return {"error": f"Notebook is not valid JSON: {exc}"}
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        return {"error": "Notebook JSON missing cells list"}
+    mode = edit_mode.strip().lower() or "replace"
+    if mode not in {"replace", "insert", "delete"}:
+        return {
+            "error": f"unknown edit_mode {edit_mode!r}",
+            "valid_modes": ["replace", "insert", "delete"],
+        }
+    normalized_type = cell_type.strip().lower()
+    if normalized_type and normalized_type not in {"code", "markdown"}:
+        return {"error": "cell_type must be code or markdown"}
+
+    target_index = next(
+        (i for i, cell in enumerate(cells) if isinstance(cell, dict) and cell.get("id") == cell_id),
+        None,
+    )
+    if mode in {"replace", "delete"} and target_index is None:
+        return {
+            "error": f"cell_id {cell_id!r} not found",
+            "available_cell_ids": [cell.get("id") for cell in cells if isinstance(cell, dict)],
+        }
+
+    original_cell_count = len(cells)
+    if mode == "replace":
+        cell = cells[target_index]
+        if not isinstance(cell, dict):
+            return {"error": f"cell_id {cell_id!r} is not an object cell"}
+        final_type = normalized_type or str(cell.get("cell_type", "code"))
+        cell["cell_type"] = final_type
+        cell["source"] = _as_source(new_source, cell.get("source"))
+        if final_type == "code":
+            cell.setdefault("execution_count", None)
+            cell.setdefault("outputs", [])
+        else:
+            cell.pop("execution_count", None)
+            cell.pop("outputs", None)
+        changed_cell_id = cell.get("id")
+    elif mode == "insert":
+        final_type = normalized_type or "code"
+        new_cell = _make_cell(final_type, new_source)
+        insert_at = len(cells) if target_index is None else target_index + 1
+        cells.insert(insert_at, new_cell)
+        changed_cell_id = new_cell["id"]
+    else:
+        removed = cells.pop(target_index)
+        changed_cell_id = removed.get("id") if isinstance(removed, dict) else cell_id
+
+    atomic_write_text(p, json.dumps(notebook, indent=1, ensure_ascii=False) + "\n")
+    if cache is not None:
+        cache.invalidate(notebook_path)
+    return {
+        "notebook_path": notebook_path,
+        "edit_mode": mode,
+        "cell_id": changed_cell_id,
+        "cell_type": normalized_type or ("" if mode == "delete" else "code"),
+        "old_cell_count": original_cell_count,
+        "new_cell_count": len(cells),
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/notebook_edit.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/notebook_edit.yaml
@@ -1,0 +1,38 @@
+name: notebook_edit
+description: |-
+  Structurally edit Jupyter notebook cells in `.ipynb` files.
+
+  Usage:
+  - Use this instead of `edit_file` for notebooks so cell JSON stays valid.
+  - Requires `read_file` on the notebook first, and refuses if the notebook changed since that read.
+  - `edit_mode="replace"` replaces an existing cell's source by `cell_id`.
+  - `edit_mode="insert"` inserts a new cell after `cell_id`, or appends when `cell_id` is empty.
+  - `edit_mode="delete"` deletes an existing cell by `cell_id`.
+  - `cell_type` is `code` or `markdown`; for replace it defaults to the current cell type.
+
+  Examples:
+  - `notebook_edit(notebook_path="analysis.ipynb", cell_id="abc123", new_source="print(result)", edit_mode="replace")`
+  - `notebook_edit(notebook_path="analysis.ipynb", new_source="# Notes", cell_type="markdown", edit_mode="insert")`
+parameters:
+  notebook_path:
+    type: string
+    description: Notebook path relative to the project root.
+  cell_id:
+    type: string
+    description: Target cell id. Required for replace/delete; optional insertion anchor for insert.
+    default: ""
+  new_source:
+    type: string
+    description: New source text for replace/insert. Ignored for delete.
+    default: ""
+  cell_type:
+    type: string
+    description: code or markdown. Required for insert; optional for replace.
+    default: ""
+  edit_mode:
+    type: string
+    description: replace, insert, or delete.
+    default: replace
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/_tools/read_file.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/read_file.py
@@ -1,0 +1,99 @@
+"""read_file tool — read with line numbers + cache integration.
+
+Receives ``workspace_config`` and ``file_cache`` through
+``ctx.resources``; ``tool.yaml`` declares
+``requires: [workspace_config, file_cache]``.
+"""
+
+from __future__ import annotations
+
+from coder_lib_tools import _resolve_safe_path, is_binary_file, read_text_with_fallback
+
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, file_path: str, start_line: int = 0, end_line: int = 0) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, file_path)
+    if p is None:
+        return {"error": f"Path '{file_path}' is outside the project directory."}
+    if not p.exists():
+        return {"error": f"File not found: {file_path}"}
+    if p.is_dir():
+        return {
+            "error": f"{file_path!r} is a directory, not a file.",
+            "recovery": f"list_dir(path={file_path!r})",
+        }
+    # Binary detection — prevents read_file from returning garbage
+    # bytes that would blow up the model's tokenizer or look like a
+    # legitimate edit target.
+    is_binary, reason = is_binary_file(p)
+    if is_binary:
+        size = p.stat().st_size
+        return {
+            "error": (
+                f"Refused: {file_path!r} appears to be a binary file "
+                f"({reason}, {size} bytes). read_file only handles text."
+            ),
+            "binary": True,
+            "size_bytes": size,
+            "recovery": (
+                "If you really need to inspect bytes, use bash with `xxd "
+                f"{file_path} | head` (still subject to the cat-on-source "
+                "refusal for project text files)."
+            ),
+        }
+    # file_unchanged optimization shared with other coder tools.
+    if cache is not None and start_line == 0 and end_line == 0 and cache.is_unchanged(file_path):
+        return {
+            "path": file_path,
+            "file_unchanged": True,
+            "note": "File has not changed since your last read. No need to re-read.",
+        }
+    text, encoding = read_text_with_fallback(p)
+    if text is None:
+        return {"error": f"Could not read {file_path!r}: {encoding}"}
+    lines = text.splitlines()
+    if start_line < 0 or end_line < 0:
+        return {
+            "error": "start_line and end_line must be non-negative (1-based).",
+            "got": {"start_line": start_line, "end_line": end_line},
+        }
+    if start_line > 0 and end_line > 0 and end_line < start_line:
+        return {
+            "error": f"end_line ({end_line}) must be >= start_line ({start_line}).",
+        }
+    if start_line > 0 and end_line > 0:
+        selected = lines[start_line - 1 : end_line]
+        numbered = [f"{start_line + i:>4} | {line}" for i, line in enumerate(selected)]
+    elif start_line > 0:
+        selected = lines[start_line - 1 :]
+        numbered = [f"{start_line + i:>4} | {line}" for i, line in enumerate(selected)]
+    else:
+        numbered = [f"{i + 1:>4} | {line}" for i, line in enumerate(lines)]
+    content = "\n".join(numbered)
+    truncated = False
+    if len(content) > 20000:
+        truncated = True
+        content = (
+            content[:10000]
+            + f"\n... [{len(content) - 20000} chars truncated — re-read with start_line/end_line] ...\n"
+            + content[-10000:]
+        )
+    if cache is not None:
+        cache.record(file_path)
+    result: dict = {
+        "path": file_path,
+        "content": content,
+        "total_lines": len(lines),
+    }
+    if encoding != "utf-8":
+        result["encoding"] = encoding
+    if truncated:
+        result["truncated"] = True
+        result["recovery_hint"] = (
+            "Use start_line/end_line to read specific ranges instead of the full file."
+        )
+    return result

--- a/examples/coder_portable.cartridge/_mcp/_tools/read_file.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/read_file.yaml
@@ -1,0 +1,30 @@
+name: read_file
+description: |-
+  Read a file from the project filesystem with line numbers.
+
+  Usage:
+  - The default reads the whole file. Pass `start_line` and/or `end_line` (1-indexed) to read a specific range — useful for files >2000 lines.
+  - Output is `cat -n` style: `   N | <line>`. Edits MUST use the literal content AFTER the ` | ` separator, never the line-number prefix.
+  - Files larger than 20K characters are truncated in the middle (first 10K chars + last 10K chars) so the model still sees both ends; use start_line/end_line to read specific regions of larger files.
+  - This tool is the **prerequisite for edit_file**: edit_file refuses to run on a file that hasn't been read in the current session, because edits without reads almost always fail (the model guesses at content). Always read_file first.
+  - On a re-read of an unchanged file the result returns `file_unchanged: true` instead of the content; use the earlier read instead of re-reading. The cache is invalidated automatically by write_file / edit_file / external bash modifications, so you'll always see fresh content after a change.
+
+  Examples:
+  - `read_file(file_path="src/foo.py")` — whole file
+  - `read_file(file_path="src/foo.py", start_line=120, end_line=180)` — just lines 120-180
+parameters:
+  file_path:
+    type: string
+    description: Path to file (relative to project root).
+  start_line:
+    type: integer
+    description: Optional 1-indexed starting line. 0 (default) means start at line 1.
+    default: 0
+  end_line:
+    type: integer
+    description: Optional 1-indexed ending line, inclusive. 0 (default) means read to end.
+    default: 0
+concurrent_safe: true
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/_tools/subagent.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/subagent.py
@@ -1,0 +1,57 @@
+"""subagent tool — portable twin of the in-process subagent.
+
+The original ``tools/subagent/execute.py`` called
+``cartridge_to_preset(<coder cartridge root>)`` to rebuild the parent's
+tool set for the sub-loop. In a fully-portable cartridge that would
+recursively re-load THIS cartridge (re-spawning its MCP/SSP/MGP
+servers), so instead we build an isolated, in-process coding tool set
+with :func:`coder_lib_tools.make_tools` (bash/list_dir/read_file/
+write_file/edit_file/glob/grep + think + done) bound to a FRESH
+``FileCache`` — the sub-agent already runs with isolated state, so it
+should not share the parent's cache anyway.
+
+The LLM is reached the portable way: ``ctx.llm`` is a
+:class:`looplet.model_gateway.ModelGatewayClient` proxy injected by the
+MCP tools server, which forwards generation to the HOST's bound backend
+over the Model Gateway Protocol. When no backend is bound (direct
+dispatch / no active loop) ``ctx.llm`` is ``None`` and we return the
+same actionable error the original did.
+"""
+
+from __future__ import annotations
+
+from coder_lib_tools import FileCache, make_tools
+
+from looplet.subagent import run_sub_loop
+from looplet.types import ToolContext
+
+
+def execute(ctx: ToolContext, *, prompt: str, max_steps: int = 5, system_prompt: str = "") -> dict:
+    if ctx.llm is None:
+        return {
+            "error": "subagent requires an active ctx.llm from composable_loop; "
+            "direct dispatch cannot run it.",
+            "recovery": "Call subagent from inside a running looplet loop (the "
+            "host binds an LLM over the Model Gateway), or run run_sub_loop "
+            "directly in Python.",
+        }
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    tools = make_tools(workspace, FileCache(workspace))
+    result = run_sub_loop(
+        llm=ctx.llm,
+        task={"goal": prompt},
+        tools=tools,
+        max_steps=max(1, int(max_steps or 5)),
+        system_prompt=system_prompt
+        or "You are a focused coding sub-agent. Investigate the requested task and return concise findings.",
+        state_mutating_tools=["done", "subagent"],
+    )
+    return {
+        "summary": result.get("summary", ""),
+        "findings": result.get("findings", []),
+        "highlights": result.get("highlights", []),
+        "step_count": len(result.get("steps", [])),
+        "llm_calls": result.get("llm_calls", 0),
+        "subagent_id": result.get("subagent_id"),
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/subagent.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/subagent.yaml
@@ -1,0 +1,27 @@
+name: subagent
+description: |-
+  Run a focused looplet coder sub-agent with isolated context and return its concise result.
+
+  Usage:
+  - Use this for bounded investigations, code review passes, or parallelizable research where raw intermediate output would distract the parent agent.
+  - Requires the host loop to provide `ctx.llm`; direct tool dispatch without an active LLM returns an actionable error.
+  - The sub-agent loads this same coder workspace against the current project root and excludes `done` and `subagent` from its cloned tool set.
+  - Keep prompts narrow and concrete. The sub-agent has its own max step budget.
+
+  Examples:
+  - `subagent(prompt="Review src/auth.py for missing tests and summarize findings", max_steps=4)`
+  - `subagent(prompt="Find where config is loaded and return the key files", system_prompt="You are a codebase cartographer.")`
+parameters:
+  prompt:
+    type: string
+    description: Focused task for the sub-agent.
+  max_steps:
+    type: integer
+    description: Maximum tool calls available to the sub-agent.
+    default: 5
+  system_prompt:
+    type: string
+    description: Optional system prompt override for the sub-agent.
+    default: ""
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/think.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/think.py
@@ -1,0 +1,5 @@
+"""think tool — pure reasoning checkpoint, no side effects."""
+
+
+def execute(*, thought: str) -> dict:
+    return {"thought": thought, "noted": True}

--- a/examples/coder_portable.cartridge/_mcp/_tools/think.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/think.yaml
@@ -1,0 +1,8 @@
+name: think
+description: Record a brief plan or hypothesis. No side effects — pure reasoning checkpoint.
+parameters:
+  thought:
+    type: string
+    description: One or two sentences capturing the current plan or hypothesis.
+free: true
+concurrent_safe: true

--- a/examples/coder_portable.cartridge/_mcp/_tools/todo.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/todo.py
@@ -1,0 +1,149 @@
+"""todo tool — persistent checklist for coder.workspace sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from looplet.types import ToolContext
+
+_VALID_STATUSES = {"not-started", "in-progress", "completed", "blocked"}
+
+
+def _todo_path(workspace: str) -> Path:
+    scratch = Path(workspace) / ".coder_scratch"
+    scratch.mkdir(parents=True, exist_ok=True)
+    return scratch / "todos.json"
+
+
+def _load(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _save(path: Path, todos: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(todos, indent=2) + "\n")
+
+
+def _normalize_items(items: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(items, start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"todo item #{index} must be an object")
+        title = str(raw.get("title", "")).strip()
+        if not title:
+            raise ValueError(f"todo item #{index} missing non-empty title")
+        status = str(raw.get("status", "not-started")).strip() or "not-started"
+        if status not in _VALID_STATUSES:
+            raise ValueError(f"todo item #{index} has invalid status {status!r}")
+        item: dict[str, Any] = {
+            "id": int(raw.get("id") or index),
+            "title": title,
+            "status": status,
+        }
+        notes = str(raw.get("notes", "")).strip()
+        if notes:
+            item["notes"] = notes
+        normalized.append(item)
+    # Reassign ids so list state stays compact and deterministic.
+    for index, item in enumerate(normalized, start=1):
+        item["id"] = index
+    return normalized
+
+
+def _status_counts(todos: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        status: sum(1 for item in todos if item.get("status") == status)
+        for status in sorted(_VALID_STATUSES)
+    }
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    operation: str = "list",
+    todos: list | None = None,
+    id: int = 0,
+    title: str = "",
+    status: str = "",
+    notes: str = "",
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    path = _todo_path(workspace)
+    op = operation.strip().lower()
+    current = _load(path)
+
+    try:
+        if op == "list":
+            updated = current
+        elif op == "replace":
+            updated = _normalize_items(list(todos or []))
+            _save(path, updated)
+        elif op == "add":
+            item_title = title.strip()
+            if not item_title:
+                return {"error": "operation=add requires a non-empty title"}
+            item_status = status.strip() or "not-started"
+            if item_status not in _VALID_STATUSES:
+                return {
+                    "error": f"invalid status {item_status!r}",
+                    "valid_statuses": sorted(_VALID_STATUSES),
+                }
+            updated = list(current)
+            item: dict[str, Any] = {
+                "id": len(updated) + 1,
+                "title": item_title,
+                "status": item_status,
+            }
+            item_notes = notes.strip()
+            if item_notes:
+                item["notes"] = item_notes
+            updated.append(item)
+            _save(path, updated)
+        elif op == "update":
+            if id <= 0:
+                return {"error": "operation=update requires id > 0"}
+            updated = list(current)
+            target = next((item for item in updated if item.get("id") == id), None)
+            if target is None:
+                return {"error": f"todo id {id} not found", "todos": current}
+            if title.strip():
+                target["title"] = title.strip()
+            if status.strip():
+                item_status = status.strip()
+                if item_status not in _VALID_STATUSES:
+                    return {
+                        "error": f"invalid status {item_status!r}",
+                        "valid_statuses": sorted(_VALID_STATUSES),
+                    }
+                target["status"] = item_status
+            if notes.strip():
+                target["notes"] = notes.strip()
+            _save(path, updated)
+        elif op == "clear":
+            updated = []
+            _save(path, updated)
+        else:
+            return {
+                "error": f"unknown operation {operation!r}",
+                "valid_operations": ["list", "replace", "add", "update", "clear"],
+            }
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    return {
+        "operation": op,
+        "todos": updated,
+        "count": len(updated),
+        "status_counts": _status_counts(updated),
+        "path": ".coder_scratch/todos.json",
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/todo.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/todo.yaml
@@ -1,0 +1,43 @@
+name: todo
+description: |-
+  Manage a session task checklist for coding work. Stores the list in `.coder_scratch/todos.json` inside the project workspace.
+
+  Usage:
+  - Use this at the start of non-trivial tasks to create a short checklist, then update items as work progresses.
+  - `operation="replace"` replaces the whole list with `todos=[{"title": ..., "status": ...}]` items.
+  - `operation="add"` appends one item from `title` (status defaults to `not-started`).
+  - `operation="update"` changes one item by `id`; pass `title`, `status`, and/or `notes`.
+  - `operation="list"` returns the current list without changing it.
+  - `operation="clear"` removes all items after the task is complete.
+  - Status values: `not-started`, `in-progress`, `completed`, `blocked`.
+
+  Examples:
+  - `todo(operation="replace", todos=[{"title": "Add tests", "status": "not-started"}, {"title": "Implement fix", "status": "not-started"}])`
+  - `todo(operation="update", id=2, status="in-progress")`
+parameters:
+  operation:
+    type: string
+    description: One of list, replace, add, update, clear.
+    default: list
+  todos:
+    type: array
+    description: Full replacement list for operation=replace. Each item may include id, title, status, notes.
+    default: []
+  id:
+    type: integer
+    description: Item id for operation=update.
+    default: 0
+  title:
+    type: string
+    description: Item title for operation=add or optional replacement title for operation=update.
+    default: ""
+  status:
+    type: string
+    description: New item status. Use not-started, in-progress, completed, or blocked.
+    default: ""
+  notes:
+    type: string
+    description: Optional notes for operation=add or operation=update.
+    default: ""
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/web_fetch.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/web_fetch.py
@@ -1,0 +1,109 @@
+"""web_fetch tool — dependency-free HTTP(S) fetch with HTML text extraction."""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+from looplet.types import ToolContext
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip = 0
+        self.parts: list[str] = []
+        self.title = ""
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "noscript", "svg"}:
+            self._skip += 1
+        if tag == "title":
+            self._in_title = True
+        if tag in {"p", "div", "section", "article", "li", "br", "h1", "h2", "h3", "h4"}:
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "noscript", "svg"} and self._skip:
+            self._skip -= 1
+        if tag == "title":
+            self._in_title = False
+        if tag in {"p", "div", "section", "article", "li", "h1", "h2", "h3", "h4"}:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_title:
+            self.title = (self.title + " " + text).strip()
+        self.parts.append(text)
+
+
+def _html_to_text(raw: str) -> tuple[str, str]:
+    parser = _TextExtractor()
+    parser.feed(raw)
+    text = " ".join(parser.parts)
+    text = re.sub(r"[ \t\r\f\v]+", " ", text)
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+    text = "\n".join(line.strip() for line in text.splitlines() if line.strip())
+    return parser.title, text.strip()
+
+
+def execute(ctx: ToolContext | None, *, url: str, prompt: str = "", max_chars: int = 12000) -> dict:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return {"error": "web_fetch only allows http and https URLs", "url": url}
+    limit = max(1000, int(max_chars or 12000))
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "looplet-coder/0.1 (+https://github.com)"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            status = getattr(response, "status", 200)
+            content_type = response.headers.get("content-type", "")
+            body = response.read(limit * 4 + 1)
+    except urllib.error.HTTPError as exc:
+        return {"error": f"HTTP {exc.code}: {exc.reason}", "url": url, "status": exc.code}
+    except urllib.error.URLError as exc:
+        return {"error": f"Fetch failed: {exc.reason}", "url": url}
+
+    encoding = "utf-8"
+    match = re.search(r"charset=([^;]+)", content_type, flags=re.I)
+    if match:
+        encoding = match.group(1).strip()
+    raw = body.decode(encoding, errors="replace")
+    if "html" in content_type.lower() or "<html" in raw[:500].lower():
+        title, text = _html_to_text(raw)
+    else:
+        title, text = "", raw.strip()
+    truncated = len(text) > limit
+    text = text[:limit]
+    result: dict = {
+        "url": url,
+        "status": status,
+        "content_type": content_type,
+        "title": title,
+        "text": text,
+        "chars": len(text),
+        "truncated": truncated,
+    }
+    if prompt.strip():
+        if ctx is None or ctx.llm is None:
+            result["prompt_note"] = "No ctx.llm was supplied, so prompt was not run."
+        else:
+            answer = ctx.llm.generate(
+                "Answer the prompt using only the fetched content.\n\n"
+                f"URL: {url}\n\nPROMPT:\n{prompt.strip()}\n\nCONTENT:\n{text}",
+                max_tokens=1000,
+                temperature=0.0,
+            )
+            result["answer"] = answer
+    return result

--- a/examples/coder_portable.cartridge/_mcp/_tools/web_fetch.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/web_fetch.yaml
@@ -1,0 +1,27 @@
+name: web_fetch
+description: |-
+  Fetch an HTTP(S) URL and return readable text. Optionally ask the active LLM to answer a prompt using the fetched content.
+
+  Usage:
+  - Use this for public documentation, changelogs, issue pages, specs, or other web pages that inform a coding task.
+  - Only `http` and `https` URLs are allowed.
+  - HTML is converted to plain readable text; non-HTML text is returned as-is.
+  - Large pages are truncated to `max_chars` to avoid filling the context.
+  - If `prompt` is provided and the host loop supplies `ctx.llm`, the tool returns `answer` generated from the fetched text.
+
+  Examples:
+  - `web_fetch(url="https://docs.python.org/3/library/pathlib.html")`
+  - `web_fetch(url="https://example.com/release-notes", prompt="Summarize breaking API changes relevant to this repo")`
+parameters:
+  url:
+    type: string
+    description: HTTP or HTTPS URL to fetch.
+  prompt:
+    type: string
+    description: Optional question or extraction prompt to run against the fetched text using ctx.llm.
+    default: ""
+  max_chars:
+    type: integer
+    description: Maximum characters of extracted text to return or pass to the prompt.
+    default: 12000
+concurrent_safe: true

--- a/examples/coder_portable.cartridge/_mcp/_tools/worktree.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/worktree.py
@@ -1,0 +1,83 @@
+"""worktree tool — managed git worktree helper."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from looplet.types import ToolContext
+
+
+def _run(workspace: str, args: list[str]) -> dict:
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, capture_output=True, text=True, timeout=60
+    )
+    return {
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _safe_name(name: str) -> str | None:
+    cleaned = name.strip()
+    if not cleaned or cleaned in {".", ".."}:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", cleaned):
+        return None
+    return cleaned
+
+
+def _managed_root(workspace: str) -> Path:
+    root = Path(workspace).resolve()
+    return root.parent / f"{root.name}.worktrees"
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    operation: str = "list",
+    name: str = "",
+    base_ref: str = "HEAD",
+    confirm: bool = False,
+    force: bool = False,
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    workspace = cfg.path if cfg is not None else "."
+    probe = _run(workspace, ["rev-parse", "--is-inside-work-tree"])
+    if probe["exit_code"] != 0:
+        return {"error": "Not inside a git worktree", "stderr": probe["stderr"]}
+    op = operation.strip().lower() or "list"
+    managed = _managed_root(workspace)
+    if op == "list":
+        result = _run(workspace, ["worktree", "list", "--porcelain"])
+        result.update({"operation": op, "managed_root": str(managed)})
+        return result
+    safe = _safe_name(name)
+    if safe is None:
+        return {"error": "name must contain only letters, numbers, dot, dash, and underscore"}
+    target = (managed / safe).resolve()
+    if managed.resolve() not in target.parents:
+        return {"error": "resolved worktree path escapes managed root"}
+    if op == "create":
+        if target.exists():
+            return {"error": f"managed worktree already exists: {target}"}
+        managed.mkdir(parents=True, exist_ok=True)
+        result = _run(workspace, ["worktree", "add", str(target), base_ref or "HEAD"])
+        result.update({"operation": op, "path": str(target), "managed_root": str(managed)})
+        return result
+    if op == "remove":
+        if not confirm:
+            return {"error": "operation=remove requires confirm=true", "path": str(target)}
+        args = ["worktree", "remove"]
+        if force:
+            args.append("--force")
+        args.append(str(target))
+        result = _run(workspace, args)
+        result.update({"operation": op, "path": str(target), "managed_root": str(managed)})
+        return result
+    return {
+        "error": f"unknown operation {operation!r}",
+        "valid_operations": ["list", "create", "remove"],
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/worktree.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/worktree.yaml
@@ -1,0 +1,38 @@
+name: worktree
+description: |-
+  Manage git worktrees for isolated coding attempts.
+
+  Usage:
+  - `operation="list"` shows current worktrees.
+  - `operation="create"` creates a sibling managed worktree under `<repo>.worktrees/<name>` from `base_ref`.
+  - `operation="remove"` removes a managed worktree and requires `confirm=true`.
+  - Worktree names are sanitized to letters, numbers, dot, dash, and underscore.
+  - This tool only removes paths inside the managed sibling worktree directory.
+
+  Examples:
+  - `worktree(operation="create", name="experiment-auth", base_ref="HEAD")`
+  - `worktree(operation="list")`
+  - `worktree(operation="remove", name="experiment-auth", confirm=true)`
+parameters:
+  operation:
+    type: string
+    description: list, create, or remove.
+    default: list
+  name:
+    type: string
+    description: Managed worktree name for create/remove.
+    default: ""
+  base_ref:
+    type: string
+    description: Git ref to create the worktree from.
+    default: HEAD
+  confirm:
+    type: boolean
+    description: Required true for remove.
+    default: false
+  force:
+    type: boolean
+    description: Pass --force to git worktree remove.
+    default: false
+requires:
+  - workspace_config

--- a/examples/coder_portable.cartridge/_mcp/_tools/write_file.py
+++ b/examples/coder_portable.cartridge/_mcp/_tools/write_file.py
@@ -1,0 +1,77 @@
+"""write_file tool — create / overwrite a file inside the workspace.
+
+Receives ``workspace_config`` and ``file_cache`` through
+``ctx.resources``; ``tool.yaml`` declares
+``requires: [workspace_config, file_cache]``.
+"""
+
+from __future__ import annotations
+
+from coder_lib_tools import _resolve_safe_path, atomic_write_text
+
+from looplet.types import ToolContext
+
+
+def execute(
+    ctx: ToolContext,
+    *,
+    file_path: str,
+    content: str,
+    overwrite: bool = False,
+) -> dict:
+    cfg = ctx.resources.get("workspace_config")
+    cache = ctx.resources.get("file_cache")
+    workspace = cfg.path if cfg is not None else "."
+    p = _resolve_safe_path(workspace, file_path)
+    if p is None:
+        return {"error": f"Path '{file_path}' is outside the project directory."}
+    if p.is_dir():
+        return {
+            "error": f"{file_path!r} is a directory, not a file.",
+        }
+    exists = p.exists()
+    # Safer-overwrite: refuse to clobber an existing file unless
+    # the caller explicitly opts in. This prevents the model from
+    # accidentally wiping a file it should have edited instead.
+    if exists and not overwrite:
+        return {
+            "error": (
+                f"Refused: {file_path!r} already exists. write_file "
+                "is for NEW files; use edit_file to modify existing "
+                "files (preserves the rest of the file + produces a "
+                "reviewable diff). If you really intend to replace "
+                "the entire file, pass `overwrite=True`."
+            ),
+            "exists": True,
+            "recovery": (
+                f"edit_file(file_path={file_path!r}, ...)  OR  write_file(..., overwrite=True)"
+            ),
+        }
+    if exists and overwrite and cache is not None:
+        if not cache.was_read(file_path):
+            return {
+                "error": (
+                    f"Cannot overwrite {file_path!r}: this file has not been read "
+                    "in the current session. Call read_file first so the full-file "
+                    "replacement is based on current content."
+                ),
+                "missing": "prior_read",
+                "recovery": f"read_file(file_path={file_path!r})",
+            }
+        if not cache.is_unchanged(file_path):
+            return {
+                "error": (
+                    f"Cannot overwrite {file_path!r}: file was modified since "
+                    "the last read. Re-read it before replacing the full file."
+                ),
+                "stale": True,
+                "recovery": f"read_file(file_path={file_path!r})",
+            }
+    atomic_write_text(p, content)
+    if cache is not None:
+        cache.invalidate(file_path)
+    return {
+        "written": file_path,
+        "lines": content.count("\n") + (0 if content.endswith("\n") or not content else 1),
+        "overwritten": exists and overwrite,
+    }

--- a/examples/coder_portable.cartridge/_mcp/_tools/write_file.yaml
+++ b/examples/coder_portable.cartridge/_mcp/_tools/write_file.yaml
@@ -1,0 +1,35 @@
+name: write_file
+description: |-
+  Create a new file or overwrite an existing one with the provided content.
+
+  Usage:
+  - Use this for **NEW** files only by default. To modify an existing file, use `edit_file` (preserves the rest of the file and produces a reviewable diff).
+  - **Refuses to clobber an existing file** unless you pass `overwrite=true`. This prevents accidental wipes when the model meant `edit_file`.
+  - When overwriting an existing file, the file must have been read in this session and must still match the last read content. If another command, linter, or user changed it, re-read before overwriting.
+  - Writes are **atomic** (tmp file + os.replace) so a crash mid-write can't leave a half-written file.
+  - Parent directories are created automatically.
+  - The path is relative to the project root and must stay inside it (paths escaping via `..` are refused).
+  - On overwrite, the file_cache entry for the path is invalidated so a subsequent read_file returns the new content.
+
+  Examples:
+  - `write_file(file_path="src/utils.py", content="def foo(): ...")` — new file
+  - `write_file(file_path="src/utils.py", content=..., overwrite=True)` — explicit replace of an existing file after `read_file`
+  - DO NOT use this to "update" a file you already read — that's `edit_file`.
+
+  Recovery:
+  - "already exists" → use `edit_file` (preferred) or read the file and pass `overwrite=True`
+  - "modified since last read" → call `read_file` again, then retry if replacement is still intentional
+parameters:
+  file_path:
+    type: string
+    description: Path to write (relative to project root). Parent dirs created if missing.
+  content:
+    type: string
+    description: Full file contents.
+  overwrite:
+    type: boolean
+    description: Allow replacing an existing file. Default false (refuses to clobber).
+    default: false
+requires:
+  - workspace_config
+  - file_cache

--- a/examples/coder_portable.cartridge/_mcp/coder_lib_tools.py
+++ b/examples/coder_portable.cartridge/_mcp/coder_lib_tools.py
@@ -1,0 +1,851 @@
+"""Tool definitions for the coder example.
+
+Pure functions and dataclasses that describe *what the agent can do*:
+read and write files, run bash, search the workspace.  No agent
+control flow, no hook logic — just the executable surface area.
+
+The module exports a single composition function,
+:func:`make_tools`, that wires every ``@tool``-decorated callable
+into a :class:`looplet.tools.BaseToolRegistry` ready to plug into
+either the library entrypoint or the runnable bundle.
+
+:class:`FileCache` is kept here because every tool in the bundle
+either reads from it (``read_file``) or invalidates it
+(``write_file``, ``edit_file``); colocating the cache with the
+tools that use it keeps the public surface small.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from looplet import tool, tools_from
+
+__all__ = [
+    "FileCache",
+    "make_tools",
+    "_EXIT_CODE_MAP",
+    "_interpret_exit_code",
+    "_run",
+    "_fuzzy_find",
+    "_resolve_safe_path",
+    "_is_path_inside",
+]
+
+
+# ── Exit code interpretation ───────────────────────────────────────
+
+
+# Maps (command_prefix, exit_code) → human explanation so the model
+# doesn't misinterpret non-error exit codes as failures.
+_EXIT_CODE_MAP: dict[str, dict[int, str]] = {
+    "diff": {1: "files differ (not an error)"},
+    "grep": {1: "no match found (not an error)"},
+    "test": {1: "expression evaluated to false"},
+    "cmp": {1: "files differ (not an error)"},
+    "ruff check": {1: "lint issues found"},
+    "mypy": {1: "type errors found"},
+    "pylint": {1: "lint issues found (fatal=1)", 2: "error (2)", 4: "warning (4)"},
+}
+
+
+def _interpret_exit_code(cmd: str, exit_code: int) -> str | None:
+    """Return a human-readable interpretation of a non-zero exit code, or None."""
+    if exit_code == 0:
+        return None
+    for prefix, codes in _EXIT_CODE_MAP.items():
+        # Match command prefix (e.g. 'diff' matches 'diff -u a b')
+        cmd_stripped = cmd.lstrip()
+        if cmd_stripped == prefix or cmd_stripped.startswith(prefix + " "):
+            if exit_code in codes:
+                return codes[exit_code]
+    return None
+
+
+# ── Bash + fuzzy matching helpers ──────────────────────────────────
+
+
+def _run(cmd: str, cwd: str, timeout: int = 120) -> dict:
+    # Sanitize: strip whitespace/newlines, handle None/empty
+    if not cmd or not isinstance(cmd, str):
+        return {
+            "stdout": "",
+            "stderr": "Error: empty command. Provide a bash command to execute.",
+            "exit_code": 1,
+        }
+    cmd = cmd.strip()
+    if not cmd:
+        return {
+            "stdout": "",
+            "stderr": "Error: empty command after stripping whitespace.",
+            "exit_code": 1,
+        }
+    # Remove common LLM artifacts: leading $, backtick fences
+    if cmd.startswith("$ "):
+        cmd = cmd[2:]
+    if cmd.startswith("```") and cmd.endswith("```"):
+        cmd = cmd[3:-3].strip()
+        if cmd.startswith("bash\n") or cmd.startswith("sh\n"):
+            cmd = cmd.split("\n", 1)[1].strip()
+    try:
+        r = subprocess.run(
+            ["bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+        )
+        stdout = r.stdout.strip()
+        stderr = r.stderr.strip()
+        result: dict = {"exit_code": r.returncode}
+        # Spill long stdout/stderr to scratch files inside the
+        # workspace so the model can re-read specific ranges via
+        # ``read_file`` instead of guessing at the truncated middle.
+        full_stdout_chars = len(r.stdout)
+        full_stderr_chars = len(r.stderr)
+        if len(stdout) > 15000:
+            spill = _spill_output(cwd, "stdout", r.stdout)
+            stdout = (
+                stdout[:7000]
+                + f"\n\n... [{len(stdout) - 14000} chars truncated — full output at {spill}] ...\n\n"
+                + stdout[-7000:]
+            )
+            result["stdout_spill_file"] = spill
+            result["stdout_full_chars"] = full_stdout_chars
+        if len(stderr) > 5000:
+            spill = _spill_output(cwd, "stderr", r.stderr)
+            stderr = (
+                stderr[:2000]
+                + f"\n... [{len(stderr) - 4000} chars truncated — full output at {spill}] ..."
+                + stderr[-2000:]
+            )
+            result["stderr_spill_file"] = spill
+            result["stderr_full_chars"] = full_stderr_chars
+        result["stdout"] = stdout
+        result["stderr"] = stderr
+        # Add semantic exit code interpretation
+        interpretation = _interpret_exit_code(cmd, r.returncode)
+        if interpretation:
+            result["exit_code_note"] = interpretation
+        return result
+    except subprocess.TimeoutExpired:
+        return {"stdout": "", "stderr": f"Command timed out after {timeout}s", "exit_code": -1}
+    except Exception as e:
+        return {"stdout": "", "stderr": str(e), "exit_code": -1}
+
+
+def _spill_output(workspace: str, stream: str, content: str) -> str:
+    """Write a long stdout/stderr blob to a workspace-relative scratch file.
+
+    Returns the workspace-relative path so the model can read_file it
+    without escaping the workspace root. The dir ``.coder_scratch/``
+    is auto-created and re-used across calls.
+    """
+    import time as _time
+
+    scratch_dir = Path(workspace) / ".coder_scratch"
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    name = f"bash_{stream}_{int(_time.time() * 1000)}.log"
+    out = scratch_dir / name
+    out.write_text(content)
+    return f".coder_scratch/{name}"
+
+
+def _fuzzy_find(text: str, target: str, threshold: float = 0.6) -> list[tuple[int, float, str]]:
+    """Find approximate matches for target's first line in text."""
+    target_lines = target.splitlines()
+    text_lines = text.splitlines()
+    if not target_lines or not text_lines:
+        return []
+    first_target = target_lines[0].strip()
+    matches = []
+    for i, line in enumerate(text_lines):
+        ratio = difflib.SequenceMatcher(None, line.strip(), first_target).ratio()
+        if ratio >= threshold:
+            matches.append((i + 1, ratio, line))
+    return sorted(matches, key=lambda x: -x[1])[:5]
+
+
+def _resolve_safe_path(workspace: str, file_path: str) -> Path | None:
+    """Resolve file_path relative to workspace, rejecting traversal.
+
+    Returns the resolved Path if it is inside the workspace, or None
+    if the path escapes (via ``..`` or absolute path).
+    """
+    ws = Path(workspace).resolve()
+    target = (ws / file_path).resolve()
+    if not _is_path_inside(target, ws):
+        return None
+    return target
+
+
+def _is_path_inside(target: Path, root: Path) -> bool:
+    try:
+        target.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+# ── File I/O helpers ───────────────────────────────────────────────
+
+
+# Common binary/non-text suffixes that read_file should reject up
+# front. The list is conservative — when a real text file slips in
+# (e.g. ``.svg``, ``.csv``) the content-sniff below catches the
+# opposite case.
+_BINARY_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".bmp",
+        ".webp",
+        ".ico",
+        ".tiff",
+        ".pdf",
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".xz",
+        ".7z",
+        ".rar",
+        ".pyc",
+        ".pyo",
+        ".so",
+        ".dll",
+        ".dylib",
+        ".o",
+        ".a",
+        ".class",
+        ".jar",
+        ".exe",
+        ".bin",
+        ".wasm",
+        ".mp3",
+        ".mp4",
+        ".wav",
+        ".ogg",
+        ".flac",
+        ".mov",
+        ".avi",
+        ".mkv",
+        ".sqlite",
+        ".db",
+        ".pkl",
+        ".npy",
+        ".npz",
+        ".h5",
+        ".pt",
+        ".onnx",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
+    }
+)
+
+
+def is_binary_file(path: Path) -> tuple[bool, str]:
+    """Return (is_binary, reason) without raising.
+
+    First checks the extension; if inconclusive, sniffs the first 8 KiB
+    for NUL bytes (the classic ``file(1)`` heuristic). The reason is a
+    short human-readable string suitable for inclusion in a tool error.
+    """
+    suffix = path.suffix.lower()
+    if suffix in _BINARY_SUFFIXES:
+        return True, f"binary file extension {suffix!r}"
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(8192)
+    except OSError as exc:
+        return False, f"could not sniff: {exc}"
+    if b"\x00" in chunk:
+        return True, "contains NUL bytes (binary)"
+    # Heuristic: if >30% of bytes are non-printable / non-whitespace
+    # ASCII control chars, treat as binary. This catches things like
+    # tar headers, raw protobuf, etc.
+    if chunk:
+        printable = sum(1 for b in chunk if b >= 0x20 or b in (0x09, 0x0A, 0x0D))
+        if printable / len(chunk) < 0.7:
+            return True, "low printable-byte ratio (binary)"
+    return False, ""
+
+
+def read_text_with_fallback(path: Path) -> tuple[str | None, str]:
+    """Read a text file with encoding fallback.
+
+    Returns (content, encoding_used). content is None on failure;
+    encoding_used carries the error message in that case.
+    """
+    for encoding in ("utf-8", "utf-8-sig", "latin-1"):
+        try:
+            return path.read_text(encoding=encoding), encoding
+        except UnicodeDecodeError:
+            continue
+        except OSError as exc:
+            return None, f"OSError: {exc}"
+    return None, "could not decode with utf-8/utf-8-sig/latin-1"
+
+
+def atomic_write_text(path: Path, content: str, encoding: str = "utf-8") -> None:
+    """Write ``content`` to ``path`` atomically (tmp + os.replace).
+
+    Avoids torn writes if the agent crashes / is killed mid-write.
+    Parent directories are created if missing.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # NamedTemporaryFile creates the file in the same directory so
+    # os.replace is guaranteed atomic on the same filesystem.
+    import tempfile
+
+    fd, tmp_path = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as fh:
+            fh.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ── Bash safety helpers ────────────────────────────────────────────
+
+
+# Commands that destroy data or alter system state. The bash tool
+# refuses to run any pipeline whose first token (or, after a
+# control-operator split, the first token of any subcommand) appears
+# in this set without the user's permission engine having explicitly
+# allowed it. The list intentionally covers the common footguns rather
+# than trying to be exhaustive — anything novel still flows through
+# the regular permission engine, which is the principled gate.
+_DESTRUCTIVE_COMMANDS: frozenset[str] = frozenset(
+    {
+        "dd",  # raw block-device writes
+        "mkfs",  # filesystem creation
+        "shred",  # secure delete
+        "shutdown",
+        "reboot",
+        "halt",
+        "poweroff",
+        "kill",  # process termination (kills any pid; use Ctrl-C in tests)
+        "killall",
+        "pkill",
+    }
+)
+
+# Argument-pattern flags that turn an otherwise-safe command into a
+# destructive one (e.g. ``rm -rf`` vs ``rm`` alone — the latter is
+# fine for individual files). Maps command name → tuple of flag
+# patterns that elevate it.
+_DESTRUCTIVE_FLAGS: dict[str, tuple[str, ...]] = {
+    "rm": ("-rf", "-fr", "-Rf", "-fR", "--recursive"),
+    "git": (
+        "push --force",
+        "push -f",
+        "reset --hard",
+        "clean -fd",
+        "branch -D",
+        "checkout --force",
+    ),
+}
+
+
+def classify_bash_command(command: str) -> dict[str, Any]:
+    r"""Inspect ``command`` and return a structured safety classification.
+
+    Returns a dict with:
+
+    * ``destructive`` (bool) — True when the command is in the
+      destructive-name set or matches a destructive-flag pattern.
+    * ``reasons`` (list[str]) — human-readable reasons; empty when
+      the command is considered safe.
+    * ``first_token`` (str) — the leading executable name parsed from
+      the command (best-effort; complex shell syntax may not parse).
+
+    The bash tool surfaces these as a model-actionable error rather
+    than running the command. Callers building their own bash wrapper
+    can use ``classify_bash_command`` directly to filter or warn.
+
+    The classification is deliberately conservative: it covers
+    *patterns the model commonly tries by mistake* (\`rm -rf\` on
+    cwd, ``git push --force`` to a shared remote) and bows out for
+    novel commands so the permission engine can decide. It is **not**
+    a sandbox.
+    """
+    reasons: list[str] = []
+    # Split on bash control operators so we can inspect each subcommand.
+    # ``cmd1 && cmd2 || cmd3 ; cmd4 | cmd5 & cmd6`` → 6 tokens.
+    parts = re.split(r"&&|\|\||\||;|&", command)
+    first_token = ""
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        # The leading word is the command name; strip leading parens
+        # / brackets that wrap subshells (best-effort; not a parser).
+        head = part.lstrip("()[]{ \t").split()
+        if not head:
+            continue
+        name = head[0]
+        if not first_token:
+            first_token = name
+        if name in _DESTRUCTIVE_COMMANDS:
+            reasons.append(f"destructive command {name!r} (in {sorted(_DESTRUCTIVE_COMMANDS)})")
+            continue
+        bad_flags = _DESTRUCTIVE_FLAGS.get(name, ())
+        for flag in bad_flags:
+            # Substring match works for both single-token (-rf) and
+            # multi-token (push --force) patterns.
+            if flag in part:
+                reasons.append(f"destructive flag {flag!r} in {name!r} subcommand")
+                break
+    return {
+        "destructive": bool(reasons),
+        "reasons": reasons,
+        "first_token": first_token,
+    }
+
+
+def classify_sed_command(command: str) -> dict[str, Any]:
+    """Detect ``sed -i`` (in-place edit) usage in ``command``.
+
+    ``sed -i`` rewrites files outside the model's read-then-edit
+    discipline and bypasses the file_cache invalidation that
+    ``edit_file`` does — so a subsequent ``read_file`` may return
+    cached pre-edit content. Surface a model-actionable error
+    pointing the model at ``edit_file`` instead of refusing
+    silently.
+
+    Returns a dict with:
+
+    * ``in_place_edit`` (bool) — True when any subcommand is
+      ``sed -i ...`` or ``sed --in-place ...``.
+    * ``recommendation`` (str) — short guidance ("use edit_file
+      instead") when ``in_place_edit``; empty otherwise.
+    """
+    parts = re.split(r"&&|\|\||\||;|&", command)
+    for part in parts:
+        part = part.strip()
+        # Token-aware: avoid matching ``sed-i`` package names or
+        # ``echo "sed -i"`` content.
+        if not part.startswith("sed "):
+            continue
+        # Look for ``-i`` as a standalone flag or a flag with bundled
+        # backup-suffix arg (``-i.bak``); also ``--in-place``.
+        tokens = part.split()
+        for tok in tokens[1:]:
+            if tok == "-i" or tok.startswith("-i.") or tok == "--in-place":
+                return {
+                    "in_place_edit": True,
+                    "recommendation": (
+                        "Use the edit_file tool for in-place file edits. "
+                        "sed -i bypasses the file cache, so the next "
+                        "read_file can return stale content."
+                    ),
+                }
+    return {"in_place_edit": False, "recommendation": ""}
+
+
+_VIEW_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "less", "more"})
+
+
+def classify_view_command(command: str) -> dict[str, Any]:
+    """Detect ``cat``/``head``/``tail``/``less``/``more`` used to view a single
+    source file (which bypasses the read_file file_cache).
+
+    Heuristics:
+
+    * Only flags the *first* subcommand of the pipeline, because using
+      ``... | head`` to trim *output* of another command is fine.
+    * Refuses only when the command's positional args look like file
+      paths (no ``-`` stdin marker, at least one arg without a leading
+      ``-`` that points at an existing-looking source file).
+    * Lets ``cat``-as-pipe-source through when the file is clearly not
+      project source (e.g. ``/proc/...``, ``/dev/...``, ``/tmp/`` outside
+      the workspace) — but the conservative default is to refuse so the
+      model self-corrects to ``read_file``.
+
+    Returns ``{"viewing_file": bool, "first_token": str, "recommendation": str}``.
+    """
+    parts = re.split(r"&&|\|\||;", command)
+    first = parts[0].strip() if parts else ""
+    tokens = first.split()
+    if not tokens:
+        return {"viewing_file": False, "first_token": "", "recommendation": ""}
+    name = tokens[0].rsplit("/", 1)[-1]
+    if name not in _VIEW_COMMANDS:
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+    # Look at positional args (skip flags). If none look like files,
+    # this is probably reading from stdin / a pipe — let it through.
+    positional = [t for t in tokens[1:] if not t.startswith("-")]
+    if not positional:
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+
+    # Allow virtual / device paths (these are never project source).
+    def is_project_path(arg: str) -> bool:
+        if arg.startswith(("/proc/", "/dev/", "/sys/")):
+            return False
+        return True
+
+    if not any(is_project_path(p) for p in positional):
+        return {"viewing_file": False, "first_token": name, "recommendation": ""}
+    return {
+        "viewing_file": True,
+        "first_token": name,
+        "recommendation": (
+            f"Use read_file to view source files. `{name}` bypasses "
+            "the file_cache, so a subsequent edit_file on the same "
+            "path will be refused with 'not been read in current "
+            "session'. Pipe-trimming output of another command "
+            "(e.g. `grep ... | head`) is still fine."
+        ),
+    }
+
+
+# ── File cache ─────────────────────────────────────────────────────
+
+
+class FileCache:
+    """Tracks recently read/written files for re-injection after compaction.
+
+    Also tracks file mtimes for stale-file detection: when a bash
+    command modifies files that were previously read, the cache can
+    report which files have stale content so the model re-reads them.
+    """
+
+    def __init__(self, workspace: str, max_files: int = 5, max_chars: int = 8000):
+        self._workspace = workspace
+        self._max_files = max_files
+        self._max_chars = max_chars
+        self._recent: dict[str, str] = {}
+        self._order: list[str] = []
+        self._mtimes: dict[str, float] = {}  # path -> mtime when last read
+        self._hashes: dict[str, str] = {}  # path -> content hash when last read
+        self._read_set: set[str] = set()  # every path ever passed to record()
+        # Sliding window of recent normalized bash commands. The bash
+        # tool consults this to refuse repeated identical commands
+        # (the model often loops on a failing command, asking the
+        # same thing 5+ times in a row instead of trying a new tactic).
+        self._recent_bash: list[str] = []
+        self._recent_bash_max: int = 4
+
+    def record_bash(self, command: str) -> int:
+        """Record a normalized bash command and return how many of the
+        last ``_recent_bash_max`` commands are identical to it.
+        """
+        norm = " ".join(command.strip().split())
+        self._recent_bash.append(norm)
+        if len(self._recent_bash) > self._recent_bash_max:
+            self._recent_bash = self._recent_bash[-self._recent_bash_max :]
+        return self._recent_bash.count(norm)
+
+    def recent_bash_repeats(self, command: str) -> int:
+        """Return how many of the recent bash commands match ``command``
+        WITHOUT recording it. Used by bash to refuse before running.
+        """
+        norm = " ".join(command.strip().split())
+        return self._recent_bash.count(norm)
+
+    def record(self, path: str) -> None:
+        p = Path(self._workspace) / path
+        if not p.exists() or not p.is_file():
+            return
+        try:
+            content = p.read_text()
+            self._hashes[path] = hashlib.sha256(content.encode()).hexdigest()[:16]
+            self._mtimes[path] = p.stat().st_mtime
+            self._read_set.add(path)
+            if len(content) > self._max_chars:
+                content = content[: self._max_chars] + "\n... [truncated]"
+            self._recent[path] = content
+            if path in self._order:
+                self._order.remove(path)
+            self._order.append(path)
+            while len(self._order) > self._max_files:
+                old = self._order.pop(0)
+                self._recent.pop(old, None)
+        except Exception:
+            pass
+
+    def stale_files(self) -> list[str]:
+        """Return paths of files whose mtime changed since last read."""
+        stale = []
+        for path, cached_mtime in self._mtimes.items():
+            p = Path(self._workspace) / path
+            try:
+                current_mtime = p.stat().st_mtime
+                if current_mtime != cached_mtime:
+                    stale.append(path)
+            except OSError:
+                pass
+        return stale
+
+    def is_unchanged(self, path: str) -> bool:
+        """True if the file content hasn't changed since last read."""
+        if path not in self._hashes:
+            return False
+        p = Path(self._workspace) / path
+        try:
+            content = p.read_text()
+            current_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+            return current_hash == self._hashes[path]
+        except OSError:
+            return False
+
+    def invalidate(self, path: str) -> None:
+        """Mark a file as modified so is_unchanged() returns False.
+
+        Call this from write_file/edit_file instead of record(). The
+        model hasn't *seen* the new content via read_file, so the
+        file_unchanged optimization must not fire on the next read.
+        """
+        self._hashes.pop(path, None)
+
+    def was_read(self, path: str) -> bool:
+        """True iff ``read_file`` has been called for ``path`` in this
+        session. Used by ``edit_file`` to enforce read-before-edit:
+        editing a file the model hasn't read is almost always a sign
+        the model is guessing at content. The error returned by
+        ``edit_file`` in that case names the read tool explicitly so
+        the model fixes the next call rather than retrying with
+        different text.
+        """
+        return path in self._read_set
+
+    def render(self) -> str:
+        if not self._recent:
+            return ""
+        parts = ["## Recently accessed files (cached)"]
+        for path in self._order:
+            content = self._recent.get(path, "")
+            parts.append(f"\n### {path}\n```\n{content}\n```")
+        return "\n".join(parts)
+
+
+# ── Tool registry ──────────────────────────────────────────────────
+
+
+def make_tools(workspace: str, file_cache: FileCache):
+    @tool(description="Execute a bash command in the project directory.", timeout_s=600)
+    def bash(*, command: str) -> dict:
+        # CWD safety: detect cd outside workspace
+        result = _run(command, workspace)
+        # Check if command tried to cd outside workspace
+        parts = re.split(r"&&|\|\||;|\n", command)
+        for part in parts:
+            part = part.strip()
+            if part.startswith("cd "):
+                target = part[3:].strip().strip("'\"")
+                resolved = Path(workspace) / target
+                try:
+                    resolved = resolved.resolve()
+                    ws_resolved = Path(workspace).resolve()
+                    if not _is_path_inside(resolved, ws_resolved):
+                        result["cwd_warning"] = (
+                            f"Warning: 'cd {target}' points outside the project directory. "
+                            f"All commands run in the project root. Use relative paths."
+                        )
+                except Exception:
+                    pass
+        return result
+
+    @tool(
+        description="List directory contents as a tree. Use at the start to understand project structure.",
+        concurrent_safe=True,
+    )
+    def list_dir(*, path: str = ".", depth: int = 2) -> dict:
+        target = Path(workspace) / path
+        if not target.exists():
+            return {"error": f"Not found: {path}"}
+        if not target.is_dir():
+            return {"error": f"Not a directory: {path}"}
+        skip = {
+            ".git",
+            "__pycache__",
+            "node_modules",
+            ".venv",
+            "venv",
+            ".tox",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".pytest_cache",
+        }
+        entries: list[str] = []
+
+        def _walk(p: Path, prefix: str, d: int) -> None:
+            if d > depth:
+                return
+            try:
+                items = sorted(p.iterdir(), key=lambda x: (not x.is_dir(), x.name))
+            except PermissionError:
+                return
+            for item in items:
+                if item.name in skip:
+                    continue
+                if item.is_dir():
+                    entries.append(f"{prefix}{item.name}/")
+                    _walk(item, prefix + "  ", d + 1)
+                elif len(entries) < 200:
+                    entries.append(f"{prefix}{item.name}")
+
+        _walk(target, "", 0)
+        return {"path": path, "entries": entries, "count": len(entries)}
+
+    @tool(
+        description="Read a file with line numbers. Optionally specify start_line and/or end_line.",
+        concurrent_safe=True,
+    )
+    def read_file(*, file_path: str, start_line: int = 0, end_line: int = 0) -> dict:
+        p = _resolve_safe_path(workspace, file_path)
+        if p is None:
+            return {"error": f"Path '{file_path}' is outside the project directory."}
+        if not p.exists():
+            return {"error": f"File not found: {file_path}"}
+        # file_unchanged optimization: skip full content if unchanged
+        # since last *read* (not edit — edits update the hash but the
+        # model hasn't seen the new content via read_file yet).
+        if start_line == 0 and end_line == 0 and file_cache.is_unchanged(file_path):
+            return {
+                "path": file_path,
+                "file_unchanged": True,
+                "note": "File has not changed since your last read. No need to re-read.",
+            }
+        try:
+            lines = p.read_text().splitlines()
+            if start_line > 0 and end_line > 0:
+                selected = lines[start_line - 1 : end_line]
+                numbered = [f"{start_line + i:>4} | {line}" for i, line in enumerate(selected)]
+            elif start_line > 0:
+                selected = lines[start_line - 1 :]
+                numbered = [f"{start_line + i:>4} | {line}" for i, line in enumerate(selected)]
+            else:
+                numbered = [f"{i + 1:>4} | {line}" for i, line in enumerate(lines)]
+            content = "\n".join(numbered)
+            if len(content) > 20000:
+                content = (
+                    content[:10000]
+                    + f"\n... [{len(content) - 20000} chars truncated] ...\n"
+                    + content[-10000:]
+                )
+            file_cache.record(file_path)
+            return {"path": file_path, "content": content, "total_lines": len(lines)}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @tool(description="Create or overwrite a file. Use for new files only.")
+    def write_file(*, file_path: str, content: str) -> dict:
+        p = _resolve_safe_path(workspace, file_path)
+        if p is None:
+            return {"error": f"Path '{file_path}' is outside the project directory."}
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        file_cache.invalidate(file_path)
+        return {"written": file_path, "lines": content.count("\n") + 1}
+
+    @tool(description="Edit a file by replacing an exact string. Always read_file first.")
+    def edit_file(*, file_path: str, old_string: str, new_string: str) -> dict:
+        p = _resolve_safe_path(workspace, file_path)
+        if p is None:
+            return {"error": f"Path '{file_path}' is outside the project directory."}
+        if not p.exists():
+            return {"error": f"File not found: {file_path}"}
+        # Guard: no-op edit wastes a step
+        if old_string == new_string:
+            return {"error": "old_string and new_string are identical. No change needed."}
+        text = p.read_text()
+        count = text.count(old_string)
+        if count == 1:
+            new_text = text.replace(old_string, new_string, 1)
+            p.write_text(new_text)
+            file_cache.invalidate(file_path)
+            # Structured diff for model verification
+            diff = difflib.unified_diff(
+                text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                fromfile=f"a/{file_path}",
+                tofile=f"b/{file_path}",
+                n=3,
+            )
+            diff_text = "".join(diff)
+            if len(diff_text) > 2000:
+                diff_text = diff_text[:2000] + "\n... [diff truncated]"
+            return {"edited": file_path, "replacements": 1, "diff": diff_text}
+        if count > 1:
+            return {
+                "error": f"Matches {count} locations. Include more surrounding context for a unique match.",
+                "matches": count,
+            }
+        # Fuzzy fallback
+        fuzzy = _fuzzy_find(text, old_string)
+        if fuzzy:
+            hints = [f"  line {n} ({r:.0%}): {t.strip()[:80]}" for n, r, t in fuzzy[:3]]
+            return {
+                "error": "Exact match not found. Similar lines:\n"
+                + "\n".join(hints)
+                + "\n\nRECOVERY: read_file at those lines, then retry with exact text.",
+                "similar_lines": [f[0] for f in fuzzy[:3]],
+            }
+        return {"error": f"Not found in {file_path}. Use read_file to see exact content."}
+
+    @tool(description="Find files by glob pattern.", concurrent_safe=True)
+    def glob(*, pattern: str) -> dict:
+        return {
+            "pattern": pattern,
+            "matches": sorted(
+                str(path.relative_to(workspace))
+                for path in Path(workspace).glob(pattern)
+                if path.is_file()
+            )[:100],
+        }
+
+    @tool(
+        description="Search file contents with regex. Returns file:line:content.",
+        concurrent_safe=True,
+    )
+    def grep(*, pattern: str, path: str = ".", include: str = "") -> dict:
+        target = _resolve_safe_path(workspace, path)
+        if target is None:
+            return {"error": f"Path '{path}' is outside the project directory."}
+        cmd = ["grep", "-rn"]
+        if include:
+            cmd.append(f"--include={include}")
+        cmd.extend(["--", pattern, str(target)])
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=workspace,
+            )
+        except subprocess.TimeoutExpired:
+            return {"error": "Search timed out", "pattern": pattern, "matches": [], "count": 0}
+        lines = result.stdout.splitlines() if result.stdout else []
+        workspace_prefix = str(Path(workspace).resolve()) + os.sep
+        relative_lines = [
+            line.removeprefix(workspace_prefix) if line.startswith(workspace_prefix) else line
+            for line in lines
+        ]
+        data = {"pattern": pattern, "matches": relative_lines[:50], "count": len(relative_lines)}
+        if result.returncode not in (0, 1):
+            data["error"] = result.stderr.strip() or f"grep exited {result.returncode}"
+        return data
+
+    return tools_from(
+        [bash, list_dir, read_file, write_file, edit_file, glob, grep],
+        include_think=True,
+        include_done=True,
+    )

--- a/examples/coder_portable.cartridge/_mcp/tools_server.py
+++ b/examples/coder_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,342 @@
+"""Out-of-process MCP stdio server exposing the coder cartridge's full
+tool set — the portable replacement for the original cartridge's 16
+in-process ``tools/<name>/execute.py`` bodies.
+
+Speaks the MCP stdio transport (newline-delimited JSON-RPC), so any
+conforming loader can drive these tools. The tool *logic* is vendored
+unchanged from the original cartridge (``coder_lib_tools.py`` helpers +
+each ``_tools/<name>.py`` body); this server is the protocol adapter
+that wires three things the original got from its Python host:
+
+* **workspace** — the original read ``ctx.resources['workspace_config'].path``
+  (an in-process ``@ref`` resource). Here it comes from
+  ``$LOOPLET_PROJECT_ROOT`` (or cwd), exposed through a tiny shim with
+  the same ``.path`` attribute.
+
+* **file_cache** — the original shared a single in-process ``FileCache``
+  between the file tools and the StaleFile/FileCache hooks via
+  ``@file_cache``. Here it lives in a separate **State Service** process;
+  we reach it through a :class:`StateServiceClient` (socket exported as
+  ``LOOPLET_STATE_FILE_CACHE``). A thin proxy gives it the exact
+  FileCache method surface the tools call.
+
+* **ctx.llm** — ``subagent`` and ``web_fetch`` need the host LLM. Here
+  it is reached over the **Model Gateway Protocol**: a
+  :class:`ModelGatewayClient` (socket ``LOOPLET_LLM_SOCKET``) forwards
+  generation to the host's bound backend. When no backend is bound,
+  ``ctx.llm`` degrades to ``None`` and the tools return their original
+  no-LLM behaviour.
+
+Each ``tools/call`` builds a lightweight :class:`ToolContext` wiring
+those three pieces and invokes the vendored ``execute(ctx, **args)``.
+"""
+
+import importlib.util
+import inspect
+import json
+import os
+import sys
+import traceback
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# Put this dir on the path so the vendored tool bodies can
+# ``from coder_lib_tools import ...`` exactly as they did in-process.
+sys.path.insert(0, _HERE)
+
+from looplet.model_gateway import ModelGatewayClient  # noqa: E402
+from looplet.state_service import StateServiceClient  # noqa: E402
+from looplet.types import ToolContext  # noqa: E402
+
+_TOOLS_DIR = os.path.join(_HERE, "_tools")
+
+# Canonical tool order (matches the original cartridge surface).
+_TOOL_NAMES = [
+    "bash",
+    "list_dir",
+    "read_file",
+    "write_file",
+    "edit_file",
+    "multi_edit",
+    "notebook_edit",
+    "glob",
+    "grep",
+    "git_inspect",
+    "worktree",
+    "web_fetch",
+    "subagent",
+    "todo",
+    "think",
+    "done",
+]
+
+# Map Python annotations to JSON-Schema types for the MCP inputSchema.
+_ANNOT_TYPES = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    dict: "object",
+}
+
+# The vendored tool modules use ``from __future__ import annotations`` (PEP
+# 563), so ``inspect.signature(fn).parameters[...].annotation`` is the
+# *string* name of the type (e.g. ``"list"``), not the type object. Map by
+# name too, otherwise structured params (``edits: list``) silently fall back
+# to ``"string"`` in the advertised schema — which makes the model encode
+# them as a JSON string and trips the tool's list validation.
+_ANNOT_TYPES_BY_NAME = {
+    "str": "string",
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "list": "array",
+    "dict": "object",
+}
+
+
+def _json_type(annotation: object) -> str:
+    """Resolve a parameter annotation (type object *or* PEP-563 string)
+    to a JSON-Schema type name, defaulting to ``"string"``."""
+    if isinstance(annotation, str):
+        # Strip an optional ``X | None`` / ``Optional[X]`` wrapper to the
+        # leading bare name so e.g. ``"list | None"`` → ``"array"``.
+        head = annotation.split("|", 1)[0].strip()
+        head = head.removeprefix("Optional[").rstrip("]").strip()
+        return _ANNOT_TYPES_BY_NAME.get(head, "string")
+    return _ANNOT_TYPES.get(annotation, "string")
+
+
+# ── workspace shim (replaces the @workspace_config resource) ─────────
+class _WorkspaceConfig:
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+
+def _project_root() -> str:
+    return os.environ.get("LOOPLET_PROJECT_ROOT") or os.getcwd()
+
+
+# ── file_cache proxy (replaces the @file_cache resource) ─────────────
+class _FileCacheProxy:
+    """Forwards the FileCache method surface to the State Service.
+
+    Exposes exactly the methods the tools call on the in-process cache
+    (``record``/``invalidate``/``is_unchanged``/``was_read``/
+    ``record_bash``/``recent_bash_repeats``). The socket is shared with
+    the StaleFile/FileCache LEP hooks, so all processes see one cache.
+    """
+
+    def __init__(self, client: "StateServiceClient | None") -> None:
+        self._c = client
+
+    def record(self, path: str) -> None:
+        if self._c is not None:
+            self._c.record(path)
+
+    def invalidate(self, path: str) -> None:
+        if self._c is not None:
+            self._c.invalidate(path)
+
+    def is_unchanged(self, path: str) -> bool:
+        if self._c is None:
+            return False
+        return bool(self._c.is_unchanged(path))
+
+    def was_read(self, path: str) -> bool:
+        if self._c is None:
+            return False
+        return bool(self._c.was_read(path))
+
+    def record_bash(self, command: str) -> int:
+        if self._c is None:
+            return 0
+        return int(self._c.record_bash(command))
+
+    def recent_bash_repeats(self, command: str) -> int:
+        if self._c is None:
+            return 0
+        return int(self._c.recent_bash_repeats(command))
+
+
+_CACHE_CLIENT: "StateServiceClient | None" = None
+_CACHE_TRIED = False
+
+
+def _file_cache() -> _FileCacheProxy:
+    global _CACHE_CLIENT, _CACHE_TRIED
+    if not _CACHE_TRIED:
+        _CACHE_TRIED = True
+        socket_path = os.environ.get("LOOPLET_STATE_FILE_CACHE")
+        if socket_path:
+            try:
+                _CACHE_CLIENT = StateServiceClient(socket_path)
+            except Exception:  # noqa: BLE001 - degrade gracefully
+                _CACHE_CLIENT = None
+    return _FileCacheProxy(_CACHE_CLIENT)
+
+
+# ── host LLM (Model Gateway) ─────────────────────────────────────────
+def _host_llm() -> "ModelGatewayClient | None":
+    """Return a ready Model Gateway client, or None when no backend is bound.
+
+    Re-checks readiness on every call so late backend binding (the host
+    binds the LLM at ``AgentPreset.run``, after this server started) is
+    picked up, and a running-but-unbound gateway degrades to ``None``.
+    """
+    client = ModelGatewayClient.from_env()
+    if client is None:
+        return None
+    if not getattr(client, "ready", False):
+        client.close()
+        return None
+    return client
+
+
+# ── load vendored tool bodies + schemas ──────────────────────────────
+def _load_tool(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"_coder_tool_{name}", os.path.join(_TOOLS_DIR, f"{name}.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.execute
+
+
+def _schema_from_signature(name: str, fn) -> dict:
+    """Derive the MCP inputSchema from ``execute``'s signature.
+
+    Avoids any YAML dependency (the spawned interpreter reaches looplet
+    over an injected ``PYTHONPATH`` but has no guaranteed PyYAML). The
+    keyword-only params are the tool arguments; the leading positional
+    ``ctx`` (when present) is the host wiring and is excluded.
+
+    Optionality note: looplet's MCP adapter flattens an inputSchema to a
+    simple ``{name: type_string}`` dict and DROPS the JSON-Schema
+    ``required`` list — it then treats a param as optional only when its
+    type/description string begins with ``(optional)``. So we encode a
+    Python default as an ``"(optional) <type>"`` type string; that keeps
+    the param *known* (passable) while marking it not-required, exactly
+    matching the original ``tool.yaml`` ``default:`` semantics.
+    """
+    properties: dict = {}
+    required: list[str] = []
+    for param in inspect.signature(fn).parameters.values():
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            continue  # ctx — host wiring, not a model-facing argument
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        jtype = _json_type(param.annotation)
+        if param.default is inspect.Parameter.empty:
+            properties[param.name] = {"type": jtype}
+            required.append(param.name)
+        else:
+            properties[param.name] = {"type": f"(optional) {jtype}"}
+    doc = (inspect.getdoc(fn) or name).strip().splitlines()
+    return {
+        "name": name,
+        "description": doc[0] if doc else name,
+        "inputSchema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        },
+    }
+
+
+_EXECUTORS = {name: _load_tool(name) for name in _TOOL_NAMES}
+_TOOLS = [_schema_from_signature(name, _EXECUTORS[name]) for name in _TOOL_NAMES]
+
+
+def _wants_ctx(fn) -> bool:
+    """True if ``execute`` takes a positional ``ctx`` (most tools do; the
+    pure builtins ``think``/``done`` declare only keyword-only params)."""
+    for param in inspect.signature(fn).parameters.values():
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
+            return True
+    return False
+
+
+_WANTS_CTX = {name: _wants_ctx(fn) for name, fn in _EXECUTORS.items()}
+
+
+def _make_ctx() -> ToolContext:
+    return ToolContext(
+        resources={
+            "workspace_config": _WorkspaceConfig(_project_root()),
+            "file_cache": _file_cache(),
+        },
+        llm=_host_llm(),
+    )
+
+
+# ── MCP stdio plumbing ───────────────────────────────────────────────
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "coder-portable-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": _TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            executor = _EXECUTORS.get(name)
+            if executor is None:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+                continue
+            try:
+                if _WANTS_CTX.get(name, True):
+                    payload = executor(_make_ctx(), **args)
+                else:
+                    payload = executor(**args)
+            except Exception as exc:  # noqa: BLE001
+                respond(
+                    msg_id,
+                    {
+                        "content": [
+                            {"type": "text", "text": f"error: {exc}\n{traceback.format_exc()}"}
+                        ],
+                        "isError": True,
+                    },
+                )
+                continue
+            respond(
+                msg_id,
+                {
+                    "content": [{"type": "text", "text": json.dumps(payload)}],
+                    "isError": False,
+                },
+            )
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/coder_portable.cartridge/_state/file_cache.py
+++ b/examples/coder_portable.cartridge/_state/file_cache.py
@@ -1,0 +1,86 @@
+"""Shared file cache — ported from the in-process ``@ref`` resource to an
+out-of-process **State Service** (State Service Protocol).
+
+In the original ``coder`` cartridge the ``FileCache`` lived at
+``resources/file_cache.py`` as a single instance shared (via
+``"@file_cache"`` refs) between the read/write/edit tools AND the
+StaleFile/FileCache hooks — all running in the SAME Python process.
+That shared-address-space requirement is exactly what pinned the
+cartridge to a Python host.
+
+Here the same cache lives in ITS OWN process behind a Unix socket. The
+loader spawns this server and exports the socket path as
+``LOOPLET_STATE_FILE_CACHE`` so the MCP tools server (read_file,
+write_file, edit_file, multi_edit, notebook_edit, bash) and the LEP
+hooks (StaleFile, FileCache) — each a SEPARATE process — connect to and
+mutate the SAME cache, reproducing the in-process ``@ref`` sharing
+across the process boundary.
+
+The underlying :class:`FileCache` logic is vendored unchanged in
+``../_mcp/coder_lib_tools.py``; this service is a thin SSP delegator
+over its public surface. All method calls are serialized under one
+lock so concurrent readers/writers (tool process + hook processes)
+see a consistent cache.
+"""
+
+import os
+import sys
+
+# The vendored FileCache implementation lives next to the MCP tools
+# server. Put that dir on the path so this separate process can reuse
+# the exact same logic the in-process original used.
+_MCP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_mcp")
+sys.path.insert(0, _MCP_DIR)
+
+from coder_lib_tools import FileCache  # noqa: E402
+
+from looplet.state_service import StateServiceBase  # noqa: E402
+
+
+def _workspace() -> str:
+    return os.environ.get("LOOPLET_PROJECT_ROOT") or os.getcwd()
+
+
+class FileCacheService(StateServiceBase):
+    """The shared coder file cache, served over SSP.
+
+    Delegates to a single :class:`FileCache` bound to the project root.
+    Every method the tools and hooks call in-process on the ``@ref``
+    cache is exposed here verbatim so the proxy on the other side of
+    the socket is a drop-in replacement.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cache = FileCache(_workspace())
+
+    # ── reads/writes recorded by the file tools ──────────────────
+    def record(self, path: str) -> None:
+        self._cache.record(path)
+
+    def invalidate(self, path: str) -> None:
+        self._cache.invalidate(path)
+
+    def is_unchanged(self, path: str) -> bool:
+        return self._cache.is_unchanged(path)
+
+    def was_read(self, path: str) -> bool:
+        return self._cache.was_read(path)
+
+    # ── bash loop-detection used by the bash tool ────────────────
+    def record_bash(self, command: str) -> int:
+        return self._cache.record_bash(command)
+
+    def recent_bash_repeats(self, command: str) -> int:
+        return self._cache.recent_bash_repeats(command)
+
+    # ── stale detection + briefing render used by the hooks ──────
+    def stale_files(self) -> list:
+        return self._cache.stale_files()
+
+    def render(self) -> str:
+        return self._cache.render()
+
+
+if __name__ == "__main__":
+    raise SystemExit(FileCacheService().serve())

--- a/examples/coder_portable.cartridge/cartridge.json
+++ b/examples/coder_portable.cartridge/cartridge.json
@@ -1,0 +1,17 @@
+{
+  "description": "Fully-portable twin of the `coder` cartridge. Every portable component is out-of-process: the 16 tools are an MCP stdio server (_mcp/tools_server.py), the shared FileCache is a State Service Protocol server (_state/file_cache.py), and all five ported hooks are kind: lep. web_fetch/subagent reach the host LLM over the Model Gateway. Compaction is a RUNTIME builtin (default_compact_service). EvalHook and the dynamic memory builders are intentionally omitted (documented limitations). `looplet portability` reports the PORTABLE profile — it runs on any conforming loader (Rust/Go/TS).",
+  "metadata": {
+    "tags": [
+      "coding",
+      "software-engineering",
+      "testing",
+      "portable",
+      "mcp",
+      "lep",
+      "ssp",
+      "mgp"
+    ]
+  },
+  "name": "coder_portable",
+  "schema_version": 2
+}

--- a/examples/coder_portable.cartridge/config.yaml
+++ b/examples/coder_portable.cartridge/config.yaml
@@ -1,0 +1,96 @@
+# Fully-portable twin of ../coder.cartridge.
+#
+# The original coder pins many components to a Python host: 16 tool
+# bodies, a @ref FileCache shared resource, and 6 in-process hook
+# classes. THIS cartridge moves every portable one of them out of
+# process behind a protocol so `looplet portability` reports PORTABLE:
+#
+#   * 16 tools .............. MCP stdio server   (_mcp/tools_server.py)
+#   * shared FileCache ...... State Service      (_state/file_cache.py)
+#   * TestGuardHook ......... kind: lep          (hooks/00_TestGuardHook)
+#   * FileCacheHook ......... kind: lep          (hooks/01_FileCacheHook)
+#   * StaleFileHook ......... kind: lep          (hooks/02_StaleFileHook)
+#   * LinterHook ............ kind: lep          (hooks/06_LinterHook)
+#   * ShellSafetyGate ....... kind: lep          (hooks/08_ShellSafetyGate)
+#   * compaction ............ RUNTIME builtin    (resources/compact_service.py
+#                                                 → default_compact_service)
+#
+# Intentionally omitted (no portable protocol surface):
+#   * EvalHook — a host-side post-run evaluation harness (collectors +
+#     evaluators) with no LEP decide-slot equivalent.
+#   * @instructions_memory / @project_memory — dynamic CallableMemorySource
+#     builders (git branch + step-count + file discovery). Replaced with a
+#     static memory/coding.md distillation; the dynamic git/step context is
+#     a documented limitation of the portable twin.
+#
+# The MCP tool server reaches the host LLM through the Model Gateway
+# (LOOPLET_LLM_SOCKET) so web_fetch/subagent keep working out-of-process.
+
+max_steps: 20
+done_tool: done
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4.6
+  reasoning_effort: high
+
+permissions:
+  default: allow
+  deny:
+    -
+      tool: bash
+      contains:
+        command: rm -rf
+      reason: destructive recursive delete
+    -
+      tool: bash
+      contains:
+        command: "sudo "
+      reason: escalated privileges
+    -
+      tool: bash
+      contains:
+        command: > /dev/
+      reason: raw device write
+    -
+      tool: write_file
+      contains:
+        file_path: /etc/
+      reason: system path
+
+builtin_hooks:
+  -
+    stagnation:
+      threshold: 6
+      nudge: [stagnation] Re-read the file, try a different approach, or think().
+      reset_after_nudge: true
+      ignore_tools:
+        - think
+        - done
+  -
+    threshold_compact:
+      budget:
+        context_window: 128000
+        warning_at: 80000
+        error_at: 100000
+        compact_buffer: 13000
+      fire_tier: warning
+  -
+    per_tool_limit:
+      default_limit: 100
+
+# Out-of-process shared mutable state (State Service Protocol). The
+# loader spawns this server and exports its socket as
+# LOOPLET_STATE_FILE_CACHE so the MCP tool server and the cache-backed
+# LEP hooks (FileCacheHook, StaleFileHook) — all separate processes —
+# read and write the SAME FileCache, exactly as the @ref demo did.
+state_services:
+  file_cache:
+    command: "python3 ${runtime.cartridge_root}/_state/file_cache.py"
+    timeout_s: 10
+
+# Out-of-process tools (MCP stdio transport). Exposes all 16 coder tools.
+mcp_servers:
+  tools:
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 10

--- a/examples/coder_portable.cartridge/hooks/00_TestGuardHook/config.yaml
+++ b/examples/coder_portable.cartridge/hooks/00_TestGuardHook/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args, tool_result, step]
+  fidelity: full
+on_failure: fail_open

--- a/examples/coder_portable.cartridge/hooks/00_TestGuardHook/server.py
+++ b/examples/coder_portable.cartridge/hooks/00_TestGuardHook/server.py
@@ -1,0 +1,45 @@
+"""TestGuardHook as a portable ``kind: lep`` server.
+
+Wraps the vendored :class:`coder_lib_hooks.TestGuardHook` (observe-only
+by default). It keeps its own ``_tests_passed`` / ``_files_written``
+state across slot calls IN THIS PROCESS — the LEP server is long-lived,
+so the in-process statefulness survives unchanged. Two slots:
+
+* ``post_dispatch`` — watch bash test runs + record written files.
+* ``check_done``    — surface the finishing-without-tests nudge
+  (strict=False never blocks).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "_lep"))
+
+from coder_lib_hooks import TestGuardHook  # noqa: E402
+from lep_common import normalize, view_to_call, view_to_result  # noqa: E402
+
+from looplet.lep import LEPServerBase  # noqa: E402
+
+
+class TestGuardServer(LEPServerBase):
+    slots = ("post_dispatch", "check_done")
+    effects = ("Continue", "InjectContext", "Block", "HookDecision")
+    view_fields = ("tool", "args", "tool_result", "step")
+    view_fidelity = "full"
+
+    def __init__(self) -> None:
+        self._hook = TestGuardHook(strict=False)
+
+    def decide(self, slot, view):
+        step = int(view.get("step") or 0)
+        if slot == "post_dispatch":
+            return normalize(
+                self._hook.post_dispatch(None, None, view_to_call(view), view_to_result(view), step)
+            )
+        if slot == "check_done":
+            return normalize(self._hook.check_done(None, None, None, step))
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(TestGuardServer().serve())

--- a/examples/coder_portable.cartridge/hooks/01_FileCacheHook/config.yaml
+++ b/examples/coder_portable.cartridge/hooks/01_FileCacheHook/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [step]
+  fidelity: digest
+on_failure: fail_open

--- a/examples/coder_portable.cartridge/hooks/01_FileCacheHook/server.py
+++ b/examples/coder_portable.cartridge/hooks/01_FileCacheHook/server.py
@@ -1,0 +1,38 @@
+"""FileCacheHook as a portable ``kind: lep`` server.
+
+Re-injects the shared file cache into the briefing after step 3
+(post-compaction safety). The cache lives in a State Service; this
+server reaches it through :class:`lep_common.FileCacheProxy` over the
+SAME socket the MCP file tools use, so the rendered cache reflects the
+tools' reads. Only the ``pre_prompt`` slot is implemented.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "_lep"))
+
+from coder_lib_hooks import FileCacheHook  # noqa: E402
+from lep_common import FileCacheProxy, normalize  # noqa: E402
+
+from looplet.lep import LEPServerBase  # noqa: E402
+
+
+class FileCacheServer(LEPServerBase):
+    slots = ("pre_prompt",)
+    effects = ("Continue", "InjectContext")
+    view_fields = ("step",)
+    view_fidelity = "digest"
+
+    def __init__(self) -> None:
+        self._hook = FileCacheHook(FileCacheProxy())
+
+    def decide(self, slot, view):
+        if slot == "pre_prompt":
+            step = int(view.get("step") or 0)
+            return normalize(self._hook.pre_prompt(None, None, None, step))
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(FileCacheServer().serve())

--- a/examples/coder_portable.cartridge/hooks/02_StaleFileHook/config.yaml
+++ b/examples/coder_portable.cartridge/hooks/02_StaleFileHook/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args, tool_result]
+  fidelity: full
+on_failure: fail_open

--- a/examples/coder_portable.cartridge/hooks/02_StaleFileHook/server.py
+++ b/examples/coder_portable.cartridge/hooks/02_StaleFileHook/server.py
@@ -1,0 +1,38 @@
+"""StaleFileHook as a portable ``kind: lep`` server.
+
+After a bash step, asks the shared file cache (State Service) which
+previously-read files were modified, and nudges the model to re-read
+them. The cache proxy connects to the SAME socket the file tools and
+FileCacheHook use. Only ``post_dispatch`` is implemented.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "_lep"))
+
+from coder_lib_hooks import StaleFileHook  # noqa: E402
+from lep_common import FileCacheProxy, normalize, view_to_call, view_to_result  # noqa: E402
+
+from looplet.lep import LEPServerBase  # noqa: E402
+
+
+class StaleFileServer(LEPServerBase):
+    slots = ("post_dispatch",)
+    effects = ("Continue", "InjectContext")
+    view_fields = ("tool", "args", "tool_result")
+    view_fidelity = "full"
+
+    def __init__(self) -> None:
+        self._hook = StaleFileHook(FileCacheProxy())
+
+    def decide(self, slot, view):
+        if slot == "post_dispatch":
+            return normalize(
+                self._hook.post_dispatch(None, None, view_to_call(view), view_to_result(view), 0)
+            )
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(StaleFileServer().serve())

--- a/examples/coder_portable.cartridge/hooks/06_LinterHook/config.yaml
+++ b/examples/coder_portable.cartridge/hooks/06_LinterHook/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args, tool_result]
+  fidelity: full
+on_failure: fail_open

--- a/examples/coder_portable.cartridge/hooks/06_LinterHook/server.py
+++ b/examples/coder_portable.cartridge/hooks/06_LinterHook/server.py
@@ -1,0 +1,42 @@
+"""LinterHook as a portable ``kind: lep`` server.
+
+Runs ``ruff check`` after Python ``edit_file`` / ``write_file`` steps
+and surfaces diagnostics. Self-contained: the vendored hook resolves
+``ruff`` in the project venv / PATH and shells out itself (stdlib
+``subprocess``), so no shared host state is needed. The workspace is
+resolved via :func:`looplet.cartridge.runtime_helpers.resolve_project_root`
+(``$LOOPLET_PROJECT_ROOT`` / git toplevel / cwd). Only ``post_dispatch``
+is implemented.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "_lep"))
+
+from coder_lib_hooks import LinterHook  # noqa: E402
+from lep_common import normalize, view_to_call, view_to_result  # noqa: E402
+
+from looplet.cartridge.runtime_helpers import resolve_project_root  # noqa: E402
+from looplet.lep import LEPServerBase  # noqa: E402
+
+
+class LinterServer(LEPServerBase):
+    slots = ("post_dispatch",)
+    effects = ("Continue", "InjectContext")
+    view_fields = ("tool", "args", "tool_result")
+    view_fidelity = "full"
+
+    def __init__(self) -> None:
+        self._hook = LinterHook(resolve_project_root())
+
+    def decide(self, slot, view):
+        if slot == "post_dispatch":
+            return normalize(
+                self._hook.post_dispatch(None, None, view_to_call(view), view_to_result(view), 0)
+            )
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(LinterServer().serve())

--- a/examples/coder_portable.cartridge/hooks/08_ShellSafetyGate/config.yaml
+++ b/examples/coder_portable.cartridge/hooks/08_ShellSafetyGate/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/coder_portable.cartridge/hooks/08_ShellSafetyGate/server.py
+++ b/examples/coder_portable.cartridge/hooks/08_ShellSafetyGate/server.py
@@ -1,0 +1,52 @@
+"""ShellSafetyGate — a portable ``kind: lep`` permission policy.
+
+A catastrophic-command guardrail for the coder agent that runs *out of
+process* over the Loop Effect Protocol (LEP). The host ships only the
+declared view (``tool`` + ``args``); this server inspects the proposed
+``bash`` command and denies a small, conservative set of irreversibly
+destructive patterns (root/home wipes, raw-disk writes, filesystem
+formats, fork bombs, world-writable recursion on ``/``). Everything else
+is allowed — ordinary coding shell usage is untouched.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a self-contained
+``kind: lep`` block alongside the cartridge's in-process hooks
+(TestGuard, FileCache, StaleFile, Linter, Eval) — demonstrating both the
+out-of-process and in-process authoring styles in one cartridge.
+"""
+
+import re
+
+from looplet.lep import LEPServerBase
+
+# Conservative, high-confidence catastrophic patterns. Each is something
+# a coding agent should never need and that is effectively irreversible.
+_DANGEROUS = [
+    re.compile(r"\brm\s+(-[a-z]*\s+)*-[a-z]*[rf][a-z]*\s+(-[a-z]*\s+)*(/|~|\$HOME)\s*($|\s)"),
+    re.compile(r":\(\)\s*\{\s*:\|:&\s*\}\s*;\s*:"),  # classic fork bomb
+    re.compile(r"\bmkfs(\.\w+)?\b"),
+    re.compile(r"\bdd\b[^\n]*\bof=/dev/"),
+    re.compile(r">\s*/dev/sd[a-z]\b"),
+    re.compile(r"\bchmod\s+(-[a-z]*\s+)*-R\s+0*777\s+/\s*($|\s)"),
+]
+
+
+class ShellSafetyServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "bash":
+            command = (view.get("args") or {}).get("command")
+            if isinstance(command, str):
+                for pattern in _DANGEROUS:
+                    if pattern.search(command):
+                        return {
+                            "kind": "Deny",
+                            "block": (
+                                "shell-safety policy: refusing a catastrophic "
+                                f"command ({pattern.pattern!r})"
+                            ),
+                        }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(ShellSafetyServer().serve())

--- a/examples/coder_portable.cartridge/memory/coding.md
+++ b/examples/coder_portable.cartridge/memory/coding.md
@@ -1,0 +1,28 @@
+# Coding guidelines
+
+Static distillation of the coder agent's working conventions. (The
+original `coder` cartridge derived equivalent memory dynamically from
+`@instructions_memory` — discovering CLAUDE.md / AGENTS.md in the
+project — and `@project_memory` — git branch + step budget. Those
+builders are in-process and not portable; this file is the static
+substitute. Per-project instruction files and live git context are not
+surfaced by the portable twin.)
+
+## Workflow
+- Read a file before editing it; never edit blind.
+- Prefer `edit_file` / `multi_edit` for surgical changes over rewriting
+  whole files with `write_file`.
+- Use `grep` and `glob` to locate code before reading; avoid scanning
+  large trees with `bash`.
+- After changing code, run the project's tests (`pytest`, `npm test`,
+  `cargo test`, `go test`) and confirm they pass before calling `done`.
+
+## Discipline
+- Make only the changes that are requested or clearly necessary.
+- Keep diffs minimal; do not refactor or reformat untouched code.
+- When stuck, `think()` to plan instead of repeating a failing action.
+- Call `done` with a concise summary once the task is verified complete.
+
+## Safety
+- Never run destructive commands (`rm -rf`, `sudo`, raw device writes).
+- Do not write to system paths (`/etc/`).

--- a/examples/coder_portable.cartridge/prompts/system.md
+++ b/examples/coder_portable.cartridge/prompts/system.md
@@ -1,0 +1,32 @@
+You are an expert software engineer. You solve tasks by understanding the codebase, planning carefully, making precise changes, and verifying with tests. You never guess — you read first, then act.
+
+## Workflow
+1. PLAN: for non-trivial work, call todo() with a short checklist and update it as you progress.
+2. EXPLORE: list_dir to see structure. glob/grep to find relevant files. Prefer grep over bash search commands.
+3. READ: read_file on files you need to modify. Understand patterns and conventions.
+4. THINK: use think() when you need to reconsider an approach or compare options.
+5. IMPLEMENT: edit_file or multi_edit for existing files, write_file for new files. Use notebook_edit for .ipynb files.
+6. INSPECT: use git_inspect for git status/diff/recent commits. Use web_fetch for public docs when external context is needed.
+7. DELEGATE: use subagent() for bounded investigations or review passes that can return concise findings.
+8. ISOLATE: use worktree() when you need a separate git worktree for an experiment.
+9. TEST: bash to run tests after EVERY change. Read failures. Fix and re-run.
+10. DONE: done() with summary only after tests pass.
+
+## Tool rules
+- ALWAYS read_file before edit_file. Never edit blind.
+- edit_file: copy-paste old_string from read_file output exactly. Include 3+ context lines.
+- If edit fails "not found": read the hint lines, re-read file at those lines, retry with exact text.
+- If edit fails "multiple matches": add more surrounding lines for uniqueness.
+- write_file: NEW files by default. Overwriting an existing file requires read_file first and fresh file state.
+- grep: use output_mode, glob/type filters, context, head_limit, and offset to keep search results focused.
+- notebook_edit: use for notebooks; do not edit raw notebook JSON with edit_file unless notebook_edit cannot express the change.
+- git_inspect: use for read-only git status/diff/log instead of bash git commands.
+- bash: use relative paths. pytest -xvs for tests (stop on first failure).
+- worktree remove requires explicit confirmation; never remove a worktree unless it was created for this task.
+- For bugs: write a failing test FIRST, then fix the code.
+
+## Code quality
+- Follow existing project style and conventions.
+- Type hints on function signatures. Docstrings on public functions.
+- Minimal changes. Don't refactor unrelated code.
+- If stuck after 3 attempts: think() to reconsider approach.

--- a/examples/coder_portable.cartridge/resources/compact_service.py
+++ b/examples/coder_portable.cartridge/resources/compact_service.py
@@ -1,0 +1,15 @@
+"""Compaction service for the coder workspace.
+
+Uses looplet's production default: prune old tool payloads, summarize
+older working context, keep recent steps verbatim, and truncate only as
+a fallback. Kept as a declarative resource so ``config.yaml`` can refer
+to it with ``compact_service: "@compact_service"``.
+"""
+
+from __future__ import annotations
+
+from looplet.compact import default_compact_service
+
+
+def build(runtime=None):
+    return default_compact_service(keep_recent=5, keep_recent_tool_results=10)

--- a/examples/coder_portable.cartridge/runtime.yaml
+++ b/examples/coder_portable.cartridge/runtime.yaml
@@ -1,0 +1,7 @@
+max_tokens: 2000
+temperature: 0.2
+# use_native_tools defaults to true (auto-falls-back if the backend lacks it).
+concurrent_dispatch: false
+reactive_recovery: true
+context_window: 128000
+compact_service: @compact_service

--- a/examples/dep_doctor_portable.cartridge/_mcp/tools_server.py
+++ b/examples/dep_doctor_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,596 @@
+"""Stdio MCP server for the dep_doctor_portable cartridge.
+
+Serves all 7 audit tools that were in-process ``tools/*/execute.py``
+bodies in the original ``dep_doctor`` cartridge — ``detect_dep_files``,
+``parse_deps``, ``check_package``, ``check_license_compat``,
+``find_alternatives``, ``think``, ``done`` — over the MCP stdio
+transport. Moving them out of process is what makes the twin fully
+portable: no Python tool body is required by the host.
+
+The package registry (``PACKAGE_DB``) and license compatibility table
+(``LICENSE_COMPATIBILITY``) are vendored here verbatim from the original
+``dep_doctor_lib.py``.
+
+``find_alternatives`` reaches the host model through the Model Gateway
+(MGP): the loader exports ``LOOPLET_LLM_SOCKET`` and this server connects
+to it lazily, so the tool returns real LLM-suggested alternatives — full
+parity with the in-process original. When no gateway is present (or no
+backend is bound yet) it degrades to empty alternatives, exactly the
+fallback the original tool takes when ``ctx.llm is None``.
+
+Relative paths (``detect_dep_files``/``parse_deps``) resolve against the
+server's working directory (``os.getcwd()``), which the loader sets to
+the host project root.
+
+Standard-library only.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import os
+import re
+import socket
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+class _HostLLM:
+    """Minimal stdlib-only client to the host Model Gateway (MGP).
+
+    Connects to ``$LOOPLET_LLM_SOCKET`` (set by the loader) and forwards
+    ``generate`` to the host's live LLM backend. ``generate`` raises if no
+    gateway/backend is reachable, so callers degrade exactly like the
+    in-process original's ``ctx.llm is None`` branch.
+    """
+
+    def __init__(self):
+        self._sock = None
+        self._buf = b""
+        self._id = 0
+        path = os.environ.get("LOOPLET_LLM_SOCKET")
+        if not path or not hasattr(socket, "AF_UNIX"):
+            return
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(30.0)
+            sock.connect(path)
+            self._sock = sock
+            self._rpc("llm/initialize", {})
+        except OSError:
+            self._sock = None
+
+    def _readline(self):
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                line, self._buf = self._buf, b""
+                return line
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return line
+
+    def _rpc(self, method, params):
+        self._id += 1
+        rid = self._id
+        self._sock.sendall(
+            (json.dumps({"id": rid, "method": method, "params": params}) + "\n").encode("utf-8")
+        )
+        line = self._readline()
+        if not line:
+            raise OSError("model gateway closed the connection")
+        msg = json.loads(line.decode("utf-8"))
+        if msg.get("error"):
+            raise RuntimeError(msg["error"].get("message", "model gateway error"))
+        return msg.get("result") or {}
+
+    def available(self):
+        """True iff the gateway has a live LLM backend bound *right now*.
+
+        Re-checks per call because the host binds the backend lazily at
+        run time (``AgentPreset.run(llm)``), which may happen after this
+        client connected. Maps to the original's ``ctx.llm is not None``
+        guard: when False, callers take their no-LLM degradation branch
+        instead of treating absence as an error.
+        """
+        if self._sock is None:
+            return False
+        try:
+            return bool(self._rpc("llm/initialize", {}).get("ready"))
+        except (OSError, RuntimeError):
+            return False
+
+    def generate(self, prompt, **kwargs):
+        if self._sock is None:
+            raise RuntimeError("no host LLM gateway is reachable")
+        return str(self._rpc("llm/generate", {"prompt": prompt, "kwargs": kwargs}).get("text", ""))
+
+
+_HOST_LLM = None
+_HOST_LLM_TRIED = False
+
+
+def _host_llm():
+    """Return the host Model Gateway client only when a backend is bound.
+
+    Returns ``None`` when there is no reachable gateway *or* no backend is
+    currently bound — i.e. exactly the cases where the in-process original
+    sees ``ctx.llm is None`` and degrades.
+    """
+    global _HOST_LLM, _HOST_LLM_TRIED
+    if not _HOST_LLM_TRIED:
+        _HOST_LLM_TRIED = True
+        client = _HostLLM()
+        if client._sock is not None:
+            _HOST_LLM = client
+    if _HOST_LLM is not None and _HOST_LLM.available():
+        return _HOST_LLM
+    return None
+
+
+PACKAGE_DB = {
+    "requests": {
+        "latest_version": "2.32.3",
+        "last_release": "2024-05-29",
+        "maintainers": 3,
+        "license": "Apache-2.0",
+        "weekly_downloads": 45_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "HTTP library for Python",
+    },
+    "flask": {
+        "latest_version": "3.1.0",
+        "last_release": "2024-11-15",
+        "maintainers": 4,
+        "license": "BSD-3-Clause",
+        "weekly_downloads": 12_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Lightweight WSGI web framework",
+    },
+    "django": {
+        "latest_version": "5.2",
+        "last_release": "2025-04-01",
+        "maintainers": 15,
+        "license": "BSD-3-Clause",
+        "weekly_downloads": 8_000_000,
+        "cves": [{"id": "CVE-2025-1234", "severity": "MEDIUM", "fixed_in": "5.1.5"}],
+        "status": "healthy",
+        "description": "High-level Python web framework",
+    },
+    "pyyaml": {
+        "latest_version": "6.0.2",
+        "last_release": "2024-08-06",
+        "maintainers": 1,
+        "license": "MIT",
+        "weekly_downloads": 35_000_000,
+        "cves": [],
+        "status": "warning",
+        "description": "YAML parser — single maintainer risk",
+    },
+    "cryptography": {
+        "latest_version": "44.0.0",
+        "last_release": "2025-01-15",
+        "maintainers": 5,
+        "license": "Apache-2.0 OR BSD-3-Clause",
+        "weekly_downloads": 50_000_000,
+        "cves": [{"id": "CVE-2024-9876", "severity": "HIGH", "fixed_in": "43.0.1"}],
+        "status": "healthy",
+        "description": "Cryptographic recipes and primitives",
+    },
+    "urllib3": {
+        "latest_version": "2.3.0",
+        "last_release": "2025-02-01",
+        "maintainers": 2,
+        "license": "MIT",
+        "weekly_downloads": 60_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "HTTP client library",
+    },
+    "pillow": {
+        "latest_version": "11.1.0",
+        "last_release": "2025-01-02",
+        "maintainers": 4,
+        "license": "MIT-CMU",
+        "weekly_downloads": 15_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Python Imaging Library fork",
+    },
+    "setuptools": {
+        "latest_version": "75.8.0",
+        "last_release": "2025-01-20",
+        "maintainers": 3,
+        "license": "MIT",
+        "weekly_downloads": 40_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Build system for Python packages",
+    },
+    "abandoned-lib": {
+        "latest_version": "0.3.1",
+        "last_release": "2021-06-15",
+        "maintainers": 1,
+        "license": "GPL-3.0",
+        "weekly_downloads": 500,
+        "cves": [{"id": "CVE-2023-5555", "severity": "CRITICAL", "fixed_in": "none"}],
+        "status": "abandoned",
+        "description": "Abandoned library with unpatched CVE",
+    },
+    "numpy": {
+        "latest_version": "2.2.0",
+        "last_release": "2025-01-10",
+        "maintainers": 20,
+        "license": "BSD-3-Clause",
+        "weekly_downloads": 55_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Numerical computing library",
+    },
+    "pandas": {
+        "latest_version": "2.2.3",
+        "last_release": "2024-09-20",
+        "maintainers": 12,
+        "license": "BSD-3-Clause",
+        "weekly_downloads": 30_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Data analysis and manipulation",
+    },
+    "express": {
+        "latest_version": "4.21.0",
+        "last_release": "2024-09-10",
+        "maintainers": 5,
+        "license": "MIT",
+        "weekly_downloads": 30_000_000,
+        "cves": [],
+        "status": "healthy",
+        "description": "Fast, minimalist web framework for Node.js",
+    },
+    "lodash": {
+        "latest_version": "4.17.21",
+        "last_release": "2021-02-20",
+        "maintainers": 1,
+        "license": "MIT",
+        "weekly_downloads": 50_000_000,
+        "cves": [],
+        "status": "warning",
+        "description": "Utility library — no updates since 2021",
+    },
+    "event-stream": {
+        "latest_version": "4.0.1",
+        "last_release": "2019-11-22",
+        "maintainers": 1,
+        "license": "MIT",
+        "weekly_downloads": 2_000_000,
+        "cves": [{"id": "CVE-2018-16487", "severity": "CRITICAL", "fixed_in": "4.0.0"}],
+        "status": "compromised",
+        "description": "Known supply chain attack target",
+    },
+}
+
+LICENSE_COMPATIBILITY = {
+    "MIT": {"compatible_with": ["MIT", "BSD-3-Clause", "Apache-2.0", "ISC", "BSD-2-Clause"]},
+    "BSD-3-Clause": {"compatible_with": ["MIT", "BSD-3-Clause", "Apache-2.0", "ISC"]},
+    "Apache-2.0": {"compatible_with": ["MIT", "BSD-3-Clause", "Apache-2.0"]},
+    "GPL-3.0": {
+        "compatible_with": ["GPL-3.0", "AGPL-3.0"],
+        "note": "Copyleft — may require open-sourcing your code",
+    },
+    "LGPL-3.0": {"compatible_with": ["GPL-3.0", "LGPL-3.0", "AGPL-3.0"], "note": "Weak copyleft"},
+}
+
+
+def _resolve(path: str) -> Path:
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path(os.getcwd()) / p
+    return p
+
+
+def detect_dep_files(project_dir):
+    p = _resolve(project_dir)
+    found = []
+    for name in [
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+        "setup.cfg",
+        "Pipfile",
+        "package.json",
+        "package-lock.json",
+        "Cargo.toml",
+        "go.mod",
+        "go.sum",
+        "Gemfile",
+    ]:
+        path = p / name
+        if path.exists():
+            found.append({"file": name, "size_bytes": path.stat().st_size})
+    return {"project": p.name, "dep_files": found, "count": len(found)}
+
+
+def parse_deps(file_path):
+    p = _resolve(file_path)
+    if not p.exists():
+        return {"error": f"File not found: {file_path}"}
+
+    content = p.read_text()
+    name = p.name
+    deps = []
+
+    if name == "pyproject.toml":
+        in_deps = False
+        for line in content.split("\n"):
+            if "dependencies" in line and "=" in line and "[" not in line:
+                continue
+            if line.strip().startswith("[") and "dependencies" in line.lower():
+                in_deps = True
+                continue
+            if line.strip().startswith("[") and in_deps:
+                in_deps = False
+                continue
+            if in_deps:
+                line = line.strip().strip(",").strip('"').strip("'")
+                if not line or line.startswith("#"):
+                    continue
+                match = re.match(r"^([a-zA-Z0-9_-]+)", line)
+                if match:
+                    pkg = match.group(1).lower()
+                    version_match = re.search(r'[><=!~]+\s*([0-9][^\s,"\']*)', line)
+                    deps.append(
+                        {
+                            "name": pkg,
+                            "constraint": version_match.group(0).strip() if version_match else "*",
+                        }
+                    )
+
+    elif name == "requirements.txt":
+        for line in content.split("\n"):
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("-"):
+                continue
+            match = re.match(r"^([a-zA-Z0-9_-]+)", line)
+            if match:
+                pkg = match.group(1).lower()
+                version_match = re.search(r"[><=!~]+\s*([0-9][^\s]*)", line)
+                deps.append(
+                    {
+                        "name": pkg,
+                        "constraint": version_match.group(0) if version_match else "*",
+                    }
+                )
+
+    elif name == "package.json":
+        try:
+            data = json.loads(content)
+            for section in ["dependencies", "devDependencies"]:
+                for pkg, ver in data.get(section, {}).items():
+                    deps.append(
+                        {"name": pkg, "constraint": ver, "dev": section == "devDependencies"}
+                    )
+        except json.JSONDecodeError:
+            return {"error": "Invalid JSON in package.json"}
+
+    return {"file": name, "dependencies": deps, "count": len(deps)}
+
+
+def check_package(package_name):
+    name = package_name.lower().strip()
+    if name in PACKAGE_DB:
+        pkg = dict(PACKAGE_DB[name])
+        try:
+            release_date = datetime.strptime(pkg["last_release"], "%Y-%m-%d")
+            days_since = (datetime.now() - release_date).days
+            pkg["days_since_release"] = days_since
+            pkg["stale"] = days_since > 365
+        except (ValueError, KeyError):
+            pkg["days_since_release"] = None
+            pkg["stale"] = False
+        return pkg
+    return {"name": name, "error": "Package not found in registry", "status": "unknown"}
+
+
+def check_license_compat(project_license, dep_license):
+    proj = project_license.strip()
+    dep = dep_license.strip()
+    proj_info = LICENSE_COMPATIBILITY.get(proj, {})
+    compatible = dep in proj_info.get("compatible_with", [proj])
+    return {
+        "project_license": proj,
+        "dependency_license": dep,
+        "compatible": compatible,
+        "note": proj_info.get("note", "") if not compatible else "",
+        "risk": "HIGH" if not compatible and "GPL" in dep else "LOW" if compatible else "MEDIUM",
+    }
+
+
+def find_alternatives(package_name):
+    # Reach the host LLM through the Model Gateway when available; else
+    # degrade to the same empty result the original returns with no LLM.
+    llm = _host_llm()
+    if llm is not None:
+        try:
+            response = llm.generate(
+                f"Suggest 2-3 well-maintained alternatives to the Python/Node.js "
+                f"package '{package_name}'. For each alternative, give the package "
+                f"name and a one-line reason. Respond as a JSON array of objects "
+                f"with 'name' and 'reason' fields. Only the JSON array, nothing else.",
+                max_tokens=200,
+            )
+            try:
+                alternatives = json.loads(response.strip())
+                if isinstance(alternatives, list):
+                    return {"package": package_name, "alternatives": alternatives}
+            except json.JSONDecodeError:
+                pass
+            return {"package": package_name, "alternatives_text": response.strip()}
+        except Exception as e:
+            return {"package": package_name, "error": str(e)}
+    return {"package": package_name, "alternatives": []}
+
+
+TOOLS = [
+    {
+        "name": "detect_dep_files",
+        "description": "Scan a project directory for dependency files.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project_dir": {"type": "string", "description": "Path to the project root."}
+            },
+            "required": ["project_dir"],
+        },
+    },
+    {
+        "name": "parse_deps",
+        "description": "Parse a dependency file and extract package names plus version constraints.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to a dependency file (requirements.txt, "
+                    "pyproject.toml, package.json, etc.).",
+                }
+            },
+            "required": ["file_path"],
+        },
+    },
+    {
+        "name": "check_package",
+        "description": "Check a package's health — latest version, release date, CVEs, "
+        "license, maintainer activity.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "package_name": {"type": "string", "description": "PyPI / npm package name."}
+            },
+            "required": ["package_name"],
+        },
+    },
+    {
+        "name": "check_license_compat",
+        "description": "Check if a dependency license is compatible with the project license.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project_license": {
+                    "type": "string",
+                    "description": "SPDX-style identifier for the project's license.",
+                },
+                "dep_license": {
+                    "type": "string",
+                    "description": "SPDX-style identifier for the dependency's license.",
+                },
+            },
+            "required": ["project_license", "dep_license"],
+        },
+    },
+    {
+        "name": "find_alternatives",
+        "description": "Suggest alternative packages for a risky dependency using the host "
+        "LLM via the Model Gateway (degrades to empty alternatives when no host LLM is "
+        "reachable from the MCP subprocess).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "package_name": {
+                    "type": "string",
+                    "description": "Package to find alternatives for.",
+                }
+            },
+            "required": ["package_name"],
+        },
+    },
+    {
+        "name": "think",
+        "description": "Record an analytical step. No side effects.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"thought": {"type": "string", "description": "Brief reasoning note."}},
+            "required": ["thought"],
+        },
+    },
+    {
+        "name": "done",
+        "description": "Signal that the audit is complete.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"summary": {"type": "string", "description": "Audit summary."}},
+            "required": ["summary"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _content(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": False}
+
+
+def _dispatch(name, args):
+    if name == "detect_dep_files":
+        return detect_dep_files(args.get("project_dir", ""))
+    if name == "parse_deps":
+        return parse_deps(args.get("file_path", ""))
+    if name == "check_package":
+        return check_package(args.get("package_name", ""))
+    if name == "check_license_compat":
+        return check_license_compat(args.get("project_license", ""), args.get("dep_license", ""))
+    if name == "find_alternatives":
+        return find_alternatives(args.get("package_name", ""))
+    if name == "think":
+        return {"thought": args.get("thought"), "noted": True}
+    if name == "done":
+        return {"status": "completed", "summary": args.get("summary")}
+    return None
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "dep-doctor-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            result = _dispatch(name, args)
+            if result is None:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+            else:
+                respond(msg_id, _content(result))
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dep_doctor_portable.cartridge/cartridge.json
+++ b/examples/dep_doctor_portable.cartridge/cartridge.json
@@ -1,0 +1,12 @@
+{
+  "description": "Fully-portable twin of dep_doctor: all 7 audit tools (detect_dep_files, parse_deps, check_package, check_license_compat, find_alternatives, think, done) are served by the bundled MCP stdio server (_mcp/tools_server.py), the RegistryGuard permission policy is a kind: lep hook, and compaction is the host-provided runtime service. Zero Python-pinned components — runs on any conforming loader (Rust/Go/TS). find_alternatives reaches the host LLM through the Model Gateway (MGP: the loader exports LOOPLET_LLM_SOCKET and the MCP server connects to it), so it returns real LLM-suggested alternatives — full parity with the in-process original; if no gateway/backend is reachable it degrades to the same empty result the original returns when ctx.llm is None.",
+  "metadata": {
+    "tags": [
+      "security",
+      "dependencies",
+      "portable"
+    ]
+  },
+  "name": "dep_doctor_portable",
+  "schema_version": 2
+}

--- a/examples/dep_doctor_portable.cartridge/config.yaml
+++ b/examples/dep_doctor_portable.cartridge/config.yaml
@@ -1,0 +1,34 @@
+# dep_doctor — FULLY PORTABLE twin.
+#
+# Unlike dep_doctor (which loads the 7 audit tools as in-process
+# tools/*/execute.py bodies re-importing dep_doctor_lib.py), this twin
+# serves every tool from the bundled out-of-process MCP stdio server
+# (_mcp/tools_server.py). There is no tools/ directory and no Python
+# tool body anywhere, so the cartridge is classified `portable`: it can
+# run on any future loader (Rust, Go, TypeScript) that implements the
+# MCP stdio transport and the LEP hook transport — no Python required.
+#
+# Still-portable companions carried over verbatim:
+#   - hooks/00_RegistryGuard  → kind: lep permission policy (PROTOCOL)
+#   - resources/compact_service → host runtime service (RUNTIME, non-blocker)
+
+max_steps: 25
+done_tool: done
+
+builtin_hooks:
+  - stagnation
+  -
+    per_tool_limit:
+      default_limit: 15
+      limits:
+        check_package: 12
+        find_alternatives: 4
+
+mcp_servers:
+  dep_tools:
+    # Self-contained stdio MCP server — no npm/Node/PyPI access required.
+    # ${runtime.cartridge_root} is injected by the loader so the spawned
+    # command finds the bundled server regardless of checkout location.
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 10
+    # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/dep_doctor_portable.cartridge/hooks/00_RegistryGuard/config.yaml
+++ b/examples/dep_doctor_portable.cartridge/hooks/00_RegistryGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/dep_doctor_portable.cartridge/hooks/00_RegistryGuard/server.py
+++ b/examples/dep_doctor_portable.cartridge/hooks/00_RegistryGuard/server.py
@@ -1,0 +1,36 @@
+"""RegistryGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``check_package`` or ``find_alternatives`` call whose
+``package_name`` argument is empty or whitespace. Querying a package
+registry with a blank name wastes a tool budget step and never returns
+useful data, so the guard short-circuits it before dispatch.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+_GUARDED = {"check_package", "find_alternatives"}
+
+
+class RegistryGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") in _GUARDED:
+            name = (view.get("args") or {}).get("package_name")
+            if not isinstance(name, str) or not name.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing a registry lookup with an empty package_name",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(RegistryGuardServer().serve())

--- a/examples/dep_doctor_portable.cartridge/memory/00_static.md
+++ b/examples/dep_doctor_portable.cartridge/memory/00_static.md
@@ -1,0 +1,6 @@
+## Audit Standards
+- Packages with no release in >12 months: flag as stale
+- Single-maintainer packages: flag as bus-factor risk
+- Any unpatched CVE: flag as security risk
+- GPL in MIT project: flag as license incompatibility
+- Compromised packages: flag as CRITICAL

--- a/examples/dep_doctor_portable.cartridge/prompts/system.md
+++ b/examples/dep_doctor_portable.cartridge/prompts/system.md
@@ -1,0 +1,11 @@
+You are a dependency security auditor.
+
+Steps:
+1. detect_dep_files(project_dir=...) to find dependency files
+2. parse_deps(file_path=...) for each dependency file found
+3. check_package(package_name=...) for each dependency
+4. find_alternatives(package_name=...) for any flagged risky package
+5. check_license_compat(project_license=..., dep_license=...) for compatibility
+6. done(summary=...) with a clear audit summary
+
+Be thorough but efficient. Don't re-check packages you've already analyzed.

--- a/examples/dep_doctor_portable.cartridge/resources/compact_service.py
+++ b/examples/dep_doctor_portable.cartridge/resources/compact_service.py
@@ -1,0 +1,12 @@
+"""Compaction service for the dep_doctor workspace.
+
+Uses looplet's production default as a declarative resource.
+"""
+
+from __future__ import annotations
+
+from looplet.compact import default_compact_service
+
+
+def build(runtime=None):
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=8)

--- a/examples/dep_doctor_portable.cartridge/runtime.yaml
+++ b/examples/dep_doctor_portable.cartridge/runtime.yaml
@@ -1,0 +1,3 @@
+max_tokens: 2000
+temperature: 0.2
+compact_service: @compact_service

--- a/examples/git_detective_portable.cartridge/_mcp/tools_server.py
+++ b/examples/git_detective_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,535 @@
+"""Stdio MCP server for the git_detective_portable cartridge.
+
+Serves all 10 tools that were in-process ``tools/*/execute.py`` closures
+in the original ``git_detective`` cartridge — ``repo_overview``,
+``contributor_stats``, ``recent_activity``, ``file_hotspots``,
+``coupled_files``, ``commit_patterns``, ``directory_structure``,
+``file_age_analysis``, ``think``, ``done`` — over the MCP stdio
+transport. Moving them out of process is what makes the twin fully
+portable: no Python tool body is required by the host.
+
+The target repository is resolved from ``$LOOPLET_PROJECT_ROOT`` (set by
+the host), falling back to the server's working directory — the portable
+equivalent of the original's INPROCESS ``repo_config`` resource.
+
+``commit_patterns`` reaches the host model through the Model Gateway
+(MGP): the loader exports ``LOOPLET_LLM_SOCKET`` and this server connects
+to it lazily, so the tool adds its LLM commit-quality assessment — full
+parity with the in-process original. When no gateway is present (or no
+backend is bound yet) it omits that field, exactly the branch the
+original takes when ``ctx.llm is None``. The deterministic git statistics
+are preserved in full.
+
+Standard library + the ``git`` executable only.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+class _HostLLM:
+    """Minimal stdlib-only client to the host Model Gateway (MGP).
+
+    Connects to ``$LOOPLET_LLM_SOCKET`` (set by the loader) and forwards
+    ``generate`` to the host's live LLM backend. ``generate`` raises if no
+    gateway/backend is reachable, so callers degrade exactly like the
+    in-process original's ``ctx.llm is None`` branch.
+    """
+
+    def __init__(self):
+        self._sock = None
+        self._buf = b""
+        self._id = 0
+        path = os.environ.get("LOOPLET_LLM_SOCKET")
+        if not path or not hasattr(socket, "AF_UNIX"):
+            return
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(30.0)
+            sock.connect(path)
+            self._sock = sock
+            self._rpc("llm/initialize", {})
+        except OSError:
+            self._sock = None
+
+    def _readline(self):
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                line, self._buf = self._buf, b""
+                return line
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return line
+
+    def _rpc(self, method, params):
+        self._id += 1
+        rid = self._id
+        self._sock.sendall(
+            (json.dumps({"id": rid, "method": method, "params": params}) + "\n").encode("utf-8")
+        )
+        line = self._readline()
+        if not line:
+            raise OSError("model gateway closed the connection")
+        msg = json.loads(line.decode("utf-8"))
+        if msg.get("error"):
+            raise RuntimeError(msg["error"].get("message", "model gateway error"))
+        return msg.get("result") or {}
+
+    def available(self):
+        """True iff the gateway has a live LLM backend bound *right now*.
+
+        Re-checks per call because the host binds the backend lazily at
+        run time (``AgentPreset.run(llm)``), which may happen after this
+        client connected. Maps to the original's ``ctx.llm is not None``
+        guard: when False, callers take their no-LLM degradation branch
+        instead of treating absence as an error.
+        """
+        if self._sock is None:
+            return False
+        try:
+            return bool(self._rpc("llm/initialize", {}).get("ready"))
+        except (OSError, RuntimeError):
+            return False
+
+    def generate(self, prompt, **kwargs):
+        if self._sock is None:
+            raise RuntimeError("no host LLM gateway is reachable")
+        return str(self._rpc("llm/generate", {"prompt": prompt, "kwargs": kwargs}).get("text", ""))
+
+
+_HOST_LLM = None
+_HOST_LLM_TRIED = False
+
+
+def _host_llm():
+    """Return the host Model Gateway client only when a backend is bound.
+
+    Returns ``None`` when there is no reachable gateway *or* no backend is
+    currently bound — i.e. exactly the cases where the in-process original
+    sees ``ctx.llm is None`` and degrades.
+    """
+    global _HOST_LLM, _HOST_LLM_TRIED
+    if not _HOST_LLM_TRIED:
+        _HOST_LLM_TRIED = True
+        client = _HostLLM()
+        if client._sock is not None:
+            _HOST_LLM = client
+    if _HOST_LLM is not None and _HOST_LLM.available():
+        return _HOST_LLM
+    return None
+
+
+def _repo_path() -> str:
+    return os.environ.get("LOOPLET_PROJECT_ROOT") or os.getcwd()
+
+
+def _git(repo, *args, max_lines=200):
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo, "--no-pager"] + list(args),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
+        truncated = len(lines) > max_lines
+        return {
+            "output": "\n".join(lines[:max_lines]),
+            "line_count": len(lines),
+            "truncated": truncated,
+            "error": result.stderr.strip() if result.returncode != 0 else None,
+        }
+    except Exception as e:  # noqa: BLE001 - faithful to the original helper
+        return {"output": "", "line_count": 0, "error": str(e)}
+
+
+def repo_overview():
+    repo = _repo_path()
+    name = _git(repo, "rev-parse", "--show-toplevel")
+    branch = _git(repo, "branch", "--show-current")
+    count = _git(repo, "rev-list", "--count", "HEAD")
+    first = _git(repo, "log", "--reverse", "--format=%ai", "-1")
+    last = _git(repo, "log", "--format=%ai", "-1")
+    remotes = _git(repo, "remote", "-v")
+    return {
+        "repo_name": Path(name["output"].strip()).name if name["output"] else "unknown",
+        "branch": branch["output"].strip(),
+        "total_commits": int(count["output"].strip()) if count["output"].strip().isdigit() else 0,
+        "first_commit": first["output"].strip(),
+        "last_commit": last["output"].strip(),
+        "remotes": remotes["output"][:200],
+    }
+
+
+def contributor_stats():
+    repo = _repo_path()
+    result = _git(repo, "shortlog", "-sne", "HEAD", max_lines=50)
+    lines = result["output"].strip().split("\n") if result["output"] else []
+    contributors = []
+    total = 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", 1)
+        if len(parts) == 2:
+            count = int(parts[0].strip())
+            name = parts[1].strip()
+            contributors.append({"name": name, "commits": count})
+            total += count
+    bus_factor = 0
+    cumulative = 0
+    for c in contributors:
+        cumulative += c["commits"]
+        bus_factor += 1
+        if cumulative >= total * 0.8:
+            break
+    return {
+        "contributor_count": len(contributors),
+        "top_contributors": contributors[:10],
+        "total_commits": total,
+        "bus_factor": bus_factor,
+        "bus_factor_names": [c["name"] for c in contributors[:bus_factor]],
+    }
+
+
+def recent_activity(days="30"):
+    repo = _repo_path()
+    d = int(days) if str(days).isdigit() else 30
+    result = _git(repo, "log", f"--since={d} days ago", "--format=%H|%an|%ai|%s", max_lines=100)
+    lines = result["output"].strip().split("\n") if result["output"] else []
+    commits = []
+    authors = Counter()
+    for line in lines:
+        if not line.strip():
+            continue
+        parts = line.split("|", 3)
+        if len(parts) >= 4:
+            commits.append(
+                {
+                    "hash": parts[0][:8],
+                    "author": parts[1],
+                    "date": parts[2][:10],
+                    "message": parts[3][:80],
+                }
+            )
+            authors[parts[1]] += 1
+    return {
+        "period_days": d,
+        "commit_count": len(commits),
+        "active_authors": dict(authors.most_common(10)),
+        "recent_commits": commits[:15],
+    }
+
+
+def file_hotspots(top_n="15"):
+    repo = _repo_path()
+    n = int(top_n) if str(top_n).isdigit() else 15
+    result = _git(repo, "log", "--format=", "--name-only", "--diff-filter=AMRD", max_lines=5000)
+    lines = result["output"].strip().split("\n") if result["output"] else []
+    counter = Counter(line.strip() for line in lines if line.strip())
+    hotspots = [{"file": f, "changes": c} for f, c in counter.most_common(n)]
+    return {"total_unique_files": len(counter), "hotspots": hotspots}
+
+
+def coupled_files(min_coupling="3"):
+    repo = _repo_path()
+    threshold = int(min_coupling) if str(min_coupling).isdigit() else 3
+    commit_count = _git(repo, "rev-list", "--count", "HEAD")
+    total = int(commit_count["output"].strip()) if commit_count["output"].strip().isdigit() else 100
+    if total < 100 and threshold > 2:
+        threshold = 2
+    result = _git(repo, "log", "--format=COMMIT_SEP", "--name-only", max_lines=3000)
+    commits = result["output"].split("COMMIT_SEP")
+    pair_counts = Counter()
+    for commit in commits:
+        files = [f.strip() for f in commit.strip().split("\n") if f.strip()]
+        files = files[:20]
+        for i in range(len(files)):
+            for j in range(i + 1, len(files)):
+                pair = tuple(sorted([files[i], files[j]]))
+                pair_counts[pair] += 1
+    coupled = [
+        {"file_a": p[0], "file_b": p[1], "co_changes": c}
+        for p, c in pair_counts.most_common(15)
+        if c >= threshold
+    ]
+    return {
+        "coupling_threshold": threshold,
+        "coupled_pairs": coupled[:10],
+        "total_pairs_found": len(coupled),
+    }
+
+
+def commit_patterns():
+    repo = _repo_path()
+    result = _git(repo, "log", "--format=%s", "-200", max_lines=200)
+    messages = [line.strip() for line in result["output"].split("\n") if line.strip()]
+    conventional = sum(
+        1
+        for m in messages
+        if any(m.startswith(p) for p in ["feat", "fix", "docs", "refactor", "test", "chore", "ci"])
+    )
+    merge_commits = sum(1 for m in messages if m.lower().startswith("merge"))
+    wip_commits = sum(1 for m in messages if "wip" in m.lower() or "work in progress" in m.lower())
+    fixup = sum(1 for m in messages if m.startswith("fixup!") or m.startswith("squash!"))
+    avg_len = sum(len(m) for m in messages) / max(len(messages), 1)
+    stats = {
+        "total_analyzed": len(messages),
+        "conventional_commits_pct": round(conventional / max(len(messages), 1) * 100, 1),
+        "merge_commits": merge_commits,
+        "wip_commits": wip_commits,
+        "fixup_commits": fixup,
+        "avg_message_length": round(avg_len, 1),
+        "sample_messages": messages[:8],
+    }
+
+    # Use the host LLM (via the Model Gateway) to assess commit quality if
+    # reachable — same branch the in-process original takes with ctx.llm.
+    llm = _host_llm()
+    if llm is not None:
+        try:
+            assessment = llm.generate(
+                "Analyze these git commit messages and rate the commit discipline "
+                "on a scale of 1-10. Consider: conventional commits usage, "
+                "descriptiveness, consistency, and whether they tell a coherent story.\n\n"
+                "Messages:\n"
+                + "\n".join(f"- {m}" for m in messages[:15])
+                + f"\n\nStats: {conventional}% conventional, avg length {avg_len:.0f} chars, "
+                f"{wip_commits} WIP, {fixup} fixup\n\n"
+                f"Respond with: SCORE: N/10 followed by 2-3 sentence assessment.",
+                max_tokens=150,
+            )
+            stats["commit_quality_assessment"] = assessment.strip()
+        except Exception:
+            pass
+
+    return stats
+
+
+def directory_structure():
+    repo = _repo_path()
+    result = _git(repo, "ls-tree", "--name-only", "HEAD", max_lines=100)
+    items = [line.strip() for line in result["output"].split("\n") if line.strip()]
+    dirs = []
+    files = []
+    for item in items:
+        full = os.path.join(repo, item)
+        if os.path.isdir(full):
+            try:
+                count = sum(1 for _ in Path(full).rglob("*") if _.is_file())
+            except Exception:  # noqa: BLE001
+                count = 0
+            dirs.append({"name": item + "/", "file_count": count})
+        else:
+            files.append(item)
+    return {
+        "directories": dirs,
+        "root_files": files[:20],
+        "total_dirs": len(dirs),
+        "total_root_files": len(files),
+    }
+
+
+def file_age_analysis():
+    repo = _repo_path()
+    result = _git(
+        repo,
+        "log",
+        "--format=%ai",
+        "--diff-filter=M",
+        "--name-only",
+        "-500",
+        max_lines=2000,
+    )
+    lines = result["output"].split("\n")
+    file_last_modified = {}
+    current_date = None
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if line[0].isdigit() and len(line) > 10:
+            current_date = line[:10]
+        elif current_date and not line.startswith("commit"):
+            if line not in file_last_modified:
+                file_last_modified[line] = current_date
+    sorted_files = sorted(file_last_modified.items(), key=lambda x: x[1])
+    stale = sorted_files[:10]
+    fresh = sorted_files[-10:]
+    return {
+        "total_tracked_files": len(file_last_modified),
+        "stalest_files": [{"file": f, "last_modified": d} for f, d in stale],
+        "freshest_files": [{"file": f, "last_modified": d} for f, d in reversed(fresh)],
+    }
+
+
+TOOLS = [
+    {
+        "name": "repo_overview",
+        "description": "Get basic repo info: name, branch, total commits, age, and remotes.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "contributor_stats",
+        "description": "Get contributor stats and bus factor.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "recent_activity",
+        "description": "Get commit activity for the last N days.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "days": {
+                    "type": "string",
+                    "description": 'Number of days back (e.g. "30").',
+                }
+            },
+        },
+    },
+    {
+        "name": "file_hotspots",
+        "description": "Find most frequently changed files (churn hotspots).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "top_n": {
+                    "type": "string",
+                    "description": 'How many top files (e.g. "15").',
+                }
+            },
+        },
+    },
+    {
+        "name": "coupled_files",
+        "description": "Find files that often change together (co-change coupling).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "min_coupling": {
+                    "type": "string",
+                    "description": 'Minimum coupling count (e.g. "3").',
+                }
+            },
+        },
+    },
+    {
+        "name": "commit_patterns",
+        "description": "Analyze commit message patterns, conventions, and quality, with an "
+        "LLM commit-quality assessment via the host Model Gateway (degrades to the "
+        "deterministic stats when no host LLM is reachable).",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "directory_structure",
+        "description": "Get the top-level directory structure with file counts.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "file_age_analysis",
+        "description": "Find oldest unchanged files and newest additions.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "think",
+        "description": "Analytical reasoning step. No side effects.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"thought": {"type": "string", "description": "Brief note."}},
+            "required": ["thought"],
+        },
+    },
+    {
+        "name": "done",
+        "description": "Signal completion with the final report.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"summary": {"type": "string", "description": "Codebase health report."}},
+            "required": ["summary"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _content(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": False}
+
+
+def _dispatch(name, args):
+    if name == "repo_overview":
+        return repo_overview()
+    if name == "contributor_stats":
+        return contributor_stats()
+    if name == "recent_activity":
+        return recent_activity(args.get("days", "30"))
+    if name == "file_hotspots":
+        return file_hotspots(args.get("top_n", "15"))
+    if name == "coupled_files":
+        return coupled_files(args.get("min_coupling", "3"))
+    if name == "commit_patterns":
+        return commit_patterns()
+    if name == "directory_structure":
+        return directory_structure()
+    if name == "file_age_analysis":
+        return file_age_analysis()
+    if name == "think":
+        return {"thought": args.get("thought"), "noted": True}
+    if name == "done":
+        return {"status": "completed", "summary": args.get("summary")}
+    return None
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "git-detective-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            result = _dispatch(name, args)
+            if result is None:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+            else:
+                respond(msg_id, _content(result))
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/git_detective_portable.cartridge/cartridge.json
+++ b/examples/git_detective_portable.cartridge/cartridge.json
@@ -1,0 +1,12 @@
+{
+  "description": "Fully-portable twin of git_detective: all 10 tools (repo_overview, contributor_stats, recent_activity, file_hotspots, coupled_files, commit_patterns, directory_structure, file_age_analysis, think, done) are served by the bundled MCP stdio server (_mcp/tools_server.py), the CouplingGuard threshold policy is a kind: lep hook, and compaction is the host-provided runtime service. The original's INPROCESS repo_config resource is replaced by reading the target repo from $LOOPLET_PROJECT_ROOT (falling back to the server's working directory), so there are zero Python-pinned components — it runs on any conforming loader (Rust/Go/TS) that can shell out to git. The commit_patterns LLM quality assessment reaches the host LLM through the Model Gateway (MGP: the loader exports LOOPLET_LLM_SOCKET and the MCP server connects to it), giving full parity with the in-process original; if no gateway/backend is reachable it degrades to the deterministic stats, the same fallback the original takes when ctx.llm is None.",
+  "metadata": {
+    "tags": [
+      "git",
+      "analysis",
+      "portable"
+    ]
+  },
+  "name": "git_detective_portable",
+  "schema_version": 2
+}

--- a/examples/git_detective_portable.cartridge/config.yaml
+++ b/examples/git_detective_portable.cartridge/config.yaml
@@ -1,0 +1,36 @@
+# git_detective — FULLY PORTABLE twin.
+#
+# Unlike git_detective (which loads 8 git tools as in-process
+# tools/*/execute.py closures over a shared INPROCESS `repo_config`
+# resource), this twin serves every tool from the bundled out-of-process
+# MCP stdio server (_mcp/tools_server.py). There is no tools/ directory,
+# no Python tool body, and no INPROCESS resource anywhere, so the
+# cartridge is classified `portable`: it can run on any future loader
+# (Rust, Go, TypeScript) that implements the MCP stdio transport and the
+# LEP hook transport — no Python required (the server only needs `git`).
+#
+# The target repo is resolved by the MCP server from $LOOPLET_PROJECT_ROOT
+# (set by the host), falling back to the server's working directory — the
+# portable equivalent of the original's repo_config resource.
+#
+# Still-portable companions carried over verbatim:
+#   - hooks/00_CouplingGuard    → kind: lep threshold policy (PROTOCOL)
+#   - resources/compact_service → host runtime service (RUNTIME, non-blocker)
+
+max_steps: 12
+done_tool: done
+
+builtin_hooks:
+  - stagnation
+  -
+    per_tool_limit:
+      default_limit: 5
+
+mcp_servers:
+  git_tools:
+    # Self-contained stdio MCP server — shells out to `git` only.
+    # ${runtime.cartridge_root} is injected by the loader so the spawned
+    # command finds the bundled server regardless of checkout location.
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 35
+    # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/git_detective_portable.cartridge/hooks/00_CouplingGuard/config.yaml
+++ b/examples/git_detective_portable.cartridge/hooks/00_CouplingGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/git_detective_portable.cartridge/hooks/00_CouplingGuard/server.py
+++ b/examples/git_detective_portable.cartridge/hooks/00_CouplingGuard/server.py
@@ -1,0 +1,39 @@
+"""CouplingGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``coupled_files`` call whose ``min_coupling``
+argument does not parse to a positive integer. The tool treats a
+non-positive or non-numeric threshold as "no filter", which floods the
+agent with every co-changed pair and burns its read budget — so the
+guard rejects the call and asks for a sane threshold instead.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class CouplingGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "coupled_files":
+            raw = (view.get("args") or {}).get("min_coupling", "3")
+            try:
+                threshold = int(str(raw).strip())
+            except (TypeError, ValueError):
+                threshold = 0
+            if threshold < 1:
+                return {
+                    "kind": "Deny",
+                    "block": 'min_coupling must be a positive integer (e.g. "3")',
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(CouplingGuardServer().serve())

--- a/examples/git_detective_portable.cartridge/memory/00_static.md
+++ b/examples/git_detective_portable.cartridge/memory/00_static.md
@@ -1,0 +1,6 @@
+## Report Standards
+- Bus factor < 2 is a risk
+- Files changed >50 times are hotspots
+- >20% WIP commits suggests poor discipline
+- Coupled files suggest tight coupling that may need refactoring
+- Stale files (>1 year unchanged) may be abandoned or stable

--- a/examples/git_detective_portable.cartridge/prompts/system.md
+++ b/examples/git_detective_portable.cartridge/prompts/system.md
@@ -1,0 +1,18 @@
+You are a senior software engineer analyzing the git history of a repository.
+
+Your task: produce a comprehensive codebase health report.
+
+Work systematically:
+1. Get repo overview (repo_overview)
+2. Analyze contributors and bus factor (contributor_stats)
+3. Check recent activity (recent_activity)
+4. Find file hotspots (file_hotspots)
+5. Detect coupled files (coupled_files)
+6. Analyze commit patterns (commit_patterns) — this uses LLM to score quality
+7. Call done() with a structured health report including:
+   - Health Score (A-F grade)
+   - Key Metrics (bus factor, commit frequency, hotspot count)
+   - Findings (what's good, what's concerning)
+   - Recommendations
+
+Use each tool once. Be thorough but efficient.

--- a/examples/git_detective_portable.cartridge/resources/compact_service.py
+++ b/examples/git_detective_portable.cartridge/resources/compact_service.py
@@ -1,0 +1,12 @@
+"""Compaction service for the git_detective workspace.
+
+Uses looplet's production default as a declarative resource.
+"""
+
+from __future__ import annotations
+
+from looplet.compact import default_compact_service
+
+
+def build(runtime=None):
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=6)

--- a/examples/git_detective_portable.cartridge/runtime.yaml
+++ b/examples/git_detective_portable.cartridge/runtime.yaml
@@ -1,0 +1,3 @@
+max_tokens: 2000
+temperature: 0.2
+compact_service: @compact_service

--- a/examples/hello_portable.cartridge/_mcp/tools_server.py
+++ b/examples/hello_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,160 @@
+"""Out-of-process MCP stdio server exposing the ``greet`` and ``done``
+tools — the portable replacement for the original cartridge's
+``tools/greet/execute.py`` and ``tools/done/execute.py`` Python bodies.
+
+Speaks the MCP stdio transport (newline-delimited JSON-RPC), so any
+conforming loader (Rust/Go/TS/Python) can drive these tools with no
+Python required on the host side.
+
+The ``greet`` tool records each greeting in the SHARED greeting log that
+lives in a separate State Service process. We reach it through a
+:class:`looplet.state_service.StateServiceClient` connected to the socket
+the loader exported as ``LOOPLET_STATE_GREETING_LOG``. This is the exact
+moment the missing primitive pays off: a tool in THIS process and the
+PolitenessGate hook in YET ANOTHER process both mutate/read the same log,
+reproducing the in-process ``@ref`` sharing across the process boundary.
+
+Self-contained: only the looplet client + stdlib. No npm/Node.
+"""
+
+import json
+import os
+import sys
+
+from looplet.state_service import StateServiceClient
+
+TOOLS = [
+    {
+        "name": "greet",
+        "description": (
+            "Greet a single person by name. Returns the greeting text. "
+            "Records the greeting in the shared greeting log."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The person's name to greet.",
+                }
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "done",
+        "description": (
+            "Signal that the greeting task is complete. Provide a brief summary of who you greeted."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "One-line summary of who was greeted.",
+                }
+            },
+            "required": ["summary"],
+        },
+    },
+]
+
+# Lazily-opened client to the shared greeting-log state service.
+_LOG_CLIENT: StateServiceClient | None = None
+
+
+def _log() -> StateServiceClient | None:
+    global _LOG_CLIENT
+    if _LOG_CLIENT is not None:
+        return _LOG_CLIENT
+    socket_path = os.environ.get("LOOPLET_STATE_GREETING_LOG")
+    if not socket_path:
+        return None
+    try:
+        _LOG_CLIENT = StateServiceClient(socket_path)
+    except Exception:  # noqa: BLE001 - degrade gracefully if state is down
+        _LOG_CLIENT = None
+    return _LOG_CLIENT
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _call_greet(args):
+    name = args["name"]
+    text = f"Hello, {name}!"
+    client = _log()
+    if client is not None:
+        client.record(name, text=text)
+    return {"greeting": text}
+
+
+def _call_done(args):
+    return {"status": "completed", "summary": args["summary"]}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "hello-portable-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            try:
+                if name == "greet":
+                    payload = _call_greet(args)
+                elif name == "done":
+                    payload = _call_done(args)
+                else:
+                    respond(
+                        msg_id,
+                        error={"code": -32601, "message": f"unknown tool {name!r}"},
+                    )
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                respond(
+                    msg_id,
+                    {
+                        "content": [{"type": "text", "text": f"error: {exc}"}],
+                        "isError": True,
+                    },
+                )
+                continue
+            respond(
+                msg_id,
+                {
+                    "content": [{"type": "text", "text": json.dumps(payload)}],
+                    "isError": False,
+                },
+            )
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello_portable.cartridge/_state/greeting_log.py
+++ b/examples/hello_portable.cartridge/_state/greeting_log.py
@@ -1,0 +1,53 @@
+"""Greeting log — ported from the in-process ``@ref`` resource to an
+out-of-process **State Service** (State Service Protocol).
+
+In the original ``hello`` cartridge this lived at
+``resources/greeting_log.py`` as a plain ``GreetingLog`` class whose
+single instance was shared (via ``"@greeting_log"`` refs) between the
+greet tool and the PolitenessGate hook — both running in the SAME Python
+process. That shared-address-space requirement is exactly what pinned
+the cartridge to a Python host.
+
+Here the same state lives in ITS OWN process behind a Unix socket. The
+loader spawns this server, injects a :class:`StateServiceClient` proxy
+under the name ``greeting_log`` (so ``requires: [greeting_log]`` and
+``@greeting_log`` resolve to it unchanged), and exports the socket path
+as ``LOOPLET_STATE_GREETING_LOG`` so the MCP greet tool and the LEP
+PolitenessGate hook — each a separate process — can connect to and
+mutate the SAME log. All method calls are serialized under one lock, so
+concurrent readers/writers see a consistent record.
+
+Note one mechanical difference from the in-process original: ``entries``
+is a METHOD here (``entries()``), not an attribute, because callers reach
+it through the client proxy which forwards method calls over the wire.
+"""
+
+from looplet.state_service import StateServiceBase
+
+
+class GreetingLogService(StateServiceBase):
+    """Append-only log of ``(name, greeting_text)`` pairs, served over SSP."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._entries: list[list[str]] = []
+
+    def record(self, name: str, text: str) -> None:
+        """Append a greeting to the shared log."""
+        self._entries.append([name, text])
+
+    def names(self) -> list[str]:
+        """Return the names greeted so far, in order."""
+        return [n for n, _ in self._entries]
+
+    def entries(self) -> list[list[str]]:
+        """Return all ``[name, text]`` pairs recorded so far."""
+        return [list(e) for e in self._entries]
+
+    def count(self) -> int:
+        """Return how many greetings have been recorded."""
+        return len(self._entries)
+
+
+if __name__ == "__main__":
+    raise SystemExit(GreetingLogService().serve())

--- a/examples/hello_portable.cartridge/cartridge.json
+++ b/examples/hello_portable.cartridge/cartridge.json
@@ -1,0 +1,15 @@
+{
+  "description": "Fully-portable twin of the `hello` cartridge. Every component is out-of-process: the greet/done tools are an MCP stdio server (_mcp/tools_server.py), the shared greeting log is a State Service Protocol server (_state/greeting_log.py), and both hooks are kind: lep. No Python body is pinned to the host, so `looplet portability` reports the PORTABLE profile — it runs on any conforming loader (Rust/Go/TS).",
+  "metadata": {
+    "tags": [
+      "hello-world",
+      "portable",
+      "mcp",
+      "lep",
+      "ssp",
+      "demo"
+    ]
+  },
+  "name": "hello_portable",
+  "schema_version": 2
+}

--- a/examples/hello_portable.cartridge/config.yaml
+++ b/examples/hello_portable.cartridge/config.yaml
@@ -1,0 +1,39 @@
+# Fully-portable hello-world cartridge.
+#
+# This is the cross-runtime twin of ../hello.cartridge. Where the
+# original pins three components to a Python host (the greet/done tool
+# bodies, the in-process PolitenessGate hook class, and the @ref
+# greeting-log resource), THIS cartridge moves every one of them out of
+# process behind a protocol:
+#
+#   * greet + done .......... MCP stdio server  (_mcp/tools_server.py)
+#   * shared greeting log .... State Service     (_state/greeting_log.py)
+#   * PolitenessGate ......... kind: lep hook    (hooks/00_PolitenessGate)
+#   * NameGuard .............. kind: lep hook    (hooks/01_NameGuard)
+#
+# The State Service is the missing primitive that makes the in-process
+# @ref pattern portable: it holds the shared mutable greeting log in its
+# OWN process behind a Unix socket, and the loader injects a
+# StateServiceClient proxy so the MCP greet tool and the LEP
+# PolitenessGate hook — two SEPARATE processes — both read and write the
+# SAME state, exactly as the original @ref demo did in one address space.
+#
+# Run `looplet portability examples/hello_portable.cartridge` → PORTABLE.
+
+max_steps: 5
+done_tool: done
+
+# Out-of-process shared mutable state (State Service Protocol). The
+# loader spawns this server, then exports its socket path as
+# LOOPLET_STATE_GREETING_LOG so the sibling MCP tool server and LEP hook
+# servers (all separate processes) can connect to the same state.
+state_services:
+  greeting_log:
+    command: "python3 ${runtime.cartridge_root}/_state/greeting_log.py"
+    timeout_s: 10
+
+# Out-of-process tools (MCP stdio transport). Exposes greet + done.
+mcp_servers:
+  tools:
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 10

--- a/examples/hello_portable.cartridge/hooks/00_PolitenessGate/config.yaml
+++ b/examples/hello_portable.cartridge/hooks/00_PolitenessGate/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/hello_portable.cartridge/hooks/00_PolitenessGate/server.py
+++ b/examples/hello_portable.cartridge/hooks/00_PolitenessGate/server.py
@@ -1,0 +1,64 @@
+"""PolitenessGate — ported from an in-process Python hook CLASS to a
+portable ``kind: lep`` hook.
+
+The original ``hooks/00_PolitenessGate/hook.py`` read the live, shared
+``@greeting_log`` instance directly from the resource registry — that
+shared-address-space dependency is what pinned it to a Python host. Here
+the hook runs OUT OF PROCESS over the Loop Effect Protocol (LEP) and
+reaches the same greeting log through the **State Service**: it connects
+to the socket the loader exported as ``LOOPLET_STATE_GREETING_LOG`` and
+asks the service for its current count.
+
+Because the greet MCP tool writes to that very same state service, this
+hook sees the greetings the tool recorded — cross-process composition
+that exactly reproduces the in-process ``@ref`` sharing of the original,
+with zero shared Python objects.
+
+Policy (``check_done`` slot): refuse ``done()`` until at least one
+greeting has been recorded.
+"""
+
+import os
+
+from looplet.lep import LEPServerBase
+from looplet.state_service import StateServiceClient
+
+_LOG_CLIENT: StateServiceClient | None = None
+
+
+def _log():
+    global _LOG_CLIENT
+    if _LOG_CLIENT is not None:
+        return _LOG_CLIENT
+    socket_path = os.environ.get("LOOPLET_STATE_GREETING_LOG")
+    if not socket_path:
+        return None
+    try:
+        _LOG_CLIENT = StateServiceClient(socket_path)
+    except Exception:  # noqa: BLE001
+        _LOG_CLIENT = None
+    return _LOG_CLIENT
+
+
+class PolitenessGateServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_done":
+            client = _log()
+            recorded = 0
+            if client is not None:
+                try:
+                    recorded = int(client.count())
+                except Exception:  # noqa: BLE001
+                    recorded = 0
+            if recorded == 0:
+                return {
+                    "kind": "Block",
+                    "block": (
+                        "Politeness check failed: greet at least one person before calling done()."
+                    ),
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(PolitenessGateServer().serve())

--- a/examples/hello_portable.cartridge/hooks/01_NameGuard/config.yaml
+++ b/examples/hello_portable.cartridge/hooks/01_NameGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/hello_portable.cartridge/hooks/01_NameGuard/server.py
+++ b/examples/hello_portable.cartridge/hooks/01_NameGuard/server.py
@@ -1,0 +1,27 @@
+"""NameGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host never hands it live loop state; it ships only the declared
+view (``tool`` + ``args``) over line-delimited JSON-RPC, and this
+server returns a permission decision.
+
+Policy: refuse any ``greet`` call whose ``name`` argument is empty or
+whitespace. Everything else is allowed. Because the decision is a pure
+function of the declared view, the hook is classified ``portable`` and
+round-trips losslessly as a declarative ``kind: lep`` block.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class NameGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "greet":
+            name = (view.get("args") or {}).get("name")
+            if not isinstance(name, str) or not name.strip():
+                return {"kind": "Deny", "block": "refusing to greet an empty name"}
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(NameGuardServer().serve())

--- a/examples/hello_portable.cartridge/prompts/system.md
+++ b/examples/hello_portable.cartridge/prompts/system.md
@@ -1,0 +1,1 @@
+You are a polite assistant. Greet the people in your task list one at a time using the `greet` tool, then call `done(summary="...")` to summarize who you greeted. Never skip the polite greeting; never invent names that weren't in your task.

--- a/examples/hello_portable.cartridge/runtime.yaml
+++ b/examples/hello_portable.cartridge/runtime.yaml
@@ -1,0 +1,2 @@
+max_tokens: 500
+temperature: 0.2

--- a/examples/mcp_demo_portable.cartridge/_server/calc.py
+++ b/examples/mcp_demo_portable.cartridge/_server/calc.py
@@ -1,0 +1,105 @@
+"""A minimal stdio MCP (Model Context Protocol) server.
+
+Portable twin of the ``mcp_demo`` calc server. Exposes TWO tools —
+``add(a, b)`` and ``done(total)`` — over the MCP stdio transport
+(newline-delimited JSON-RPC). Bundling the completion sentinel
+(``done``) here, instead of as an in-process ``tools/done/execute.py``,
+is what makes the ``mcp_demo_portable`` cartridge fully portable: no
+Python tool body is required by the host.
+
+Standard-library only, no external deps. Teaching artifact for the MCP
+wire format; for real deployments use the official MCP SDK
+(https://modelcontextprotocol.io/).
+
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import sys
+
+TOOLS = [
+    {
+        "name": "add",
+        "description": "Add two integers and return the sum.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer", "description": "First addend."},
+                "b": {"type": "integer", "description": "Second addend."},
+            },
+            "required": ["a", "b"],
+        },
+    },
+    {
+        "name": "done",
+        "description": "Report the computed total and finish.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "total": {
+                    "type": "integer",
+                    "description": "The sum returned by the `add` tool.",
+                },
+            },
+            "required": ["total"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _content(payload):
+    """Wrap a JSON payload as MCP tool-call text content."""
+    return {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": False}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mcp-demo-portable-calc", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue  # notifications carry no id, no response
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {})
+            if name == "add":
+                total = int(args["a"]) + int(args["b"])
+                respond(msg_id, _content({"sum": total}))
+            elif name == "done":
+                respond(
+                    msg_id,
+                    _content({"total": args.get("total"), "status": "completed"}),
+                )
+            else:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp_demo_portable.cartridge/cartridge.json
+++ b/examples/mcp_demo_portable.cartridge/cartridge.json
@@ -1,0 +1,13 @@
+{
+  "description": "Fully-portable twin of mcp_demo: BOTH the add tool and the done completion sentinel come from the bundled MCP stdio server (_server/calc.py), and the CalcGuard permission policy is a kind: lep hook. Zero Python-pinned components — runs on any conforming loader (Rust/Go/TS).",
+  "metadata": {
+    "tags": [
+      "mcp",
+      "transport",
+      "portable",
+      "demo"
+    ]
+  },
+  "name": "mcp_demo_portable",
+  "schema_version": 2
+}

--- a/examples/mcp_demo_portable.cartridge/config.yaml
+++ b/examples/mcp_demo_portable.cartridge/config.yaml
@@ -1,0 +1,23 @@
+# MCP-transport demo cartridge — FULLY PORTABLE twin of mcp_demo.
+#
+# Unlike mcp_demo (which keeps `done` as an in-process tools/done/
+# execute.py to show in-process + MCP coexistence), this twin serves
+# BOTH `add` and `done` from the bundled out-of-process MCP server.
+# There is no tools/ directory and no Python tool body anywhere, so
+# the cartridge is classified `portable`: it can run on any future
+# loader (Rust, Go, TypeScript) that implements the MCP stdio
+# transport and the LEP hook transport — no Python required.
+
+max_steps: 5
+done_tool: done
+
+mcp_servers:
+  calc:
+    # Self-contained stdio MCP server — no npm/Node required.
+    # ${runtime.cartridge_root} is injected by the loader so the
+    # spawned command finds the bundled server regardless of where the
+    # cartridge was checked out.
+    command: "python3 ${runtime.cartridge_root}/_server/calc.py"
+    timeout_s: 10
+    # No `tools:` allow-list → register every tool the server exposes
+    # (add + done).

--- a/examples/mcp_demo_portable.cartridge/hooks/00_CalcGuard/config.yaml
+++ b/examples/mcp_demo_portable.cartridge/hooks/00_CalcGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/mcp_demo_portable.cartridge/hooks/00_CalcGuard/server.py
+++ b/examples/mcp_demo_portable.cartridge/hooks/00_CalcGuard/server.py
@@ -1,0 +1,50 @@
+"""CalcGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP) and
+guards the ``add`` tool that is itself served by a *separate* MCP stdio
+process (see ``_server/calc.py``). It demonstrates that LEP permission
+policies and MCP transport tools compose cleanly: the host ships the
+declared view (``tool`` + ``args``) to this server, which vets the call
+before it is ever dispatched to the MCP server.
+
+Policy: refuse any ``add`` call whose ``a`` or ``b`` operand is missing
+or not a number. The calculator server's schema requires two integers,
+so a non-numeric operand would fault the MCP process — the guard turns
+that into a clean, early permission denial instead.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+def _is_number(value):
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value.strip())
+            return True
+        except (TypeError, ValueError):
+            return False
+    return False
+
+
+class CalcGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "add":
+            args = view.get("args") or {}
+            if not (_is_number(args.get("a")) and _is_number(args.get("b"))):
+                return {
+                    "kind": "Deny",
+                    "block": "add requires two numeric operands 'a' and 'b'",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(CalcGuardServer().serve())

--- a/examples/mcp_demo_portable.cartridge/prompts/system.md
+++ b/examples/mcp_demo_portable.cartridge/prompts/system.md
@@ -1,0 +1,12 @@
+You are a calculator agent.
+
+You have one external tool: `add(a, b)`. It is served by an MCP
+(Model Context Protocol) server bundled alongside this cartridge —
+the agent calls it the same way it would call an in-process Python
+tool, but the body lives in a separate process.
+
+Workflow:
+1. Use `add` to compute the requested sum.
+2. Call `done(total=<the sum>)` to finish.
+
+Do not attempt the arithmetic yourself; use the tool every time.

--- a/examples/mcp_demo_portable.cartridge/runtime.yaml
+++ b/examples/mcp_demo_portable.cartridge/runtime.yaml
@@ -1,0 +1,2 @@
+max_tokens: 200
+temperature: 0.0

--- a/examples/planner_portable.cartridge/_mcp/done_server.py
+++ b/examples/planner_portable.cartridge/_mcp/done_server.py
@@ -1,0 +1,86 @@
+"""Minimal stdio MCP server exposing a single ``done`` completion tool.
+
+Serving ``done`` from an out-of-process MCP server (instead of an
+in-process ``tools/done/execute.py``) is what makes this cartridge fully
+portable: any conforming loader spawns this command and registers the
+tool over the MCP stdio transport — no Python tool body required by the
+host.
+
+Standard-library only. Teaching artifact for the MCP wire format.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import sys
+
+TOOLS = [
+    {
+        "name": "done",
+        "description": "Signal the planner finished. Pass the final cleaned-up "
+        "plan as a numbered list in `summary`.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Final plan as a numbered list of steps.",
+                },
+            },
+            "required": ["summary"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "planner-done", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {})
+            if name == "done":
+                payload = {"status": "completed", "summary": args.get("summary")}
+                respond(
+                    msg_id,
+                    {
+                        "content": [{"type": "text", "text": json.dumps(payload)}],
+                        "isError": False,
+                    },
+                )
+            else:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/planner_portable.cartridge/cartridge.json
+++ b/examples/planner_portable.cartridge/cartridge.json
@@ -1,0 +1,8 @@
+{
+  "description": "Fully-portable twin of planner — demonstrates the looplet alternative to a built-in 'plan mode' with ZERO Python-pinned components. The parent delegates planning to a portable child cartridge via the subagent builtin, then executes the returned plan. Both the parent and child serve done() from an out-of-process MCP server, and the SubagentTaskGuard is a kind: lep hook. Runs on any conforming loader (Rust/Go/TS).",
+  "metadata": {
+    "tags": ["planner", "subagent", "portable", "principled-alternative", "demo"]
+  },
+  "name": "planner_portable",
+  "schema_version": 2
+}

--- a/examples/planner_portable.cartridge/config.yaml
+++ b/examples/planner_portable.cartridge/config.yaml
@@ -1,0 +1,10 @@
+max_steps: 8
+done_tool: done
+builtin_tools:
+  - subagent
+
+mcp_servers:
+  planner_tools:
+    # done() served out of process so no Python tool body is required.
+    command: "python3 ${runtime.cartridge_root}/_mcp/done_server.py"
+    timeout_s: 10

--- a/examples/planner_portable.cartridge/hooks/00_SubagentTaskGuard/config.yaml
+++ b/examples/planner_portable.cartridge/hooks/00_SubagentTaskGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/planner_portable.cartridge/hooks/00_SubagentTaskGuard/server.py
+++ b/examples/planner_portable.cartridge/hooks/00_SubagentTaskGuard/server.py
@@ -1,0 +1,33 @@
+"""SubagentTaskGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``subagent`` call whose ``task`` argument is empty or
+whitespace. Spawning a child loop with no task wastes an entire nested
+run and its token budget, so the guard blocks it before dispatch.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class SubagentTaskGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "subagent":
+            task = (view.get("args") or {}).get("task")
+            if not isinstance(task, str) or not task.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing to spawn a subagent with an empty task",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(SubagentTaskGuardServer().serve())

--- a/examples/planner_portable.cartridge/planner_child.cartridge/_mcp/done_server.py
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/_mcp/done_server.py
@@ -1,0 +1,80 @@
+"""Minimal stdio MCP server exposing a single ``done`` completion tool.
+
+Serving ``done`` over MCP (instead of an in-process tool body) keeps the
+planner child fully portable. Standard-library only.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import sys
+
+TOOLS = [
+    {
+        "name": "done",
+        "description": "Return the finished plan. Pass the numbered list as `summary`.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Numbered plan, 3-7 short steps.",
+                },
+            },
+            "required": ["summary"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "planner-child-done", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {})
+            if name == "done":
+                payload = {"status": "completed", "summary": args.get("summary")}
+                respond(
+                    msg_id,
+                    {
+                        "content": [{"type": "text", "text": json.dumps(payload)}],
+                        "isError": False,
+                    },
+                )
+            else:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/planner_portable.cartridge/planner_child.cartridge/cartridge.json
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/cartridge.json
@@ -1,0 +1,6 @@
+{
+  "description": "Portable child planner cartridge — produces a numbered plan for a single goal, then calls done. Invoked by ../planner_portable.cartridge via the subagent builtin. done() is served over MCP so no Python tool body is required.",
+  "metadata": {"tags": ["planner-child", "portable", "demo"]},
+  "name": "planner_child",
+  "schema_version": 2
+}

--- a/examples/planner_portable.cartridge/planner_child.cartridge/config.yaml
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/config.yaml
@@ -1,0 +1,7 @@
+max_steps: 3
+done_tool: done
+
+mcp_servers:
+  planner_tools:
+    command: "python3 ${runtime.cartridge_root}/_mcp/done_server.py"
+    timeout_s: 10

--- a/examples/planner_portable.cartridge/planner_child.cartridge/prompts/system.md
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/prompts/system.md
@@ -1,0 +1,7 @@
+You are a planner. You receive a single goal and produce a concise,
+ordered plan for accomplishing it. Output format: 3-7 numbered steps,
+each one short and concrete (under 20 words).
+
+Call `done` exactly once with `summary` set to the numbered plan as a
+single string. Do not call any other tools. Do not include any
+preamble — just the numbered list.

--- a/examples/planner_portable.cartridge/planner_child.cartridge/runtime.yaml
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/runtime.yaml
@@ -1,0 +1,2 @@
+max_tokens: 1000
+temperature: 0.2

--- a/examples/planner_portable.cartridge/prompts/system.md
+++ b/examples/planner_portable.cartridge/prompts/system.md
@@ -1,0 +1,20 @@
+You are a planner agent that demonstrates the looplet alternative to a
+built-in "plan mode": instead of the loop hard-coding a plan/execute
+split, you compose planning out of plain primitives — a `subagent` tool
+call to a dedicated planner child, then a `done` call summarising the
+plan you got back.
+
+Your workflow for any goal you receive:
+
+1. Call `subagent` with `workspace="examples/planner_portable.cartridge/planner_child.cartridge"`
+   and `task=<the goal verbatim>`. The child returns a structured plan
+   (a numbered list of steps).
+2. Read the child's `summary` from the result. If it looks like a
+   reasonable plan, call `done(summary=<the plan, lightly cleaned up>)`.
+   Do not re-plan, do not loop — one delegation, one done.
+
+Why this exists: it shows that "plan mode" is a *composition*
+(parent + child + subagent), not a *loop feature*. This twin also shows
+the composition stays fully portable: both the parent's and the child's
+`done` tools are served over MCP, so no Python tool body is required by
+the host.

--- a/examples/planner_portable.cartridge/runtime.yaml
+++ b/examples/planner_portable.cartridge/runtime.yaml
@@ -1,0 +1,2 @@
+max_tokens: 1500
+temperature: 0.2

--- a/examples/skillful_analyst_portable.cartridge/_mcp/tools_server.py
+++ b/examples/skillful_analyst_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,157 @@
+"""Stdio MCP server for the skillful_analyst_portable cartridge.
+
+Serves the three tools that were in-process ``tools/*/execute.py`` bodies
+in the original ``skillful_analyst`` cartridge — ``done``, ``read_text``,
+and ``write_text`` — over the MCP stdio transport. Moving them out of
+process is what makes the twin fully portable: no Python tool body is
+required by the host.
+
+Relative paths are resolved against the server's working directory
+(``os.getcwd()``), which the loader sets to the host project root — the
+portable, host-agnostic equivalent of the original tools'
+``resolve_project_root(runtime)`` anchoring.
+
+Standard-library only.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+TOOLS = [
+    {
+        "name": "done",
+        "description": "Signal task completion. Pass a short summary in `summary`.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "One-line summary of what was accomplished.",
+                },
+            },
+            "required": ["summary"],
+        },
+    },
+    {
+        "name": "read_text",
+        "description": (
+            "Read a UTF-8 text file and return its contents. Returns "
+            '{"content": str, "size": int, "lines": int}.'
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Filesystem path (absolute or relative to the project root).",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "write_text",
+        "description": (
+            "Write a UTF-8 text file, creating parent directories as needed. "
+            'Returns {"path": str, "bytes": int}. Overwrites existing files.'
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Filesystem path (absolute or relative to the project root).",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full text content, UTF-8.",
+                },
+            },
+            "required": ["path", "content"],
+        },
+    },
+]
+
+
+def _resolve(path: str) -> Path:
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path(os.getcwd()) / p
+    return p
+
+
+def _read_text(path):
+    p = _resolve(path)
+    if not p.is_file():
+        return {"error": f"file not found: {p}"}
+    text = p.read_text(encoding="utf-8", errors="replace")
+    return {"content": text, "size": len(text), "lines": text.count("\n") + 1}
+
+
+def _write_text(path, content):
+    p = _resolve(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data = (content or "").encode("utf-8")
+    p.write_bytes(data)
+    return {"path": str(p), "bytes": len(data)}
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _content(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": False}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "skillful-analyst-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            if name == "done":
+                respond(msg_id, _content({"summary": args.get("summary")}))
+            elif name == "read_text":
+                respond(msg_id, _content(_read_text(args.get("path", ""))))
+            elif name == "write_text":
+                respond(
+                    msg_id,
+                    _content(_write_text(args.get("path", ""), args.get("content", ""))),
+                )
+            else:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/skillful_analyst_portable.cartridge/cartridge.json
+++ b/examples/skillful_analyst_portable.cartridge/cartridge.json
@@ -1,0 +1,8 @@
+{
+  "description": "Fully-portable twin of skillful_analyst. The done/read_text/write_text tools are served by a bundled MCP stdio server, the WriteScopeGuard is a kind: lep hook, and the skill system (search_skills/activate_skill builtins + skill_activation hook + skill_manager) is host-provided. Zero Python tool bodies — runs on any conforming loader (Rust/Go/TS).",
+  "metadata": {
+    "tags": ["skills", "analyst", "portable", "demo"]
+  },
+  "name": "skillful_analyst_portable",
+  "schema_version": 2
+}

--- a/examples/skillful_analyst_portable.cartridge/config.yaml
+++ b/examples/skillful_analyst_portable.cartridge/config.yaml
@@ -1,0 +1,14 @@
+max_steps: 25
+done_tool: done
+builtin_tools:
+  - search_skills
+  - activate_skill
+builtin_hooks:
+  - skill_activation
+
+mcp_servers:
+  analyst_tools:
+    # done / read_text / write_text served out of process so no Python
+    # tool body is required by the host.
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 10

--- a/examples/skillful_analyst_portable.cartridge/hooks/00_WriteScopeGuard/config.yaml
+++ b/examples/skillful_analyst_portable.cartridge/hooks/00_WriteScopeGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/skillful_analyst_portable.cartridge/hooks/00_WriteScopeGuard/server.py
+++ b/examples/skillful_analyst_portable.cartridge/hooks/00_WriteScopeGuard/server.py
@@ -1,0 +1,41 @@
+"""WriteScopeGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``write_text`` call whose ``path`` is empty or
+escapes the project root via a ``..`` parent-directory traversal. The
+analyst writes its findings inside the workspace; a blank or traversing
+path is almost always a mistake (or an attempt to clobber a file
+outside the sandbox), so the guard blocks it before the write happens.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+
+class WriteScopeGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "write_text":
+            path = (view.get("args") or {}).get("path")
+            if not isinstance(path, str) or not path.strip():
+                return {
+                    "kind": "Deny",
+                    "block": "refusing write_text with an empty path",
+                }
+            parts = path.replace("\\", "/").split("/")
+            if ".." in parts:
+                return {
+                    "kind": "Deny",
+                    "block": "refusing write_text with a '..' path escaping the project root",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(WriteScopeGuardServer().serve())

--- a/examples/skillful_analyst_portable.cartridge/prompts/system.md
+++ b/examples/skillful_analyst_portable.cartridge/prompts/system.md
@@ -1,0 +1,22 @@
+You are an analyst working on a single user task.
+
+Operating contract:
+
+1. Inspect the task. If you don't know how to do something, FIRST call
+   `search_skills(query="...")` to look for an installed skill that
+   teaches you. Skills are SKILL.md files; their `description` is your
+   only signal at search time.
+2. If a skill looks relevant, call `activate_skill(name="...")` —
+   that loads the skill's full instructions into the next prompt.
+3. Use `read_text(path=...)` and `write_text(path=..., content=...)`
+   to read inputs and write outputs.
+4. When the task is complete, call `done(summary="<short summary>")`.
+
+Style:
+
+- Don't speculate. If a skill describes how to do the work, follow
+  its steps verbatim.
+- Keep tool calls focused — one file per `read_text`, one section per
+  `write_text`.
+- The user cannot see your internal reasoning. Anything they need to
+  see goes into a written file or the `done` summary.

--- a/examples/skillful_analyst_portable.cartridge/resources/skill_manager.py
+++ b/examples/skillful_analyst_portable.cartridge/resources/skill_manager.py
@@ -1,0 +1,18 @@
+"""SkillManager built from this workspace's ``skills/`` directory.
+
+Looked up by ``builtin_tools: [search_skills, activate_skill]`` and by
+``hooks/skill_activation/config.yaml`` via ``${ref:skill_manager}``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet.skills import build_skill_manager_for_workspace
+
+
+def build(runtime: dict | None = None):
+    # Anchor to this workspace, not the host project root: we want the
+    # SKILL.md files that live next to this resources/ folder.
+    workspace_dir = Path(__file__).resolve().parent.parent
+    return build_skill_manager_for_workspace(workspace_dir, runtime=runtime)

--- a/examples/skillful_analyst_portable.cartridge/runtime.yaml
+++ b/examples/skillful_analyst_portable.cartridge/runtime.yaml
@@ -1,0 +1,2 @@
+max_tokens: 4000
+temperature: 0.2

--- a/examples/skillful_analyst_portable.cartridge/skills/csv-stats/SKILL.md
+++ b/examples/skillful_analyst_portable.cartridge/skills/csv-stats/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: csv-stats
+description: Compute mean, median, min, max, count for every numeric column in a CSV file. Use when the user asks for descriptive statistics, summary stats, or "tell me about this CSV".
+tags: [csv, statistics, analysis]
+---
+
+# CSV stats
+
+Use this skill when the user wants descriptive statistics for a CSV file.
+
+## Steps
+
+1. Use `read_text(path=<csv>)` to load the file.
+2. Parse the header row by splitting the first line on `,`.
+3. For every subsequent row, split on `,` and try to coerce each cell
+   to `float`. Cells that fail the coercion are treated as missing
+   for that column.
+4. For every column with at least one numeric value, compute:
+   `count`, `mean`, `median`, `min`, `max`. Use the standard
+   formulas:
+   - mean = sum(values) / count
+   - median = sorted middle value (or average of two middles for
+     even-length lists)
+5. Render a Markdown table with one row per numeric column. Headers:
+   `column | count | mean | median | min | max`. Round all floats to
+   3 decimal places.
+6. Write the Markdown table to `<csv stem>_stats.md` next to the
+   input file using `write_text`. Include a top-level heading
+   `# Statistics for <filename>`.
+
+## Output contract
+
+The user expects a `<stem>_stats.md` file written to disk. The
+`done(answer=...)` summary should mention the path.

--- a/examples/skillful_analyst_portable.cartridge/skills/file-summarize/SKILL.md
+++ b/examples/skillful_analyst_portable.cartridge/skills/file-summarize/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: file-summarize
+description: Produce a short Markdown summary of a text file (line count, top tokens, first/last lines). Use when the user asks "what's in this file" or wants a quick characterisation.
+tags: [text, summary, exploration]
+---
+
+# File summariser
+
+Use this skill when the user wants a quick characterisation of a text
+file but does NOT want full content reproduction.
+
+## Steps
+
+1. Use `read_text(path=<file>)` to load the file.
+2. Count: total lines, total chars, distinct words (split on
+   whitespace, lowercased, stripped of `.,;:!?"'()`).
+3. Identify the 10 most-frequent words, ignoring this stoplist:
+   `the a an of to in for and or is are was were be been being it its
+   this that these those on at by from as with`.
+4. Capture the first 3 non-empty lines and the last 3 non-empty
+   lines.
+5. Write a Markdown report to `<stem>.summary.md` with sections:
+   `## Counts`, `## Top words`, `## First lines`, `## Last lines`.
+
+## Output contract
+
+The user expects `<stem>.summary.md`. Report the path in
+`done(answer=...)`.

--- a/examples/skillful_analyst_portable.cartridge/skills/json-pretty/SKILL.md
+++ b/examples/skillful_analyst_portable.cartridge/skills/json-pretty/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: json-pretty
+description: Pretty-print a JSON file with sorted keys and 2-space indent. Use when the user asks to format, prettify, or "make this JSON readable".
+tags: [json, formatting]
+---
+
+# JSON pretty-printer
+
+Use this skill when the user wants a JSON file formatted for human
+reading.
+
+## Steps
+
+1. Use `read_text(path=<json>)` to load the file.
+2. Parse it with `json.loads`. If parsing fails, write the parse
+   error to `<stem>.parse_error.txt` and stop — do not write a
+   partial output.
+3. Re-emit with `json.dumps(obj, indent=2, sort_keys=True,
+   ensure_ascii=False)`.
+4. Write the result back to `<stem>.pretty.json` next to the
+   original. Do NOT modify the original.
+
+## Output contract
+
+The user expects a `<stem>.pretty.json` file. The `done(answer=...)`
+summary should report the new file's path.

--- a/examples/threat_intel_portable.cartridge/_mcp/tools_server.py
+++ b/examples/threat_intel_portable.cartridge/_mcp/tools_server.py
@@ -1,0 +1,499 @@
+"""Stdio MCP server for the threat_intel_portable cartridge.
+
+Serves all 7 tools that were in-process ``tools/*/execute.py`` bodies in
+the original ``threat_intel`` cartridge — ``fetch_feed``, ``search_cve``,
+``extract_iocs``, ``map_mitre``, ``assess_risk``, ``think``, ``done`` —
+over the MCP stdio transport. Moving them out of process is what makes
+the twin fully portable: no Python tool body is required by the host.
+
+The simulated threat feeds (``THREAT_FEEDS``) and the MITRE technique
+table are vendored here verbatim from the original ``threat_intel_lib``.
+
+LLM-backed behaviour reaches the host model through the Model Gateway
+(MGP): the loader exports ``LOOPLET_LLM_SOCKET`` and this server connects
+to it lazily, so ``extract_iocs`` can add its ``llm_severity`` field and
+``assess_risk`` can return a real analyst assessment — full parity with
+the in-process original. When no gateway is present (or no backend is
+bound yet) the calls degrade to exactly the branches the originals take
+when ``ctx.llm is None``.
+
+Standard-library only.
+Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
+"""
+
+import json
+import os
+import re
+import socket
+import sys
+
+
+class _HostLLM:
+    """Minimal stdlib-only client to the host Model Gateway (MGP).
+
+    Connects to ``$LOOPLET_LLM_SOCKET`` (set by the loader) and forwards
+    ``generate`` to the host's live LLM backend. ``generate`` raises if no
+    gateway/backend is reachable, so callers degrade exactly like the
+    in-process original's ``ctx.llm is None`` branch.
+    """
+
+    def __init__(self):
+        self._sock = None
+        self._buf = b""
+        self._id = 0
+        path = os.environ.get("LOOPLET_LLM_SOCKET")
+        if not path or not hasattr(socket, "AF_UNIX"):
+            return
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(30.0)
+            sock.connect(path)
+            self._sock = sock
+            self._rpc("llm/initialize", {})
+        except OSError:
+            self._sock = None
+
+    def _readline(self):
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                line, self._buf = self._buf, b""
+                return line
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return line
+
+    def _rpc(self, method, params):
+        self._id += 1
+        rid = self._id
+        self._sock.sendall(
+            (json.dumps({"id": rid, "method": method, "params": params}) + "\n").encode("utf-8")
+        )
+        line = self._readline()
+        if not line:
+            raise OSError("model gateway closed the connection")
+        msg = json.loads(line.decode("utf-8"))
+        if msg.get("error"):
+            raise RuntimeError(msg["error"].get("message", "model gateway error"))
+        return msg.get("result") or {}
+
+    def available(self):
+        """True iff the gateway has a live LLM backend bound *right now*.
+
+        Re-checks per call because the host binds the backend lazily at
+        run time (``AgentPreset.run(llm)``), which may happen after this
+        client connected. Maps to the original's ``ctx.llm is not None``
+        guard: when False, callers take their no-LLM degradation branch
+        instead of treating absence as an error.
+        """
+        if self._sock is None:
+            return False
+        try:
+            return bool(self._rpc("llm/initialize", {}).get("ready"))
+        except (OSError, RuntimeError):
+            return False
+
+    def generate(self, prompt, **kwargs):
+        if self._sock is None:
+            raise RuntimeError("no host LLM gateway is reachable")
+        return str(self._rpc("llm/generate", {"prompt": prompt, "kwargs": kwargs}).get("text", ""))
+
+
+_HOST_LLM = None
+_HOST_LLM_TRIED = False
+
+
+def _host_llm():
+    """Return the host Model Gateway client only when a backend is bound.
+
+    Returns ``None`` when there is no reachable gateway *or* no backend is
+    currently bound — i.e. exactly the cases where the in-process original
+    sees ``ctx.llm is None`` and degrades.
+    """
+    global _HOST_LLM, _HOST_LLM_TRIED
+    if not _HOST_LLM_TRIED:
+        _HOST_LLM_TRIED = True
+        client = _HostLLM()
+        if client._sock is not None:
+            _HOST_LLM = client
+    if _HOST_LLM is not None and _HOST_LLM.available():
+        return _HOST_LLM
+    return None
+
+
+THREAT_FEEDS = {
+    "cisa_alerts": [
+        {
+            "id": "AA26-113A",
+            "title": "Critical Vulnerability in Bitwarden CLI Supply Chain",
+            "date": "2026-04-23",
+            "source": "CISA",
+            "summary": (
+                "CISA is aware of an ongoing supply chain compromise affecting the "
+                "Bitwarden CLI package distributed via npm. The malicious version "
+                "(2026.4.1) exfiltrates vault credentials to an attacker-controlled "
+                "endpoint at collect.checkmarx-analytics[.]com. Organizations using "
+                "Bitwarden CLI should immediately verify package integrity against "
+                "known-good hashes published at bitwarden.com/checksums. "
+                "CVE-2026-3891 has been assigned with a CVSS score of 9.8."
+            ),
+            "cves": ["CVE-2026-3891"],
+            "iocs": [
+                "collect.checkmarx-analytics[.]com",
+                "npm package bitwarden-cli@2026.4.1",
+                "SHA256:a1b2c3d4e5f6...malicious_hash",
+            ],
+            "severity": "CRITICAL",
+        },
+        {
+            "id": "AA26-112B",
+            "title": "French Government Agency Data Breach via API Misconfiguration",
+            "date": "2026-04-22",
+            "source": "CISA",
+            "summary": (
+                "A French government employment agency confirmed a data breach "
+                "affecting 43 million records. The breach was caused by an "
+                "unauthenticated API endpoint that exposed personal information "
+                "including names, social security numbers, and employment history. "
+                "The exposed API was api.emploi-gouv[.]fr/v2/citizens. "
+                "No CVE assigned. Organizations should audit their public-facing APIs."
+            ),
+            "cves": [],
+            "iocs": ["api.emploi-gouv[.]fr/v2/citizens"],
+            "severity": "HIGH",
+        },
+    ],
+    "nvd_recent": [
+        {
+            "cve_id": "CVE-2026-3891",
+            "description": "Bitwarden CLI npm package supply chain compromise allowing "
+            "credential exfiltration",
+            "cvss_v3": 9.8,
+            "vendor": "Bitwarden",
+            "product": "CLI",
+            "published": "2026-04-23",
+        },
+        {
+            "cve_id": "CVE-2026-3847",
+            "description": "GitHub Actions runner token exposure via crafted workflow in "
+            "public repositories",
+            "cvss_v3": 8.1,
+            "vendor": "GitHub",
+            "product": "Actions",
+            "published": "2026-04-22",
+        },
+        {
+            "cve_id": "CVE-2026-3802",
+            "description": "MeshCore mesh networking firmware buffer overflow allowing "
+            "remote code execution",
+            "cvss_v3": 7.5,
+            "vendor": "MeshCore",
+            "product": "Firmware",
+            "published": "2026-04-21",
+        },
+    ],
+    "osint_reports": [
+        {
+            "title": "Telecom Surveillance Campaign Targeting European Carriers",
+            "source": "TechCrunch / Citizen Lab",
+            "date": "2026-04-23",
+            "summary": (
+                "Researchers have uncovered two sophisticated surveillance campaigns "
+                "targeting European telecom providers. The campaigns use custom "
+                "implants delivered via SS7 protocol exploitation and compromise of "
+                "lawful intercept systems. Attribution points to state-sponsored "
+                "actors. Affected infrastructure includes Diameter signaling nodes "
+                "and GTP tunneling endpoints. IOCs include C2 domains "
+                "update.telecom-infra[.]net and ssl-verify.carrier-mgmt[.]com, "
+                "and implant hashes SHA256:deadbeef1234...implant_a and "
+                "SHA256:cafebabe5678...implant_b."
+            ),
+            "iocs": [
+                "update.telecom-infra[.]net",
+                "ssl-verify.carrier-mgmt[.]com",
+                "SHA256:deadbeef1234...implant_a",
+                "SHA256:cafebabe5678...implant_b",
+            ],
+            "ttp_ids": ["T1557", "T1040", "T1132"],
+        },
+    ],
+}
+
+_MITRE_DB = {
+    "T1557": {"name": "Adversary-in-the-Middle", "tactic": "Credential Access, Collection"},
+    "T1040": {"name": "Network Sniffing", "tactic": "Credential Access, Discovery"},
+    "T1132": {"name": "Data Encoding", "tactic": "Command and Control"},
+    "T1195": {"name": "Supply Chain Compromise", "tactic": "Initial Access"},
+    "T1059": {"name": "Command and Scripting Interpreter", "tactic": "Execution"},
+}
+
+
+def fetch_feed(feed_name):
+    available = list(THREAT_FEEDS.keys())
+    if feed_name not in THREAT_FEEDS:
+        return {"error": f"Unknown feed '{feed_name}'. Available: {available}"}
+    items = THREAT_FEEDS[feed_name]
+    return {"feed": feed_name, "item_count": len(items), "items": items}
+
+
+def search_cve(cve_id):
+    for item in THREAT_FEEDS.get("nvd_recent", []):
+        if item["cve_id"] == cve_id:
+            return item
+    return {"cve_id": cve_id, "error": "CVE not found in recent data"}
+
+
+def extract_iocs(text):
+    ip_pattern = r"\b(?:\d{1,3}\.){3}\d{1,3}\b"
+    domain_pattern = r"\b[a-zA-Z0-9][-a-zA-Z0-9]*\[?\.\]?[a-zA-Z]{2,}(?:\[?\.\]?[a-zA-Z]{2,})*\b"
+    cve_pattern = r"CVE-\d{4}-\d{4,}"
+    sha256_pattern = r"SHA256:[a-fA-F0-9]+"
+    hash_pattern = r"\b[a-fA-F0-9]{64}\b"
+
+    ips = re.findall(ip_pattern, text)
+    domains = [
+        d
+        for d in re.findall(domain_pattern, text)
+        if "[.]" in d or (len(d) > 5 and "." in d and not d[0].isdigit())
+    ]
+    cves = re.findall(cve_pattern, text)
+    hashes = re.findall(sha256_pattern, text) + re.findall(hash_pattern, text)
+
+    result = {
+        "ips": list(set(ips)),
+        "domains": list(set(domains)),
+        "cves": list(set(cves)),
+        "hashes": list(set(hashes)),
+        "total_iocs": len(set(ips)) + len(set(domains)) + len(set(cves)) + len(set(hashes)),
+    }
+
+    # Use the host LLM (via the Model Gateway) to classify severity if
+    # reachable — same branch the in-process original takes with ctx.llm.
+    llm = _host_llm()
+    if llm is not None and result["total_iocs"] > 0:
+        try:
+            classification = llm.generate(
+                f"Given these IOCs extracted from a threat report, classify the overall "
+                f"threat severity as CRITICAL, HIGH, MEDIUM, or LOW. Respond with just "
+                f"the severity level, nothing else.\n\nIOCs: {json.dumps(result, indent=2)}",
+                max_tokens=20,
+            )
+            result["llm_severity"] = classification.strip().upper()
+        except Exception:
+            pass
+
+    return result
+
+
+def map_mitre(technique_ids):
+    ids = [t.strip() for t in technique_ids.split(",")]
+    results = {}
+    for tid in ids:
+        results[tid] = _MITRE_DB.get(tid, {"name": "Unknown", "tactic": "Unknown"})
+    return {"techniques": results, "count": len(results)}
+
+
+def assess_risk(title, severity, affected_products):
+    # Reach the host LLM through the Model Gateway when available; else
+    # degrade to the original's no-LLM fallback message.
+    llm = _host_llm()
+    if llm is not None:
+        try:
+            assessment = llm.generate(
+                f"You are a threat intelligence analyst. Assess the organizational risk "
+                f"for this threat in 2-3 sentences. Consider likelihood of exploitation, "
+                f"blast radius, and recommended priority.\n\n"
+                f"Threat: {title}\nSeverity: {severity}\n"
+                f"Affected: {affected_products}\n\n"
+                f"Respond with: PRIORITY: [IMMEDIATE/HIGH/MEDIUM/LOW] followed by "
+                f"a brief justification.",
+                max_tokens=150,
+            )
+            return {
+                "title": title,
+                "severity": severity,
+                "assessment": assessment.strip(),
+            }
+        except Exception as e:
+            return {"title": title, "severity": severity, "assessment": f"LLM error: {e}"}
+    return {
+        "title": title,
+        "severity": severity,
+        "assessment": f"Risk assessment unavailable (no LLM). Severity: {severity}",
+    }
+
+
+TOOLS = [
+    {
+        "name": "fetch_feed",
+        "description": "Fetch a specific threat feed by name (cisa_alerts, nvd_recent, "
+        "osint_reports).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "feed_name": {
+                    "type": "string",
+                    "description": "One of cisa_alerts, nvd_recent, osint_reports.",
+                }
+            },
+            "required": ["feed_name"],
+        },
+    },
+    {
+        "name": "search_cve",
+        "description": "Look up details for a specific CVE ID.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier (e.g. CVE-2025-12345).",
+                }
+            },
+            "required": ["cve_id"],
+        },
+    },
+    {
+        "name": "extract_iocs",
+        "description": "Extract IOCs (IPs, domains, CVEs, hashes) from text via pattern "
+        "matching, then add an LLM severity classification via the host Model Gateway "
+        "(degrades to pattern-only when no host LLM is reachable).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"text": {"type": "string", "description": "Raw text to scan for IOCs."}},
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "map_mitre",
+        "description": "Map comma-separated MITRE ATT&CK technique IDs to names and tactics.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "technique_ids": {
+                    "type": "string",
+                    "description": "Comma-separated technique IDs (e.g. T1059,T1071).",
+                }
+            },
+            "required": ["technique_ids"],
+        },
+    },
+    {
+        "name": "assess_risk",
+        "description": "Assess organizational risk for a specific threat using the host "
+        "LLM via the Model Gateway (degrades to a severity-only summary when no host "
+        "LLM is reachable).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Threat title."},
+                "severity": {
+                    "type": "string",
+                    "description": "critical | high | medium | low.",
+                },
+                "affected_products": {
+                    "type": "string",
+                    "description": "Comma-separated product list.",
+                },
+            },
+            "required": ["title", "severity", "affected_products"],
+        },
+    },
+    {
+        "name": "think",
+        "description": "Record an analytical step or hypothesis. No side effects.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"analysis": {"type": "string", "description": "Brief analytical note."}},
+            "required": ["analysis"],
+        },
+    },
+    {
+        "name": "done",
+        "description": "Signal that the briefing is complete.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "The structured threat-intel briefing.",
+                }
+            },
+            "required": ["summary"],
+        },
+    },
+]
+
+
+def respond(msg_id, result=None, error=None):
+    out = {"jsonrpc": "2.0", "id": msg_id}
+    if error is not None:
+        out["error"] = error
+    else:
+        out["result"] = result
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()
+
+
+def _content(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}], "isError": False}
+
+
+def _dispatch(name, args):
+    if name == "fetch_feed":
+        return fetch_feed(args.get("feed_name", ""))
+    if name == "search_cve":
+        return search_cve(args.get("cve_id", ""))
+    if name == "extract_iocs":
+        return extract_iocs(args.get("text", ""))
+    if name == "map_mitre":
+        return map_mitre(args.get("technique_ids", ""))
+    if name == "assess_risk":
+        return assess_risk(
+            args.get("title", ""),
+            args.get("severity", ""),
+            args.get("affected_products", ""),
+        )
+    if name == "think":
+        return {"analysis": args.get("analysis"), "noted": True}
+    if name == "done":
+        return {"status": "completed", "summary": args.get("summary")}
+    return None
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        req = json.loads(line)
+        method = req.get("method")
+        msg_id = req.get("id")
+        if method == "initialize":
+            respond(
+                msg_id,
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "threat-intel-tools", "version": "0.1"},
+                },
+            )
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            respond(msg_id, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = req.get("params", {})
+            name = params.get("name")
+            args = params.get("arguments", {}) or {}
+            result = _dispatch(name, args)
+            if result is None:
+                respond(msg_id, error={"code": -32601, "message": f"unknown tool {name!r}"})
+            else:
+                respond(msg_id, _content(result))
+        else:
+            respond(msg_id, error={"code": -32601, "message": f"method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/threat_intel_portable.cartridge/cartridge.json
+++ b/examples/threat_intel_portable.cartridge/cartridge.json
@@ -1,0 +1,12 @@
+{
+  "description": "Fully-portable twin of threat_intel: all 7 tools (fetch_feed, search_cve, extract_iocs, map_mitre, assess_risk, think, done) are served by the bundled MCP stdio server (_mcp/tools_server.py), the FeedAllowlistGuard egress policy is a kind: lep hook, and compaction is the host-provided runtime service. Zero Python-pinned components — runs on any conforming loader (Rust/Go/TS). The LLM-backed parts (extract_iocs severity classification, assess_risk reasoning) reach the host LLM through the Model Gateway (MGP: the loader exports LOOPLET_LLM_SOCKET and the MCP server connects to it), giving full parity with the in-process originals; if no gateway/backend is reachable they degrade gracefully (same fallback the originals take when ctx.llm is None), and the deterministic regex IOC extraction is preserved in full regardless.",
+  "metadata": {
+    "tags": [
+      "security",
+      "threat-intel",
+      "portable"
+    ]
+  },
+  "name": "threat_intel_portable",
+  "schema_version": 2
+}

--- a/examples/threat_intel_portable.cartridge/config.yaml
+++ b/examples/threat_intel_portable.cartridge/config.yaml
@@ -1,0 +1,34 @@
+# threat_intel — FULLY PORTABLE twin.
+#
+# Unlike threat_intel (which loads the 7 tools as in-process
+# tools/*/execute.py bodies re-importing threat_intel_lib.py), this twin
+# serves every tool from the bundled out-of-process MCP stdio server
+# (_mcp/tools_server.py). There is no tools/ directory and no Python tool
+# body anywhere, so the cartridge is classified `portable`: it can run on
+# any future loader (Rust, Go, TypeScript) that implements the MCP stdio
+# transport and the LEP hook transport — no Python required.
+#
+# Still-portable companions carried over verbatim:
+#   - hooks/00_FeedAllowlistGuard → kind: lep egress policy (PROTOCOL)
+#   - resources/compact_service   → host runtime service (RUNTIME, non-blocker)
+
+max_steps: 15
+done_tool: done
+
+builtin_hooks:
+  - stagnation
+  -
+    per_tool_limit:
+      default_limit: 8
+      limits:
+        fetch_feed: 3
+        search_cve: 5
+
+mcp_servers:
+  ti_tools:
+    # Self-contained stdio MCP server — no network/API access required.
+    # ${runtime.cartridge_root} is injected by the loader so the spawned
+    # command finds the bundled server regardless of checkout location.
+    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    timeout_s: 10
+    # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/threat_intel_portable.cartridge/hooks/00_FeedAllowlistGuard/config.yaml
+++ b/examples/threat_intel_portable.cartridge/hooks/00_FeedAllowlistGuard/config.yaml
@@ -1,0 +1,6 @@
+kind: lep
+server: server.py
+view:
+  fields: [tool, args]
+  fidelity: digest
+on_failure: fail_closed

--- a/examples/threat_intel_portable.cartridge/hooks/00_FeedAllowlistGuard/server.py
+++ b/examples/threat_intel_portable.cartridge/hooks/00_FeedAllowlistGuard/server.py
@@ -1,0 +1,39 @@
+"""FeedAllowlistGuard — a portable ``kind: lep`` permission policy.
+
+This hook runs *out of process* over the Loop Effect Protocol (LEP).
+The host ships only the declared view (``tool`` + ``args``) over
+line-delimited JSON-RPC; this server returns a permission decision.
+
+Policy: refuse any ``fetch_feed`` call whose ``feed_name`` is not on the
+trusted allowlist. A threat-intel agent should only pull from vetted
+sources (CISA, NVD, curated OSINT); an unknown feed name is either a
+hallucination or an attempt to reach an unapproved source, so the guard
+denies it. This is the classic out-of-process "egress allowlist"
+pattern expressed as a portable cartridge hook.
+
+Because the decision is a pure function of the declared view, the hook
+is classified ``portable`` and round-trips losslessly as a declarative
+``kind: lep`` block — no Python source needs to be vendored beyond this
+self-contained server.
+"""
+
+from looplet.lep import LEPServerBase
+
+_ALLOWED_FEEDS = {"cisa_alerts", "nvd_recent", "osint_reports"}
+
+
+class FeedAllowlistGuardServer(LEPServerBase):
+    def decide(self, slot, view):
+        if slot == "check_permission" and view.get("tool") == "fetch_feed":
+            feed = (view.get("args") or {}).get("feed_name")
+            if not isinstance(feed, str) or feed.strip() not in _ALLOWED_FEEDS:
+                allowed = ", ".join(sorted(_ALLOWED_FEEDS))
+                return {
+                    "kind": "Deny",
+                    "block": f"feed_name must be one of the allowlisted sources: {allowed}",
+                }
+        return {"kind": "Continue"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(FeedAllowlistGuardServer().serve())

--- a/examples/threat_intel_portable.cartridge/memory/00_static.md
+++ b/examples/threat_intel_portable.cartridge/memory/00_static.md
@@ -1,0 +1,5 @@
+## Briefing Standards
+- Always include CVE IDs with CVSS scores
+- Defang all IOCs (use [.] instead of .)
+- Prioritize supply chain and zero-day threats
+- Include MITRE ATT&CK mapping when available

--- a/examples/threat_intel_portable.cartridge/prompts/system.md
+++ b/examples/threat_intel_portable.cartridge/prompts/system.md
@@ -1,0 +1,17 @@
+You are a senior threat intelligence analyst producing a daily briefing. Your task:
+
+1. Fetch all three feeds: cisa_alerts, nvd_recent, osint_reports
+2. For each critical/high severity item, extract IOCs and assess risk
+3. Map any MITRE ATT&CK technique IDs
+4. Call done() with a structured briefing that includes:
+   - Executive Summary (3-4 sentences)
+   - Critical Findings (with CVEs, IOCs, and risk assessment)
+   - Recommended Actions
+
+Work systematically through the feeds. Use tools, don't guess.
+
+## Briefing Standards
+- Always include CVE IDs with CVSS scores
+- Defang all IOCs (use [.] instead of .)
+- Map every threat to a MITRE ATT&CK technique where possible
+- Risk assessments must reference specific affected products

--- a/examples/threat_intel_portable.cartridge/resources/compact_service.py
+++ b/examples/threat_intel_portable.cartridge/resources/compact_service.py
@@ -1,0 +1,12 @@
+"""Compaction service for the threat_intel workspace.
+
+Uses looplet's production default as a declarative resource.
+"""
+
+from __future__ import annotations
+
+from looplet.compact import default_compact_service
+
+
+def build(runtime=None):
+    return default_compact_service(keep_recent=3, keep_recent_tool_results=6)

--- a/examples/threat_intel_portable.cartridge/runtime.yaml
+++ b/examples/threat_intel_portable.cartridge/runtime.yaml
@@ -1,0 +1,3 @@
+max_tokens: 2000
+temperature: 0.2
+compact_service: @compact_service

--- a/tests/test_example_coder_portable_cartridge.py
+++ b/tests/test_example_coder_portable_cartridge.py
@@ -1,0 +1,243 @@
+"""End-to-end dogfood of the fully-portable ``coder_portable`` cartridge.
+
+This is the cross-runtime twin of ``coder`` — the most complex example
+cartridge (16 tools, a shared ``FileCache`` resource, and six hooks).
+Every portable component lives out of process behind a protocol:
+
+* 16 tools .............. MCP stdio server   (``_mcp/tools_server.py``)
+* shared FileCache ...... State Service       (``_state/file_cache.py``)
+* TestGuard/FileCache/
+  StaleFile/Linter/
+  ShellSafetyGate hooks .. ``kind: lep`` servers
+* web_fetch / subagent .. reach the host LLM over the Model Gateway
+* compaction ........... a RUNTIME builtin (``default_compact_service``)
+
+The tests prove the twin composes across process boundaries:
+
+1. Static profile is ``portable`` with zero blockers.
+2. The loader spawns exactly one MCP server + one State Service, and the
+   16 tools are reachable across the boundary.
+3. The deterministic file tools (write/read/edit/grep) run out of
+   process AND their reads land in the SAME FileCache State Service that
+   a DIFFERENT process (the cache-backed LEP hooks) would observe —
+   reproducing the original in-process ``@ref`` sharing with zero shared
+   Python objects.
+4. The ``subagent`` tool reaches the host LLM over the Model Gateway: it
+   degrades cleanly with no backend bound, and runs a real sub-loop when
+   a scripted backend is bound to the twin's gateway.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = Path(__file__).resolve().parent.parent / "examples" / "coder_portable.cartridge"
+
+_TOOLS = {
+    "bash",
+    "list_dir",
+    "read_file",
+    "write_file",
+    "edit_file",
+    "multi_edit",
+    "notebook_edit",
+    "glob",
+    "grep",
+    "git_inspect",
+    "worktree",
+    "web_fetch",
+    "subagent",
+    "todo",
+    "think",
+    "done",
+}
+
+
+class _ScriptedLLM:
+    """Deterministic backend: returns canned replies in order."""
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self.prompts: list[str] = []
+
+    def generate(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        return self._replies.pop(0) if self._replies else "DONE"
+
+
+def test_coder_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+
+
+@pytest.mark.timeout(90)
+def test_coder_portable_cross_process_tools(monkeypatch, tmp_path) -> None:
+    # The MCP server + State Service subprocesses bind their project root
+    # from the environment at spawn time, so set it BEFORE loading.
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(tmp_path))
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # Exactly one MCP server + one State Service were spawned.
+        assert len(preset.state_service_handles) == 1
+        assert len(preset.mcp_adapters) == 1
+
+        reg = preset.tools
+        assert set(reg.tool_names) == _TOOLS
+
+        cache = preset.resources["file_cache"]
+
+        # (1) write_file (separate process) creates a real file.
+        target = "pkg/mod.py"
+        w = reg.dispatch(
+            ToolCall(
+                tool="write_file",
+                args={"file_path": target, "content": "def add(a, b):\n    return a + b\n"},
+            )
+        )
+        assert w.error is None
+        # NB: the framework strips whitespace on string args, so the
+        # trailing newline is trimmed — assert on the body, not bytes.
+        assert (tmp_path / target).read_text().rstrip() == "def add(a, b):\n    return a + b"
+
+        # (2) read_file (separate process) reads it back AND records the
+        #     read into the shared FileCache State Service.
+        r = reg.dispatch(ToolCall(tool="read_file", args={"file_path": target}))
+        assert r.error is None
+        assert "def add(a, b):" in r.data["content"]
+        assert r.data["total_lines"] == 2
+
+        # (3) The read is visible across the process boundary: a DIFFERENT
+        #     process (the State Service) recorded it, exactly as the
+        #     cache-backed LEP hooks would observe.
+        assert cache.was_read(target) is True
+
+        # (4) edit_file (separate process) mutates the file in place.
+        e = reg.dispatch(
+            ToolCall(
+                tool="edit_file",
+                args={
+                    "file_path": target,
+                    "old_string": "a + b",
+                    "new_string": "a + b  # sum",
+                },
+            )
+        )
+        assert e.error is None
+        assert "# sum" in (tmp_path / target).read_text()
+
+        # (5) grep (separate process) finds the new content.
+        g = reg.dispatch(ToolCall(tool="grep", args={"pattern": "# sum", "path": "."}))
+        assert g.error is None
+        assert g.data["count"] >= 1
+
+        # (6) think + done (no-ctx tools) dispatch across the boundary.
+        t = reg.dispatch(ToolCall(tool="think", args={"thought": "looks good"}))
+        assert t.error is None
+        d = reg.dispatch(ToolCall(tool="done", args={"summary": "added add()"}))
+        assert d.error is None
+    finally:
+        preset.close()
+        assert preset.state_service_handles == []
+        assert preset.mcp_adapters == []
+
+
+def test_coder_portable_structured_param_schema_and_coercion(monkeypatch, tmp_path) -> None:
+    """Regression: structured tool params (``multi_edit.edits: list``) must
+    advertise as JSON-Schema ``array`` — not ``string`` — and a JSON-string
+    value for such a param must be coerced to a list across the MCP boundary.
+
+    The vendored tool modules use ``from __future__ import annotations``
+    (PEP 563), so ``inspect.signature`` reports the annotation as the string
+    ``"list"``. A type-keyed lookup misses it and falls back to ``"string"``,
+    which (a) tells the model the param is a string so it double-encodes the
+    value and (b) trips the tool's list validation. This pins both halves of
+    the fix: correct schema type + host-side str→list coercion.
+    """
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(tmp_path))
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        reg = preset.tools
+        multi_edit = reg._tools["multi_edit"]
+        assert (multi_edit.parameters or {}).get("edits") == "array"
+        # subagent.max_steps is an int param → integer, not string.
+        subagent = reg._tools["subagent"]
+        assert (subagent.parameters or {}).get("max_steps", "").endswith("integer")
+
+        target = "frob.py"
+        (tmp_path / target).write_text("VALUE = 1\n")
+        reg.dispatch(ToolCall(tool="read_file", args={"file_path": target}))
+
+        # Pass ``edits`` as a JSON STRING (what a model does when the schema
+        # mislabels the param). The host adapter must parse it to a list.
+        import json as _json
+
+        edits_str = _json.dumps([{"old_string": "VALUE = 1", "new_string": "VALUE = 2"}])
+        m = reg.dispatch(
+            ToolCall(tool="multi_edit", args={"file_path": target, "edits": edits_str})
+        )
+        assert m.error is None
+        assert "error" not in (m.data or {}), m.data
+        assert (tmp_path / target).read_text().strip() == "VALUE = 2"
+    finally:
+        preset.close()
+        assert preset.state_service_handles == []
+        assert preset.mcp_adapters == []
+
+
+@pytest.mark.timeout(60)
+def test_coder_portable_subagent_degrades_without_backend(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(tmp_path))
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # No backend bound (load-time default) → the documented
+        # ctx.llm-None degradation branch, identical to the original.
+        s = preset.tools.dispatch(
+            ToolCall(tool="subagent", args={"prompt": "investigate the repo"})
+        )
+        assert s.error is None
+        assert "requires an active ctx.llm" in s.data["error"]
+        assert "recovery" in s.data
+    finally:
+        preset.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="model gateway requires AF_UNIX sockets",
+)
+@pytest.mark.timeout(90)
+def test_coder_portable_subagent_runs_over_model_gateway(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(tmp_path))
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # The loader auto-started a Model Gateway (the cartridge has
+        # mcp_servers); bind a scripted backend as AgentPreset.run would.
+        assert preset.model_gateway is not None, "gateway should auto-start"
+        backend_used = _ScriptedLLM(['{"tool": "done", "args": {"summary": "investigated"}}'])
+        preset.model_gateway.set_backend(backend_used)
+
+        # The subagent runs an isolated sub-loop whose LLM calls cross the
+        # process boundary (MCP tool subprocess → host gateway → backend).
+        s = preset.tools.dispatch(
+            ToolCall(
+                tool="subagent",
+                args={"prompt": "summarize the repo", "max_steps": 2},
+            )
+        )
+        assert s.error is None
+        assert "error" not in s.data
+        # The sub-loop completed via the host LLM: at least one
+        # generation crossed the boundary (MCP subprocess → gateway).
+        assert s.data["llm_calls"] >= 1
+        assert "summary" in s.data
+        # The scripted backend's reply was consumed by the sub-loop.
+        assert backend_used.prompts, "gateway backend was never called"
+    finally:
+        preset.close()

--- a/tests/test_example_dep_doctor_portable_cartridge.py
+++ b/tests/test_example_dep_doctor_portable_cartridge.py
@@ -1,0 +1,139 @@
+"""End-to-end dogfood of the fully-portable ``dep_doctor_portable``.
+
+Cross-runtime twin of ``dep_doctor``. All 7 audit tools are served by a
+bundled MCP stdio server, the RegistryGuard is a ``kind: lep`` permission
+hook, and compaction is the host-provided RUNTIME-tier ``compact_service``
+resource. Nothing pins it to Python.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = Path(__file__).resolve().parent.parent / "examples" / "dep_doctor_portable.cartridge"
+
+
+def test_dep_doctor_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # all 7 audit tools
+    assert "lep" in details  # RegistryGuard
+    assert "host-service" in details  # compact_service (RUNTIME tier)
+
+
+@pytest.mark.timeout(60)
+def test_dep_doctor_portable_cross_process_composition(tmp_path: Path) -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        assert len(preset.mcp_adapters) == 1
+        assert preset.state_service_handles == []
+        names = set(preset.tools.tool_names)
+        assert {
+            "detect_dep_files",
+            "parse_deps",
+            "check_package",
+            "check_license_compat",
+            "find_alternatives",
+            "think",
+            "done",
+        } <= names
+
+        guard = next(h for h in preset.hooks if "RegistryGuard" in getattr(h, "_cartridge_id", ""))
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) LEP RegistryGuard (separate process) refuses an empty
+            #     package_name, allows a real one.
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="check_package", args={"package_name": "  "}),
+                    None,
+                )
+                is False
+            )
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="check_package", args={"package_name": "django"}),
+                    None,
+                )
+                is True
+            )
+
+            # (2) MCP detect_dep_files over a real on-disk project.
+            (tmp_path / "requirements.txt").write_text(
+                "django>=5.0\nrequests==2.32.3\nabandoned-lib\n"
+            )
+            (tmp_path / "package.json").write_text('{"dependencies": {"express": "^4.21.0"}}')
+            d = preset.tools.dispatch(
+                ToolCall(tool="detect_dep_files", args={"project_dir": str(tmp_path)})
+            )
+            assert d.error is None
+            assert d.data["count"] == 2
+            files = {f["file"] for f in d.data["dep_files"]}
+            assert files == {"requirements.txt", "package.json"}
+
+            # (3) MCP parse_deps on the requirements file.
+            pd = preset.tools.dispatch(
+                ToolCall(
+                    tool="parse_deps",
+                    args={"file_path": str(tmp_path / "requirements.txt")},
+                )
+            )
+            assert pd.error is None
+            assert pd.data["count"] == 3
+            parsed = {x["name"] for x in pd.data["dependencies"]}
+            assert {"django", "requests", "abandoned-lib"} == parsed
+
+            # (4) MCP check_package surfaces the CVE + abandoned status.
+            cp = preset.tools.dispatch(
+                ToolCall(tool="check_package", args={"package_name": "abandoned-lib"})
+            )
+            assert cp.error is None
+            assert cp.data["status"] == "abandoned"
+            assert cp.data["cves"][0]["severity"] == "CRITICAL"
+            assert cp.data["stale"] is True
+
+            # (5) MCP check_license_compat flags a GPL clash.
+            lc = preset.tools.dispatch(
+                ToolCall(
+                    tool="check_license_compat",
+                    args={"project_license": "MIT", "dep_license": "GPL-3.0"},
+                )
+            )
+            assert lc.error is None
+            assert lc.data["compatible"] is False
+            assert lc.data["risk"] == "HIGH"
+
+            # (6) find_alternatives degrades to empty (no host LLM in subprocess).
+            fa = preset.tools.dispatch(
+                ToolCall(tool="find_alternatives", args={"package_name": "abandoned-lib"})
+            )
+            assert fa.error is None
+            assert fa.data["alternatives"] == []
+
+            # (7) think + done round-trip.
+            th = preset.tools.dispatch(
+                ToolCall(tool="think", args={"thought": "abandoned-lib is a risk"})
+            )
+            assert th.error is None
+            assert th.data["noted"] is True
+
+            done = preset.tools.dispatch(ToolCall(tool="done", args={"summary": "audit complete"}))
+            assert done.error is None
+            assert done.data["status"] == "completed"
+            assert done.data["summary"] == "audit complete"
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()

--- a/tests/test_example_git_detective_portable_cartridge.py
+++ b/tests/test_example_git_detective_portable_cartridge.py
@@ -1,0 +1,169 @@
+"""End-to-end dogfood of the fully-portable ``git_detective_portable``.
+
+Cross-runtime twin of ``git_detective``. All 10 tools are served by a
+bundled MCP stdio server, the CouplingGuard threshold policy is a
+``kind: lep`` hook, and compaction is the host-provided RUNTIME-tier
+``compact_service`` resource. The original's INPROCESS ``repo_config``
+resource is replaced by ``$LOOPLET_PROJECT_ROOT`` resolution in the
+server, so nothing pins it to Python.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = (
+    Path(__file__).resolve().parent.parent / "examples" / "git_detective_portable.cartridge"
+)
+
+
+def test_git_detective_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # all 10 tools
+    assert "lep" in details  # CouplingGuard
+    assert "host-service" in details  # compact_service (RUNTIME tier)
+    # The original's INPROCESS repo_config resource must be gone.
+    assert "repo_config" not in {c.name for c in report.components}
+
+
+def _make_repo(root: Path) -> None:
+    def run(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    run("init", "-q")
+    run("config", "user.email", "detective@example.com")
+    run("config", "user.name", "Sherlock")
+    (root / "a.py").write_text("print('a')\n")
+    (root / "b.py").write_text("print('b')\n")
+    run("add", "-A")
+    run("commit", "-q", "-m", "feat: initial files")
+    (root / "a.py").write_text("print('a2')\n")
+    (root / "b.py").write_text("print('b2')\n")
+    run("add", "-A")
+    run("commit", "-q", "-m", "fix: tweak both files together")
+
+
+@pytest.mark.timeout(90)
+def test_git_detective_portable_cross_process_composition(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _make_repo(repo)
+
+    # The MCP server resolves the target repo from $LOOPLET_PROJECT_ROOT,
+    # which the spawned subprocess inherits from this process's environment.
+    prev = os.environ.get("LOOPLET_PROJECT_ROOT")
+    os.environ["LOOPLET_PROJECT_ROOT"] = str(repo)
+    try:
+        preset = cartridge_to_preset(_CARTRIDGE)
+        try:
+            assert len(preset.mcp_adapters) == 1
+            assert preset.state_service_handles == []
+            names = set(preset.tools.tool_names)
+            assert {
+                "repo_overview",
+                "contributor_stats",
+                "recent_activity",
+                "file_hotspots",
+                "coupled_files",
+                "commit_patterns",
+                "directory_structure",
+                "file_age_analysis",
+                "think",
+                "done",
+            } <= names
+
+            guard = next(
+                h for h in preset.hooks if "CouplingGuard" in getattr(h, "_cartridge_id", "")
+            )
+            for h in preset.hooks:
+                if hasattr(h, "pre_loop"):
+                    h.pre_loop(None, None, None)
+
+            try:
+                # (1) LEP CouplingGuard refuses a non-positive threshold,
+                #     allows a sane one.
+                assert (
+                    guard.check_permission(
+                        ToolCall(tool="coupled_files", args={"min_coupling": "0"}),
+                        None,
+                    )
+                    is False
+                )
+                assert (
+                    guard.check_permission(
+                        ToolCall(tool="coupled_files", args={"min_coupling": "2"}),
+                        None,
+                    )
+                    is True
+                )
+
+                # (2) MCP repo_overview over the real temp git repo.
+                ro = preset.tools.dispatch(ToolCall(tool="repo_overview", args={}))
+                assert ro.error is None
+                assert ro.data["repo_name"] == "repo"
+                assert ro.data["total_commits"] == 2
+
+                # (3) MCP contributor_stats.
+                cs = preset.tools.dispatch(ToolCall(tool="contributor_stats", args={}))
+                assert cs.error is None
+                assert cs.data["contributor_count"] == 1
+                assert cs.data["total_commits"] == 2
+
+                # (4) MCP file_hotspots — a.py and b.py both changed twice.
+                fh = preset.tools.dispatch(ToolCall(tool="file_hotspots", args={"top_n": "5"}))
+                assert fh.error is None
+                hotspot_files = {h["file"] for h in fh.data["hotspots"]}
+                assert {"a.py", "b.py"} <= hotspot_files
+
+                # (5) MCP coupled_files — a.py and b.py co-change.
+                cf = preset.tools.dispatch(
+                    ToolCall(tool="coupled_files", args={"min_coupling": "2"})
+                )
+                assert cf.error is None
+                assert cf.data["coupling_threshold"] == 2
+
+                # (6) MCP commit_patterns (deterministic; no LLM assessment).
+                cp = preset.tools.dispatch(ToolCall(tool="commit_patterns", args={}))
+                assert cp.error is None
+                assert cp.data["total_analyzed"] == 2
+                assert cp.data["conventional_commits_pct"] == 100.0
+                assert "commit_quality_assessment" not in cp.data  # degraded
+
+                # (7) think + done round-trip.
+                th = preset.tools.dispatch(
+                    ToolCall(tool="think", args={"thought": "tight coupling"})
+                )
+                assert th.error is None
+                assert th.data["noted"] is True
+
+                done = preset.tools.dispatch(
+                    ToolCall(tool="done", args={"summary": "health report"})
+                )
+                assert done.error is None
+                assert done.data["status"] == "completed"
+            finally:
+                for h in preset.hooks:
+                    if hasattr(h, "close"):
+                        h.close()
+        finally:
+            preset.close()
+    finally:
+        if prev is None:
+            os.environ.pop("LOOPLET_PROJECT_ROOT", None)
+        else:
+            os.environ["LOOPLET_PROJECT_ROOT"] = prev

--- a/tests/test_example_hello_portable_cartridge.py
+++ b/tests/test_example_hello_portable_cartridge.py
@@ -1,0 +1,102 @@
+"""End-to-end dogfood of the fully-portable ``hello_portable`` cartridge.
+
+This is the cross-runtime twin of ``hello``: every component lives out
+of process behind a protocol —
+
+* greet + done ........ MCP stdio server   (``_mcp/tools_server.py``)
+* shared greeting log .. State Service      (``_state/greeting_log.py``)
+* PolitenessGate ....... ``kind: lep`` hook (reads the state service)
+* NameGuard ............ ``kind: lep`` hook
+
+The test loads the cartridge to a live preset (spawning the MCP server,
+the state service, and the two LEP hook servers — four separate
+processes) and witnesses that they compose: the MCP greet tool's writes
+land in the state service, and the LEP PolitenessGate hook — a DIFFERENT
+process — reads that same state across the boundary to gate ``done()``.
+This reproduces the original in-process ``@ref`` sharing with zero shared
+Python objects, proving the State Service primitive closes the
+portability gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = Path(__file__).resolve().parent.parent / "examples" / "hello_portable.cartridge"
+
+
+def test_hello_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+
+
+@pytest.mark.timeout(60)
+def test_hello_portable_cross_process_composition() -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # The loader spawned exactly one state service + one MCP server.
+        assert len(preset.state_service_handles) == 1
+        assert len(preset.mcp_adapters) == 1
+
+        reg = preset.tools
+        assert set(reg.tool_names) == {"greet", "done"}
+
+        # The injected client proxies the out-of-process greeting log.
+        log = preset.resources["greeting_log"]
+        assert set(log.methods) == {"record", "names", "entries", "count"}
+        assert log.count() == 0
+
+        # Identify the two LEP hooks and open their sessions.
+        polite = next(h for h in preset.hooks if "Politeness" in getattr(h, "_cartridge_id", ""))
+        nameg = next(h for h in preset.hooks if h is not polite)
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) PolitenessGate (separate process) reads the state service
+            #     and blocks done() while no greeting has been recorded.
+            blocked = polite.check_done(None, None, None, 0)
+            assert blocked and "greet at least one person" in blocked
+
+            # (2) NameGuard denies an empty name, allows a real one.
+            assert (
+                nameg.check_permission(ToolCall(tool="greet", args={"name": "  "}), None) is False
+            )
+            assert (
+                nameg.check_permission(ToolCall(tool="greet", args={"name": "Ada"}), None) is True
+            )
+
+            # (3) MCP greet tool (separate process) records into the SAME
+            #     state service the hook reads from.
+            r1 = reg.dispatch(ToolCall(tool="greet", args={"name": "Ada"}))
+            assert r1.error is None
+            assert r1.data == {"greeting": "Hello, Ada!"}
+            reg.dispatch(ToolCall(tool="greet", args={"name": "Bob"}))
+
+            # (4) The write is visible across the process boundary.
+            assert log.count() == 2
+            assert log.names() == ["Ada", "Bob"]
+
+            # (5) PolitenessGate now lets done() through (sees count == 2).
+            assert polite.check_done(None, None, None, 1) is None
+
+            # (6) MCP done tool completes.
+            r3 = reg.dispatch(ToolCall(tool="done", args={"summary": "Greeted both"}))
+            assert r3.error is None
+            assert r3.data["status"] == "completed"
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()
+        # Teardown drains the spawned subprocesses.
+        assert preset.state_service_handles == []
+        assert preset.mcp_adapters == []

--- a/tests/test_example_mcp_demo_portable_cartridge.py
+++ b/tests/test_example_mcp_demo_portable_cartridge.py
@@ -1,0 +1,77 @@
+"""End-to-end dogfood of the fully-portable ``mcp_demo_portable`` cartridge.
+
+Cross-runtime twin of ``mcp_demo``. Unlike the original (which keeps the
+``done`` completion sentinel as an in-process ``tools/done/execute.py``),
+this twin serves BOTH ``add`` and ``done`` from the bundled MCP stdio
+server and guards them with a ``kind: lep`` permission hook. Nothing is
+pinned to a Python host.
+
+The test loads the cartridge to a live preset (spawning the MCP server
+and the LEP hook server — two separate processes) and witnesses that the
+MCP transport tools and the LEP permission policy compose: the guard
+vets ``add`` operands before dispatch, the MCP ``add`` computes the sum
+out of process, and the MCP ``done`` completes the run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = Path(__file__).resolve().parent.parent / "examples" / "mcp_demo_portable.cartridge"
+
+
+def test_mcp_demo_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # add + done served over MCP
+    assert "lep" in details  # CalcGuard permission policy
+
+
+@pytest.mark.timeout(60)
+def test_mcp_demo_portable_cross_process_composition() -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # One MCP server, no state services, no in-process tool bodies.
+        assert len(preset.mcp_adapters) == 1
+        assert preset.state_service_handles == []
+
+        reg = preset.tools
+        assert set(reg.tool_names) == {"add", "done"}
+
+        guard = next(h for h in preset.hooks if "CalcGuard" in getattr(h, "_cartridge_id", ""))
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) LEP CalcGuard (separate process) denies non-numeric
+            #     operands and allows numeric ones.
+            assert (
+                guard.check_permission(ToolCall(tool="add", args={"a": "x", "b": 2}), None) is False
+            )
+            assert guard.check_permission(ToolCall(tool="add", args={"a": 2, "b": 3}), None) is True
+
+            # (2) MCP add tool (separate process) computes the sum.
+            r1 = reg.dispatch(ToolCall(tool="add", args={"a": 2, "b": 3}))
+            assert r1.error is None
+            assert r1.data == {"sum": 5}
+
+            # (3) MCP done tool completes the run.
+            r2 = reg.dispatch(ToolCall(tool="done", args={"total": 5}))
+            assert r2.error is None
+            assert r2.data["status"] == "completed"
+            assert r2.data["total"] == 5
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()
+        assert preset.mcp_adapters == []

--- a/tests/test_example_planner_portable_cartridge.py
+++ b/tests/test_example_planner_portable_cartridge.py
@@ -1,0 +1,87 @@
+"""End-to-end dogfood of the fully-portable ``planner_portable`` cartridge.
+
+Cross-runtime twin of ``planner``. Demonstrates that the "plan mode is a
+composition, not a loop feature" story stays fully portable: both the
+parent's and the child's ``done`` tools are served over MCP, the
+``subagent`` builtin is host-provided, and the ``SubagentTaskGuard`` is a
+``kind: lep`` permission hook. No Python tool body is pinned to the host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+_CARTRIDGE = _EXAMPLES / "planner_portable.cartridge"
+_CHILD = _CARTRIDGE / "planner_child.cartridge"
+
+
+def test_planner_portable_static_profile_is_portable() -> None:
+    for root in (_CARTRIDGE, _CHILD):
+        report = analyse_cartridge(root)
+        assert report.profile == "portable", root.name
+        assert report.blockers == (), root.name
+
+
+@pytest.mark.timeout(60)
+def test_planner_portable_cross_process_composition() -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        # done() comes from the MCP server; subagent is a host builtin.
+        assert len(preset.mcp_adapters) == 1
+        assert preset.state_service_handles == []
+        assert "done" in preset.tools.tool_names
+        assert "subagent" in preset.tools.tool_names
+
+        guard = next(
+            h for h in preset.hooks if "SubagentTaskGuard" in getattr(h, "_cartridge_id", "")
+        )
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) LEP guard (separate process) blocks an empty-task subagent
+            #     call and allows a real one.
+            assert (
+                guard.check_permission(ToolCall(tool="subagent", args={"task": "  "}), None)
+                is False
+            )
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="subagent", args={"task": "ship the feature"}), None
+                )
+                is True
+            )
+
+            # (2) MCP done tool (separate process) completes the run.
+            r = preset.tools.dispatch(ToolCall(tool="done", args={"summary": "1. do X\n2. do Y"}))
+            assert r.error is None
+            assert r.data["status"] == "completed"
+            assert r.data["summary"].startswith("1.")
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()
+        assert preset.mcp_adapters == []
+
+
+@pytest.mark.timeout(60)
+def test_planner_portable_child_done_over_mcp() -> None:
+    preset = cartridge_to_preset(_CHILD)
+    try:
+        assert len(preset.mcp_adapters) == 1
+        assert set(preset.tools.tool_names) == {"done"}
+        r = preset.tools.dispatch(ToolCall(tool="done", args={"summary": "1. plan\n2. build"}))
+        assert r.error is None
+        assert r.data["status"] == "completed"
+    finally:
+        preset.close()
+        assert preset.mcp_adapters == []

--- a/tests/test_example_skillful_analyst_portable_cartridge.py
+++ b/tests/test_example_skillful_analyst_portable_cartridge.py
@@ -1,0 +1,113 @@
+"""End-to-end dogfood of the fully-portable ``skillful_analyst_portable``.
+
+Cross-runtime twin of ``skillful_analyst``. The done/read_text/write_text
+tools are served by a bundled MCP stdio server, the WriteScopeGuard is a
+``kind: lep`` permission hook, and the skill system is host-provided
+(``search_skills``/``activate_skill`` builtins + ``skill_activation`` hook
++ the RUNTIME-tier ``skill_manager`` resource). Nothing pins it to Python.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = (
+    Path(__file__).resolve().parent.parent / "examples" / "skillful_analyst_portable.cartridge"
+)
+
+
+def test_skillful_analyst_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # done/read_text/write_text
+    assert "lep" in details  # WriteScopeGuard
+    assert "host-service" in details  # skill_manager (RUNTIME tier)
+
+
+@pytest.mark.timeout(60)
+def test_skillful_analyst_portable_cross_process_composition(tmp_path: Path) -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        assert len(preset.mcp_adapters) == 1
+        assert preset.state_service_handles == []
+        names = set(preset.tools.tool_names)
+        assert {"done", "read_text", "write_text"} <= names
+        # Skill builtins are host-provided.
+        assert {"search_skills", "activate_skill"} <= names
+
+        guard = next(
+            h for h in preset.hooks if "WriteScopeGuard" in getattr(h, "_cartridge_id", "")
+        )
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) LEP WriteScopeGuard (separate process) blocks empty/escaping
+            #     paths, allows an in-scope one.
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="write_text", args={"path": "  ", "content": "x"}),
+                    None,
+                )
+                is False
+            )
+            assert (
+                guard.check_permission(
+                    ToolCall(
+                        tool="write_text",
+                        args={"path": "../escape.txt", "content": "x"},
+                    ),
+                    None,
+                )
+                is False
+            )
+            target = tmp_path / "report.txt"
+            assert (
+                guard.check_permission(
+                    ToolCall(
+                        tool="write_text",
+                        args={"path": str(target), "content": "x"},
+                    ),
+                    None,
+                )
+                is True
+            )
+
+            # (2) MCP write_text then read_text (separate process) round-trip.
+            #     NB: looplet's dispatch strips trailing whitespace from string
+            #     args (same for the original in-process tool), so the content
+            #     here has no trailing newline to begin with.
+            w = preset.tools.dispatch(
+                ToolCall(
+                    tool="write_text",
+                    args={"path": str(target), "content": "hello\nworld"},
+                )
+            )
+            assert w.error is None
+            assert w.data["path"] == str(target)
+            assert target.read_text() == "hello\nworld"
+
+            r = preset.tools.dispatch(ToolCall(tool="read_text", args={"path": str(target)}))
+            assert r.error is None
+            assert r.data["content"] == "hello\nworld"
+            assert r.data["lines"] == 2
+
+            # (3) MCP done completes.
+            d = preset.tools.dispatch(ToolCall(tool="done", args={"summary": "analysed"}))
+            assert d.error is None
+            assert d.data["summary"] == "analysed"
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()
+        assert preset.mcp_adapters == []

--- a/tests/test_example_threat_intel_portable_cartridge.py
+++ b/tests/test_example_threat_intel_portable_cartridge.py
@@ -1,0 +1,143 @@
+"""End-to-end dogfood of the fully-portable ``threat_intel_portable``.
+
+Cross-runtime twin of ``threat_intel``. All 7 tools are served by a
+bundled MCP stdio server, the FeedAllowlistGuard egress policy is a
+``kind: lep`` hook, and compaction is the host-provided RUNTIME-tier
+``compact_service`` resource. Nothing pins it to Python.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import analyse_cartridge, cartridge_to_preset
+from looplet.types import ToolCall
+
+_CARTRIDGE = Path(__file__).resolve().parent.parent / "examples" / "threat_intel_portable.cartridge"
+
+
+def test_threat_intel_portable_static_profile_is_portable() -> None:
+    report = analyse_cartridge(_CARTRIDGE)
+    assert report.profile == "portable"
+    assert report.blockers == ()
+    details = {c.detail for c in report.components}
+    assert "mcp" in details  # all 7 tools
+    assert "lep" in details  # FeedAllowlistGuard
+    assert "host-service" in details  # compact_service (RUNTIME tier)
+
+
+@pytest.mark.timeout(60)
+def test_threat_intel_portable_cross_process_composition() -> None:
+    preset = cartridge_to_preset(_CARTRIDGE)
+    try:
+        assert len(preset.mcp_adapters) == 1
+        assert preset.state_service_handles == []
+        names = set(preset.tools.tool_names)
+        assert {
+            "fetch_feed",
+            "search_cve",
+            "extract_iocs",
+            "map_mitre",
+            "assess_risk",
+            "think",
+            "done",
+        } <= names
+
+        guard = next(
+            h for h in preset.hooks if "FeedAllowlistGuard" in getattr(h, "_cartridge_id", "")
+        )
+        for h in preset.hooks:
+            if hasattr(h, "pre_loop"):
+                h.pre_loop(None, None, None)
+
+        try:
+            # (1) LEP FeedAllowlistGuard (separate process) refuses an
+            #     off-allowlist feed, allows a trusted one.
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="fetch_feed", args={"feed_name": "evil_feed"}),
+                    None,
+                )
+                is False
+            )
+            assert (
+                guard.check_permission(
+                    ToolCall(tool="fetch_feed", args={"feed_name": "cisa_alerts"}),
+                    None,
+                )
+                is True
+            )
+
+            # (2) MCP fetch_feed returns the CISA alerts.
+            ff = preset.tools.dispatch(
+                ToolCall(tool="fetch_feed", args={"feed_name": "cisa_alerts"})
+            )
+            assert ff.error is None
+            assert ff.data["item_count"] == 2
+            assert ff.data["items"][0]["severity"] == "CRITICAL"
+
+            # (3) MCP search_cve finds the Bitwarden CVE.
+            sc = preset.tools.dispatch(
+                ToolCall(tool="search_cve", args={"cve_id": "CVE-2026-3891"})
+            )
+            assert sc.error is None
+            assert sc.data["cvss_v3"] == 9.8
+            assert sc.data["vendor"] == "Bitwarden"
+
+            # (4) MCP extract_iocs (deterministic regex extraction).
+            ei = preset.tools.dispatch(
+                ToolCall(
+                    tool="extract_iocs",
+                    args={
+                        "text": "C2 at update.telecom-infra[.]net and CVE-2026-3891, "
+                        "hash SHA256:deadbeef1234",
+                    },
+                )
+            )
+            assert ei.error is None
+            assert "CVE-2026-3891" in ei.data["cves"]
+            assert ei.data["total_iocs"] >= 2
+            assert "llm_severity" not in ei.data  # degraded in portable twin
+
+            # (5) MCP map_mitre resolves known + unknown techniques.
+            mm = preset.tools.dispatch(
+                ToolCall(tool="map_mitre", args={"technique_ids": "T1557,T9999"})
+            )
+            assert mm.error is None
+            assert mm.data["techniques"]["T1557"]["name"] == "Adversary-in-the-Middle"
+            assert mm.data["techniques"]["T9999"]["name"] == "Unknown"
+
+            # (6) MCP assess_risk degrades to severity-only (no host LLM).
+            ar = preset.tools.dispatch(
+                ToolCall(
+                    tool="assess_risk",
+                    args={
+                        "title": "Bitwarden supply chain",
+                        "severity": "CRITICAL",
+                        "affected_products": "Bitwarden CLI",
+                    },
+                )
+            )
+            assert ar.error is None
+            assert "no LLM" in ar.data["assessment"]
+
+            # (7) think + done round-trip.
+            th = preset.tools.dispatch(
+                ToolCall(tool="think", args={"analysis": "supply chain risk is high"})
+            )
+            assert th.error is None
+            assert th.data["noted"] is True
+
+            done = preset.tools.dispatch(
+                ToolCall(tool="done", args={"summary": "briefing complete"})
+            )
+            assert done.error is None
+            assert done.data["status"] == "completed"
+        finally:
+            for h in preset.hooks:
+                if hasattr(h, "close"):
+                    h.close()
+    finally:
+        preset.close()

--- a/tests/test_portable_llm_parity.py
+++ b/tests/test_portable_llm_parity.py
@@ -1,0 +1,265 @@
+"""LLM parity: portable twins (via the Model Gateway) match the originals.
+
+The three portable twins — ``dep_doctor_portable``, ``threat_intel_portable``,
+``git_detective_portable`` — serve their tools out of process over MCP. The
+LLM-backed tools (``find_alternatives``, ``extract_iocs`` / ``assess_risk``,
+``commit_patterns``) used to *degrade* because an out-of-process server had no
+handle on the host's ``ctx.llm``. The **Model Gateway (MGP)** closes that gap:
+the loader starts a host-resident 1:N socket server, exports
+``LOOPLET_LLM_SOCKET``, and binds the live backend at run time; the MCP server
+connects to it and calls back into the *same* model.
+
+Each test here proves two things against the *same scripted backend*:
+
+1. **Functional + qualitative parity** — with a backend bound to the twin's
+   gateway, the portable tool returns the identical LLM-derived field/value
+   that the in-process original returns when handed the backend via
+   ``ctx.llm``.
+2. **Graceful degradation** — with no backend bound (the load-time default,
+   e.g. a headless dispatch before any run), the portable tool falls back to
+   exactly the ``ctx.llm is None`` branch.
+
+This is the end-to-end dogfood of the new primitive: a real LLM call crosses
+the process boundary (host gateway ← MCP tool subprocess) and comes back.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from looplet.cartridge import cartridge_to_preset
+from looplet.types import ToolCall, ToolContext
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="model gateway requires AF_UNIX sockets",
+)
+
+
+class _ScriptedLLM:
+    """Deterministic backend: returns canned replies in order, records calls.
+
+    Shared by the portable preset (via the gateway) and the in-process
+    original (via ``ctx.llm``) so any divergence is a parity bug, not a
+    backend difference.
+    """
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self.prompts: list[str] = []
+
+    def generate(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        return self._replies.pop(0) if self._replies else "DONE"
+
+
+def _original_ctx(backend):
+    return ToolContext(llm=backend)
+
+
+# ── dep_doctor: find_alternatives ─────────────────────────────
+
+
+@pytest.mark.timeout(60)
+def test_dep_doctor_find_alternatives_parity():
+    reply = '[{"name": "httpx", "reason": "actively maintained async client"}]'
+    portable = cartridge_to_preset(_EXAMPLES / "dep_doctor_portable.cartridge")
+    original = cartridge_to_preset(_EXAMPLES / "dep_doctor.cartridge")
+    try:
+        # The loader started a gateway for the portable twin (it has
+        # mcp_servers); bind a backend exactly as AgentPreset.run would.
+        assert portable.model_gateway is not None, "gateway should auto-start"
+        portable.model_gateway.set_backend(_ScriptedLLM([reply]))
+
+        p = portable.tools.dispatch(
+            ToolCall(tool="find_alternatives", args={"package_name": "requests"})
+        )
+        o = original.tools.dispatch(
+            ToolCall(tool="find_alternatives", args={"package_name": "requests"}),
+            ctx=_original_ctx(_ScriptedLLM([reply])),
+        )
+        assert p.error is None and o.error is None
+        # Identical LLM-derived structure.
+        assert p.data == o.data
+        assert p.data["alternatives"] == [
+            {"name": "httpx", "reason": "actively maintained async client"}
+        ]
+    finally:
+        portable.close()
+        original.close()
+
+
+@pytest.mark.timeout(60)
+def test_dep_doctor_find_alternatives_degrades_without_backend():
+    portable = cartridge_to_preset(_EXAMPLES / "dep_doctor_portable.cartridge")
+    try:
+        # No backend bound (load-time default) → degrade to empty list,
+        # the original's ctx.llm-None branch.
+        p = portable.tools.dispatch(
+            ToolCall(tool="find_alternatives", args={"package_name": "requests"})
+        )
+        assert p.error is None
+        assert p.data == {"package": "requests", "alternatives": []}
+    finally:
+        portable.close()
+
+
+# ── threat_intel: extract_iocs + assess_risk ──────────────────
+
+
+@pytest.mark.timeout(60)
+def test_threat_intel_extract_iocs_severity_parity():
+    text = "C2 at update.telecom-infra[.]net and CVE-2026-3891, hash SHA256:deadbeef1234"
+    portable = cartridge_to_preset(_EXAMPLES / "threat_intel_portable.cartridge")
+    original = cartridge_to_preset(_EXAMPLES / "threat_intel.cartridge")
+    try:
+        assert portable.model_gateway is not None
+        portable.model_gateway.set_backend(_ScriptedLLM(["  high  "]))
+
+        p = portable.tools.dispatch(ToolCall(tool="extract_iocs", args={"text": text}))
+        o = original.tools.dispatch(
+            ToolCall(tool="extract_iocs", args={"text": text}),
+            ctx=_original_ctx(_ScriptedLLM(["  high  "])),
+        )
+        assert p.error is None and o.error is None
+        # The LLM severity field is now present in BOTH, normalised the
+        # same way (.strip().upper()).
+        assert p.data["llm_severity"] == "HIGH"
+        assert o.data["llm_severity"] == "HIGH"
+        # The deterministic IOC payload is identical too.
+        assert p.data["cves"] == o.data["cves"]
+        assert p.data["total_iocs"] == o.data["total_iocs"]
+    finally:
+        portable.close()
+        original.close()
+
+
+@pytest.mark.timeout(60)
+def test_threat_intel_assess_risk_parity():
+    assessment = "PRIORITY: IMMEDIATE. Patch Bitwarden CLI now; credential theft is active."
+    portable = cartridge_to_preset(_EXAMPLES / "threat_intel_portable.cartridge")
+    original = cartridge_to_preset(_EXAMPLES / "threat_intel.cartridge")
+    try:
+        assert portable.model_gateway is not None
+        portable.model_gateway.set_backend(_ScriptedLLM([assessment]))
+
+        args = {
+            "title": "Bitwarden supply chain",
+            "severity": "CRITICAL",
+            "affected_products": "Bitwarden CLI",
+        }
+        p = portable.tools.dispatch(ToolCall(tool="assess_risk", args=args))
+        o = original.tools.dispatch(
+            ToolCall(tool="assess_risk", args=args),
+            ctx=_original_ctx(_ScriptedLLM([assessment])),
+        )
+        assert p.error is None and o.error is None
+        assert p.data == o.data
+        assert p.data["assessment"] == assessment
+        assert "no LLM" not in p.data["assessment"]
+    finally:
+        portable.close()
+        original.close()
+
+
+@pytest.mark.timeout(60)
+def test_threat_intel_degrades_without_backend():
+    portable = cartridge_to_preset(_EXAMPLES / "threat_intel_portable.cartridge")
+    try:
+        ar = portable.tools.dispatch(
+            ToolCall(
+                tool="assess_risk",
+                args={
+                    "title": "x",
+                    "severity": "HIGH",
+                    "affected_products": "y",
+                },
+            )
+        )
+        assert ar.error is None
+        assert "no LLM" in ar.data["assessment"]
+
+        ei = portable.tools.dispatch(ToolCall(tool="extract_iocs", args={"text": "CVE-2026-3891"}))
+        assert ei.error is None
+        assert "llm_severity" not in ei.data
+    finally:
+        portable.close()
+
+
+# ── git_detective: commit_patterns ────────────────────────────
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "Test")
+    (repo / "a.py").write_text("x = 1\n")
+    (repo / "b.py").write_text("y = 2\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: initial")
+    (repo / "a.py").write_text("x = 2\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "fix: bump a")
+    return repo
+
+
+@pytest.mark.timeout(60)
+def test_git_detective_commit_patterns_parity(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    reply = "SCORE: 9/10 Disciplined conventional commits with clear, scoped messages."
+
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(repo))
+    portable = cartridge_to_preset(_EXAMPLES / "git_detective_portable.cartridge")
+    original = cartridge_to_preset(
+        _EXAMPLES / "git_detective.cartridge", runtime={"repo": str(repo)}
+    )
+    try:
+        assert portable.model_gateway is not None
+        portable.model_gateway.set_backend(_ScriptedLLM([reply]))
+
+        p = portable.tools.dispatch(ToolCall(tool="commit_patterns", args={}))
+        o = original.tools.dispatch(
+            ToolCall(tool="commit_patterns", args={}),
+            ctx=_original_ctx(_ScriptedLLM([reply])),
+        )
+        assert p.error is None and o.error is None
+        # The LLM assessment is present in both and identical.
+        assert p.data["commit_quality_assessment"] == reply
+        assert o.data["commit_quality_assessment"] == reply
+        # Deterministic stats match too.
+        assert p.data["conventional_commits_pct"] == o.data["conventional_commits_pct"]
+        assert p.data["total_analyzed"] == o.data["total_analyzed"]
+    finally:
+        portable.close()
+        original.close()
+
+
+@pytest.mark.timeout(60)
+def test_git_detective_commit_patterns_degrades_without_backend(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(repo))
+    portable = cartridge_to_preset(_EXAMPLES / "git_detective_portable.cartridge")
+    try:
+        p = portable.tools.dispatch(ToolCall(tool="commit_patterns", args={}))
+        assert p.error is None
+        assert "commit_quality_assessment" not in p.data
+        assert p.data["conventional_commits_pct"] == 100.0
+    finally:
+        portable.close()


### PR DESCRIPTION
Stacked on #87. Adds a fully-portable cross-runtime twin for each of the 8 example cartridges (coder, dep_doctor, git_detective, hello, mcp_demo, planner, skillful_analyst, threat_intel):

- Each `*_portable.cartridge` reimplements its python-host twin using only protocol surfaces: tools as MCP servers (`_mcp/`), hooks as `kind: lep` out-of-process servers, shared state as state services (`_state/`), compaction/skills via builtin runtime services.
- `looplet portability <twin>` reports **portable** (zero Python-pinned blockers) for every twin.
- Tests: `test_example_*_portable_cartridge.py` (per-cartridge load + portability assertions) and `test_portable_llm_parity.py` (twin produces equivalent behaviour to its python-host original under a scripted backend).

Additive only. Full suite green (2100 passed, 2 skipped); ruff + pyright clean. This is the final PR in the stack; it also un-skips the `hello_portable` assertion added in #87.