### PR TITLE
feat(rpc): turnkey keyless proxy backend + protocol stamp

### DIFF
--- a/src/looplet/backends.py
+++ b/src/looplet/backends.py
@@ -841,8 +841,8 @@ def make_backend(*, provider: str | None = None, model: str | None = None) -> An
         return AnthropicBackend.from_env(model=model)
     if prov in ("openai", "oai"):
         return OpenAIBackend.from_env(model=model)
-    # OpenAI-compatible proxy (Copilot proxy / local endpoint) — the path the
-    # looplet-tax README documents. Any host with these set drives over RPC
+    # OpenAI-compatible proxy (Copilot proxy / local endpoint)
+    # Any host with these set drives over RPC
     # with no glue, no provider= needed.
     base = os.environ.get("COPILOT_PROXY_URL") or os.environ.get("LOOPLET_TAX_LLM_BASE_URL")
     key = os.environ.get("COPILOT_PROXY_KEY") or os.environ.get("LOOPLET_TAX_LLM_API_KEY")

--- a/src/looplet/backends.py
+++ b/src/looplet/backends.py
@@ -841,8 +841,35 @@ def make_backend(*, provider: str | None = None, model: str | None = None) -> An
         return AnthropicBackend.from_env(model=model)
     if prov in ("openai", "oai"):
         return OpenAIBackend.from_env(model=model)
+    # OpenAI-compatible proxy (Copilot proxy / local endpoint) — the path the
+    # looplet-tax README documents. Any host with these set drives over RPC
+    # with no glue, no provider= needed.
+    base = os.environ.get("COPILOT_PROXY_URL") or os.environ.get("LOOPLET_TAX_LLM_BASE_URL")
+    key = os.environ.get("COPILOT_PROXY_KEY") or os.environ.get("LOOPLET_TAX_LLM_API_KEY")
+    if prov in ("copilot", "proxy") or base or key:
+        return OpenAIBackend(
+            base_url=base,
+            api_key=key,
+            model=model or os.environ.get("LOOPLET_TAX_LLM_MODEL") or "gpt-4o",
+        )
+    # Keyless fallback (opt-in): a deterministic mock so the RPC path is runnable
+    # on ANY repo/CI without secrets. Off by default so prod fails loud.
+    if os.environ.get("LOOPLET_ALLOW_MOCK", "").lower() in ("1", "true", "yes"):
+        import json  # noqa: PLC0415
+
+        from looplet.testing import MockLLMBackend  # noqa: PLC0415
+
+        return MockLLMBackend(
+            responses=[
+                json.dumps(
+                    {"tool": "done", "args": {"summary": "keyless mock"}, "reasoning": "mock"}
+                )
+            ],
+            cycle=True,
+        )
     raise ValueError(
         "make_backend(): could not resolve a provider. Pass provider='anthropic'|'openai' "
-        "(or kwargs.provider over RPC), set LOOPLET_PROVIDER, or export ANTHROPIC_API_KEY / "
-        "OPENAI_API_KEY (or OPENAI_BASE_URL for a local proxy)."
+        "(or kwargs.provider over RPC), set LOOPLET_PROVIDER, export ANTHROPIC_API_KEY / "
+        "OPENAI_API_KEY (or OPENAI_BASE_URL / COPILOT_PROXY_URL for a proxy), or set "
+        "LOOPLET_ALLOW_MOCK=1 for a keyless deterministic mock."
     )

--- a/src/looplet/rpc.py
+++ b/src/looplet/rpc.py
@@ -161,6 +161,12 @@ class StopReason(str, Enum):
 #: single source of truth the ``done`` event maps onto.
 STOP_REASONS: tuple[str, ...] = tuple(r.value for r in StopReason)
 
+#: RPC contract version, surfaced in the handshake ``capabilities.protocol`` so
+#: an orchestrator can detect a stale/mismatched checkout instead of mis-reading
+#: the API (the dogfood F1: pre-/post-#90 rpc.py differed silently). Bump on any
+#: wire-incompatible change.
+RPC_PROTOCOL_VERSION = "1.0"
+
 # Loop-internal ``stop_reason`` strings that denote step-budget exhaustion
 # (the contract's ``max_steps``) rather than a resource budget. The loop seeds
 # ``stop_reason = "budget_exhausted"`` and leaves it untouched when the
@@ -261,6 +267,9 @@ def _capabilities(preset: Any) -> dict[str, Any]:
     return {
         "events": True,
         "cancel": True,
+        # Contract/version stamp: lets an orchestrator detect a stale checkout
+        # or protocol mismatch from the handshake instead of mis-reading the API.
+        "protocol": RPC_PROTOCOL_VERSION,
         # A server capability like events/cancel: the loop checkpoints ANY run
         # given a per-call ``checkpoint_dir`` on run/resume (config.checkpoint_dir
         # is only the auto-default), so advertise it unconditionally. Gating it on

--- a/tests/test_make_backend_env.py
+++ b/tests/test_make_backend_env.py
@@ -1,0 +1,44 @@
+"""make_backend resolves on any host: copilot/proxy, opt-in keyless mock, or raises."""
+
+from __future__ import annotations
+
+import pytest
+
+from looplet.backends import OpenAIBackend, make_backend
+from looplet.testing import MockLLMBackend
+
+_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "LOOPLET_PROVIDER",
+    "COPILOT_PROXY_URL",
+    "COPILOT_PROXY_KEY",
+    "LOOPLET_TAX_LLM_BASE_URL",
+    "LOOPLET_TAX_LLM_API_KEY",
+    "LOOPLET_ALLOW_MOCK",
+]
+
+
+def _clear(mp: pytest.MonkeyPatch) -> None:
+    for k in _KEYS:
+        mp.delenv(k, raising=False)
+
+
+def test_keyless_mock_when_opted_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear(monkeypatch)
+    monkeypatch.setenv("LOOPLET_ALLOW_MOCK", "1")
+    assert isinstance(make_backend(), MockLLMBackend)
+
+
+def test_copilot_proxy_resolves_to_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear(monkeypatch)
+    monkeypatch.setenv("COPILOT_PROXY_URL", "http://localhost:8080/v1")
+    monkeypatch.setenv("COPILOT_PROXY_KEY", "x")
+    assert isinstance(make_backend(), OpenAIBackend)
+
+
+def test_no_creds_no_mock_raises_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear(monkeypatch)
+    with pytest.raises(ValueError, match="LOOPLET_ALLOW_MOCK"):
+        make_backend()

--- a/tests/test_rpc_capabilities.py
+++ b/tests/test_rpc_capabilities.py
@@ -30,6 +30,7 @@ EXPECTED_KEYS = {
     "cost",
     "permission_authority",
     "stop_reasons",
+    "protocol",
 }
 
 # The frozen stop-reason enum (formalised as a StopReason enum in §1.3).


### PR DESCRIPTION
Remainder of the RPC orchestration-glue epic, split out after #92 (the `make_backend` factory + honest checkpoint capability) was merged.

## What

- **Turnkey keyless proxy backend** — `make_backend` gains an OpenAI-compatible proxy path (`COPILOT_PROXY_*` / `LOOPLET_TAX_LLM_*`) plus an opt-in deterministic mock (`LOOPLET_ALLOW_MOCK`), so any host/CI can drive a cartridge over RPC with **no per-host glue and no secrets**. _(closes G2/F2)_
- **Protocol stamp** — the RPC handshake now stamps `capabilities.protocol = RPC_PROTOCOL_VERSION`, so a stale checkout is detectable over the wire. _(closes F1)_

B1 (checkpoint advertised unconditionally) already shipped in #92.

## Diff

`src/looplet/backends.py` (+26/-2), `src/looplet/rpc.py` (+9), `tests/test_rpc_capabilities.py` (+1), and a new `tests/test_make_backend_env.py` (+35).

## Tests

`pytest tests/test_make_backend.py tests/test_make_backend_env.py tests/test_rpc_capabilities.py` → **17 passed**.
