### PR TITLE
RPC orchestration glue: honest checkpoint capability + make_backend factory

### DIFF
--- a/src/looplet/backends.py
+++ b/src/looplet/backends.py
@@ -802,3 +802,43 @@ class AsyncAnthropicBackend:
         async with self._client.messages.stream(**kwargs) as stream:
             async for text in stream.text_stream:
                 yield text
+
+
+# ── Turnkey factory for the RPC `set_backend` wire ───────────────────
+
+
+def make_backend(*, provider: str | None = None, model: str | None = None) -> Any:
+    """Build an :class:`LLMBackend` from the environment.
+
+    A module-level factory so a non-Python orchestrator can wire a real
+    backend over the RPC ``set_backend`` command without writing glue::
+
+        {"cmd": "set_backend", "factory": "looplet.backends:make_backend",
+         "kwargs": {"model": "claude-sonnet-4-20250514"}}
+
+    ``provider`` selects the adapter; when omitted it is read from
+    ``LOOPLET_PROVIDER`` and finally auto-detected from whichever API key is
+    present (``ANTHROPIC_API_KEY`` → anthropic, ``OPENAI_API_KEY`` → openai).
+    ``model`` overrides the provider's env/default model.
+
+    Raises ``ValueError`` with an actionable message when no provider can be
+    resolved, so the orchestrator gets a clear ``error`` frame instead of an
+    opaque import failure.
+    """
+    import os
+
+    prov = (
+        provider
+        or os.environ.get("LOOPLET_PROVIDER")
+        or ("anthropic" if os.environ.get("ANTHROPIC_API_KEY") else "")
+        or ("openai" if os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_BASE_URL") else "")
+    ).lower()
+    if prov in ("anthropic", "claude"):
+        return AnthropicBackend.from_env(model=model)
+    if prov in ("openai", "oai"):
+        return OpenAIBackend.from_env(model=model)
+    raise ValueError(
+        "make_backend(): could not resolve a provider. Pass provider='anthropic'|'openai' "
+        "(or kwargs.provider over RPC), set LOOPLET_PROVIDER, or export ANTHROPIC_API_KEY / "
+        "OPENAI_API_KEY (or OPENAI_BASE_URL for a local proxy)."
+    )

--- a/src/looplet/backends.py
+++ b/src/looplet/backends.py
@@ -831,7 +831,11 @@ def make_backend(*, provider: str | None = None, model: str | None = None) -> An
         provider
         or os.environ.get("LOOPLET_PROVIDER")
         or ("anthropic" if os.environ.get("ANTHROPIC_API_KEY") else "")
-        or ("openai" if os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_BASE_URL") else "")
+        or (
+            "openai"
+            if os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_BASE_URL")
+            else ""
+        )
     ).lower()
     if prov in ("anthropic", "claude"):
         return AnthropicBackend.from_env(model=model)

--- a/src/looplet/rpc.py
+++ b/src/looplet/rpc.py
@@ -246,20 +246,26 @@ def _capabilities(preset: Any) -> dict[str, Any]:
     * ``events`` / ``cancel`` — always offered by the RPC server itself
       (every loop emits :class:`~looplet.events.LifecycleEvent`\\ s and
       accepts a cancel token), so they are unconditionally true.
-    * ``checkpoint`` — true when the preset persists checkpoints
-      (``config.checkpoint_dir`` is set).
+    * ``checkpoint`` — always true: like events/cancel it is offered by the
+      RPC server itself. The loop checkpoints *any* run when the caller passes
+      a per-call ``checkpoint_dir`` to ``run``/``resume`` (``config.checkpoint_dir``
+      only sets the auto-default), so an orchestrator must not gate crash-recovery
+      on whether a cartridge happened to set ``checkpoint_dir``.
     * ``cost`` — true when a cost sink is wired.
     * ``permission_authority`` — true when a permission hook (a
       ``PermissionEngine``-backed or LEP hook) is present.
     * ``stop_reasons`` — the frozen termination enum the ``done`` event
       reports.
     """
-    config = getattr(preset, "config", None)
     hooks = getattr(preset, "hooks", None) or []
     return {
         "events": True,
         "cancel": True,
-        "checkpoint": bool(getattr(config, "checkpoint_dir", None)),
+        # A server capability like events/cancel: the loop checkpoints ANY run
+        # given a per-call ``checkpoint_dir`` on run/resume (config.checkpoint_dir
+        # is only the auto-default), so advertise it unconditionally. Gating it on
+        # the cartridge config made orchestrators wrongly skip crash-recovery.
+        "checkpoint": True,
         "cost": _has_cost_sink(preset),
         "permission_authority": _has_permission_authority(hooks),
         "stop_reasons": list(STOP_REASONS),

--- a/tests/test_make_backend.py
+++ b/tests/test_make_backend.py
@@ -13,10 +13,16 @@ from looplet.backends import make_backend
 
 
 def test_make_backend_explicit_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(backends.AnthropicBackend, "from_env",
-                        classmethod(lambda cls, *, model=None: ("anthropic", model)))
-    monkeypatch.setattr(backends.OpenAIBackend, "from_env",
-                        classmethod(lambda cls, *, model=None: ("openai", model)))
+    monkeypatch.setattr(
+        backends.AnthropicBackend,
+        "from_env",
+        classmethod(lambda cls, *, model=None: ("anthropic", model)),
+    )
+    monkeypatch.setattr(
+        backends.OpenAIBackend,
+        "from_env",
+        classmethod(lambda cls, *, model=None: ("openai", model)),
+    )
     assert make_backend(provider="anthropic", model="m1") == ("anthropic", "m1")
     assert make_backend(provider="openai") == ("openai", None)
     # aliases
@@ -24,10 +30,12 @@ def test_make_backend_explicit_provider(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_make_backend_autodetects_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(backends.AnthropicBackend, "from_env",
-                        classmethod(lambda cls, *, model=None: "anthropic"))
-    monkeypatch.setattr(backends.OpenAIBackend, "from_env",
-                        classmethod(lambda cls, *, model=None: "openai"))
+    monkeypatch.setattr(
+        backends.AnthropicBackend, "from_env", classmethod(lambda cls, *, model=None: "anthropic")
+    )
+    monkeypatch.setattr(
+        backends.OpenAIBackend, "from_env", classmethod(lambda cls, *, model=None: "openai")
+    )
     monkeypatch.delenv("LOOPLET_PROVIDER", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")

--- a/tests/test_make_backend.py
+++ b/tests/test_make_backend.py
@@ -1,0 +1,45 @@
+"""Tests for the turnkey ``make_backend`` factory (RPC ``set_backend`` wire).
+
+Monkeypatches the provider ``from_env`` classmethods so no SDK or API key is
+needed — we only assert provider resolution/routing and the error path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from looplet import backends
+from looplet.backends import make_backend
+
+
+def test_make_backend_explicit_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(backends.AnthropicBackend, "from_env",
+                        classmethod(lambda cls, *, model=None: ("anthropic", model)))
+    monkeypatch.setattr(backends.OpenAIBackend, "from_env",
+                        classmethod(lambda cls, *, model=None: ("openai", model)))
+    assert make_backend(provider="anthropic", model="m1") == ("anthropic", "m1")
+    assert make_backend(provider="openai") == ("openai", None)
+    # aliases
+    assert make_backend(provider="claude")[0] == "anthropic"
+
+
+def test_make_backend_autodetects_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(backends.AnthropicBackend, "from_env",
+                        classmethod(lambda cls, *, model=None: "anthropic"))
+    monkeypatch.setattr(backends.OpenAIBackend, "from_env",
+                        classmethod(lambda cls, *, model=None: "openai"))
+    monkeypatch.delenv("LOOPLET_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert make_backend() == "anthropic"
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert make_backend() == "openai"
+
+
+def test_make_backend_no_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("LOOPLET_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ValueError, match="could not resolve a provider"):
+        make_backend()

--- a/tests/test_rpc_capabilities.py
+++ b/tests/test_rpc_capabilities.py
@@ -113,14 +113,14 @@ def test_capabilities_stop_reasons_enum(tmp_path: Path) -> None:
 
 
 def test_plain_cartridge_capability_defaults(tmp_path: Path) -> None:
-    """A vanilla scaffolded cartridge has no permission hook, cost sink,
-    or checkpoint dir — but the server always offers events + cancel."""
+    """A vanilla scaffolded cartridge has no permission hook or cost sink,
+    but the server always offers events + cancel + checkpoint."""
     ws = _scaffold(tmp_path)
     preset = cartridge_to_preset(str(ws), runtime={"workspace": str(tmp_path)})
     caps = _capabilities(preset)
     assert caps["permission_authority"] is False
     assert caps["cost"] is False
-    assert caps["checkpoint"] is False
+    assert caps["checkpoint"] is True
     assert caps["events"] is True
     assert caps["cancel"] is True
 
@@ -160,8 +160,11 @@ def test_cost_true_with_cost_tracker_resource() -> None:
     assert caps["cost"] is True
 
 
-def test_checkpoint_reflects_checkpoint_dir(tmp_path: Path) -> None:
-    assert _capabilities(_FakePreset())["checkpoint"] is False
+def test_checkpoint_is_a_server_capability(tmp_path: Path) -> None:
+    # checkpoint is offered by the RPC server for ANY run (via a per-call
+    # checkpoint_dir on run/resume), so it is advertised unconditionally —
+    # whether or not the cartridge sets config.checkpoint_dir.
+    assert _capabilities(_FakePreset())["checkpoint"] is True
     cfg = LoopConfig(max_steps=5, checkpoint_dir=str(tmp_path))
     assert _capabilities(_FakePreset(config=cfg))["checkpoint"] is True
 


### PR DESCRIPTION
## RPC orchestration glue: honest checkpoint capability + `make_backend` factory

Two small, additive fixes that make a looplet cartridge cleanly drivable over RPC by an external orchestrator (a host that spawns `python -m looplet.rpc`, performs the capability handshake, injects a backend, and streams steps/events back).

- **B1 — honest `checkpoint` capability.** The RPC handshake derived `capabilities.checkpoint` from the cartridge's *load‑time* config, but `run`/`resume` accept a *per‑call* `checkpoint_dir` that works regardless. A host gating crash‑recovery on the advertised capability would needlessly skip it. Now reports `checkpoint: true`, since per‑run `checkpoint_dir` is always supported.
- **G2 — `looplet.backends:make_backend(*, provider=None, model=None)`** — a turnkey, dotted‑path factory the RPC `set_backend` can resolve (auto‑detects the provider from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENAI_BASE_URL`, with a clear error when none is present). Previously every host had to author its own factory module just to inject a real LLM backend over the wire.

### Tests
New `tests/test_make_backend.py` + updated `tests/test_rpc_capabilities.py`; frozen‑surface + RPC suites green on py3.11/3.12/3.13; ruff check + ruff format + pyright clean.
