### PR TITLE
feat(coder): add web_search tool + sharpen the coder system prompt

### DIFF
--- a/examples/coder.cartridge/prompts/system.md
+++ b/examples/coder.cartridge/prompts/system.md
@@ -6,7 +6,7 @@ You are an expert software engineer. You solve tasks by understanding the codeba
 3. READ: read_file on files you need to modify. Understand patterns and conventions.
 4. THINK: use think() when you need to reconsider an approach or compare options.
 5. IMPLEMENT: edit_file or multi_edit for existing files, write_file for new files. Use notebook_edit for .ipynb files.
-6. INSPECT: use git_inspect for git status/diff/recent commits. Use web_fetch for public docs when external context is needed.
+6. INSPECT: use git_inspect for git status/diff/recent commits. Use web_search to find and web_fetch to read public docs when external context is needed.
 7. DELEGATE: use subagent() for bounded investigations or review passes that can return concise findings.
 8. ISOLATE: use worktree() when you need a separate git worktree for an experiment.
 9. TEST: bash to run tests after EVERY change. Read failures. Fix and re-run.
@@ -23,10 +23,16 @@ You are an expert software engineer. You solve tasks by understanding the codeba
 - git_inspect: use for read-only git status/diff/log instead of bash git commands.
 - bash: use relative paths. pytest -xvs for tests (stop on first failure).
 - worktree remove requires explicit confirmation; never remove a worktree unless it was created for this task.
+- Never revert changes you didn't make; if you see unexpected edits, stop and ask. Never `git reset --hard` or `git checkout --` without approval.
 - For bugs: write a failing test FIRST, then fix the code.
 
 ## Code quality
 - Follow existing project style and conventions.
+- Before using a library or API, confirm it already exists in this repo (imports or manifest) — don't assume it's installed.
 - Type hints on function signatures. Docstrings on public functions.
 - Minimal changes. Don't refactor unrelated code.
 - If stuck after 3 attempts: think() to reconsider approach.
+
+## When explaining or designing (not editing)
+
+- Lead with the key decision or insight, be specific and quantify, and name the main tradeoffs.

--- a/examples/coder.cartridge/tools/web_search/execute.py
+++ b/examples/coder.cartridge/tools/web_search/execute.py
@@ -1,0 +1,158 @@
+"""web_search tool — dependency-free web search with pluggable backends.
+
+Mirrors ``web_fetch``'s zero-dependency style: the default backend is
+DuckDuckGo's no-key HTML endpoint, parsed with the standard library so the
+cartridge keeps zero runtime dependencies. If one of the optional API keys
+is present in the environment, that higher-quality backend is used instead
+(checked in this order):
+
+* ``BRAVE_API_KEY``  → Brave Search API
+* ``TAVILY_API_KEY`` → Tavily Search API
+* ``SEARXNG_URL``    → a self-hosted SearXNG instance (JSON API)
+
+Returns ``{"query", "backend", "count", "results": [{"title", "url",
+"snippet"}]}`` on success, or ``{"error": ..., "query": ...}`` on failure.
+The tool only *finds* pages; use ``web_fetch`` to read one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+
+from looplet.types import ToolContext
+
+_UA = "looplet-coder/0.1 (+https://github.com)"
+_TIMEOUT = 20
+
+
+def _clean_ddg_url(href: str | None) -> str:
+    """Resolve DuckDuckGo's ``/l/?uddg=`` redirect wrapper to the real URL."""
+    if not href:
+        return ""
+    if href.startswith("//"):
+        href = "https:" + href
+    parsed = urllib.parse.urlparse(href)
+    if "duckduckgo.com" in parsed.netloc and parsed.path.startswith("/l/"):
+        qs = urllib.parse.parse_qs(parsed.query)
+        if "uddg" in qs:
+            return qs["uddg"][0]
+    return href
+
+
+class _DDGParser(HTMLParser):
+    """Extract result links and snippets from DuckDuckGo's HTML endpoint."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[dict] = []
+        self._mode: str | None = None  # "title" | "snippet"
+        self._href: str | None = None
+        self._buf: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        attr = dict(attrs)
+        cls = attr.get("class") or ""
+        if "result__a" in cls:
+            self._mode = "title"
+            self._href = attr.get("href")
+            self._buf = []
+        elif "result__snippet" in cls:
+            self._mode = "snippet"
+            self._buf = []
+
+    def handle_data(self, data: str) -> None:
+        if self._mode:
+            self._buf.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "a" or self._mode is None:
+            return
+        text = " ".join("".join(self._buf).split())
+        if self._mode == "title":
+            self.results.append({"title": text, "url": _clean_ddg_url(self._href), "snippet": ""})
+        elif self._mode == "snippet" and self.results:
+            self.results[-1]["snippet"] = text
+        self._mode = None
+        self._buf = []
+
+
+def _get(url: str, *, headers: dict | None = None, data: bytes | None = None) -> str:
+    request = urllib.request.Request(url, data=data, headers={"User-Agent": _UA, **(headers or {})})
+    with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _search_duckduckgo(query: str, max_results: int) -> list[dict]:
+    body = urllib.parse.urlencode({"q": query}).encode()
+    html = _get("https://html.duckduckgo.com/html/", data=body)
+    parser = _DDGParser()
+    parser.feed(html)
+    out = [r for r in parser.results if r["url"]]
+    return out[:max_results]
+
+
+def _search_brave(query: str, max_results: int, key: str) -> list[dict]:
+    url = "https://api.search.brave.com/res/v1/web/search?" + urllib.parse.urlencode(
+        {"q": query, "count": max_results}
+    )
+    raw = _get(url, headers={"Accept": "application/json", "X-Subscription-Token": key})
+    data = json.loads(raw)
+    return [
+        {"title": r.get("title", ""), "url": r.get("url", ""), "snippet": r.get("description", "")}
+        for r in data.get("web", {}).get("results", [])[:max_results]
+    ]
+
+
+def _search_tavily(query: str, max_results: int, key: str) -> list[dict]:
+    payload = json.dumps({"api_key": key, "query": query, "max_results": max_results}).encode()
+    raw = _get(
+        "https://api.tavily.com/search", headers={"Content-Type": "application/json"}, data=payload
+    )
+    data = json.loads(raw)
+    return [
+        {"title": r.get("title", ""), "url": r.get("url", ""), "snippet": r.get("content", "")}
+        for r in data.get("results", [])[:max_results]
+    ]
+
+
+def _search_searxng(query: str, max_results: int, base: str) -> list[dict]:
+    url = base.rstrip("/") + "/search?" + urllib.parse.urlencode({"q": query, "format": "json"})
+    data = json.loads(_get(url))
+    return [
+        {"title": r.get("title", ""), "url": r.get("url", ""), "snippet": r.get("content", "")}
+        for r in data.get("results", [])[:max_results]
+    ]
+
+
+def execute(ctx: ToolContext | None, *, query: str, max_results: int = 5) -> dict:
+    query = (query or "").strip()
+    if not query:
+        return {"error": "web_search requires a non-empty query", "query": query}
+    n = max(1, min(int(max_results or 5), 20))
+
+    if os.environ.get("BRAVE_API_KEY"):
+        backend, run = "brave", lambda: _search_brave(query, n, os.environ["BRAVE_API_KEY"])
+    elif os.environ.get("TAVILY_API_KEY"):
+        backend, run = "tavily", lambda: _search_tavily(query, n, os.environ["TAVILY_API_KEY"])
+    elif os.environ.get("SEARXNG_URL"):
+        backend, run = "searxng", lambda: _search_searxng(query, n, os.environ["SEARXNG_URL"])
+    else:
+        backend, run = "duckduckgo", lambda: _search_duckduckgo(query, n)
+
+    try:
+        results = run()
+    except urllib.error.HTTPError as exc:
+        return {"error": f"HTTP {exc.code}: {exc.reason}", "query": query, "backend": backend}
+    except urllib.error.URLError as exc:
+        return {"error": f"Search failed: {exc.reason}", "query": query, "backend": backend}
+    except (json.JSONDecodeError, ValueError) as exc:
+        return {"error": f"Bad response from {backend}: {exc}", "query": query, "backend": backend}
+
+    return {"query": query, "backend": backend, "count": len(results), "results": results}

--- a/examples/coder.cartridge/tools/web_search/tool.yaml
+++ b/examples/coder.cartridge/tools/web_search/tool.yaml
@@ -1,0 +1,22 @@
+name: web_search
+description: |-
+  Search the web and return a ranked list of results (title, URL, snippet). Dependency-free; uses DuckDuckGo by default (no API key required).
+
+  Usage:
+  - Use this to FIND the right page before `web_fetch` reads it: search, pick the best result, then `web_fetch` its URL.
+  - Good for locating documentation, changelogs, issue threads, error messages, or specs when you don't already have the URL.
+  - Returns a ranked list only; it does NOT return full page contents (use `web_fetch` for that).
+  - Backend is auto-selected: DuckDuckGo (default, no key). If set in the environment, `BRAVE_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_URL` is used instead for higher-quality results.
+
+  Examples:
+  - `web_search(query="python pathlib read_text encoding argument")`
+  - `web_search(query="fastapi background tasks documentation", max_results=8)`
+parameters:
+  query:
+    type: string
+    description: The search query.
+  max_results:
+    type: integer
+    description: Maximum number of results to return.
+    default: 5
+concurrent_safe: true

--- a/tests/test_cartridge.py
+++ b/tests/test_cartridge.py
@@ -517,6 +517,7 @@ def test_coder_workspace_loads_with_shared_filecache(tmp_path) -> None:
         "think",
         "todo",
         "web_fetch",
+        "web_search",
         "worktree",
         "write_file",
     ]
@@ -794,6 +795,7 @@ def test_coder_workspace_bidirectional_round_trip(tmp_path) -> None:
         "think",
         "todo",
         "web_fetch",
+        "web_search",
         "worktree",
         "write_file",
     ]


### PR DESCRIPTION
## What

Two small, additive improvements to `examples/coder.cartridge`, validated by
the coder-vs-agents benchmark in **#94**:

1. **A zero-dependency `web_search` tool.** looplet's coder already had
   `web_fetch` (read a URL) but no way to *find* one — the only web gap versus
   Claude Code / Codex. This adds `tools/web_search/`, mirroring `web_fetch`'s
   style: **DuckDuckGo by default (no API key)**, parsed with the same stdlib
   `HTMLParser` (decoding DDG's `/l/?uddg=` redirect), with optional
   higher-quality backends auto-selected from `BRAVE_API_KEY`,
   `TAVILY_API_KEY`, or `SEARXNG_URL`. It returns ranked `{title, url,
   snippet}`; `web_fetch` then reads the chosen page. Guidance lives in the
   tool description, so the prompt doesn't grow for it.

2. **Four targeted `prompts/system.md` lines (no bloat).**
   - INSPECT step mentions `web_search` alongside `web_fetch`.
   - Repo-safety: never revert changes you didn't make; no `git reset --hard`
     / `checkout --` without approval.
   - Accuracy: confirm a library/API exists in the repo before using it.
   - One answer-quality line for design/explanation responses ("lead with the
     key decision, be specific and quantify, name the main tradeoffs").

## Why these specific lines

In the non-coding suite (#94, blind LLM judge, same model), the single
answer-quality line **closed ~62% of the quality gap** vs Copilot (looplet
17.2 → 18.0 / 20). A follow-up experiment adding *more* analytical-depth
prose + a `think()` nudge did **not** help and slightly regressed — so this PR
deliberately stops at the four lines that earned their keep. The coder prompt
stays ~600 tokens.

## Verification

- `ruff check` / `ruff format` clean.
- `cartridge_to_preset` registers `web_search` (17 tools); live DuckDuckGo
  search returns real results.

Independent of #94 (that PR is the benchmark + reports; this is the product
change it justified).
