### PR TITLE
docs: refresh website and task guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,8 +39,8 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.12" }
 
-      - name: Install mkdocs
-        run: pip install mkdocs-material
+      - name: Install docs dependencies
+        run: pip install -r docs/requirements.txt
 
       - name: Build
         # docs/index.md is committed directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Task-oriented documentation.** New guides cover installation, migration
+  from a private tool loop, troubleshooting, experiment selection, runtime
+  operations, the CLI and Python API surfaces, and saved artifact layouts.
+
+### Changed
+
+- **Documentation front door and navigation.** The site now routes readers by
+  task, uses the custom domain as its canonical URL, preserves the
+  network-free regression proof as the primary demonstration, and adopts a
+  restrained engineering-focused visual system.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 **Test-driven harness engineering for Python agents.**
 
+<!-- markdownlint-disable-next-line MD026 -->
 ## Own the loop. Test every change.
 
 Looplet is for teams building a tool-calling agent that is fundamentally
@@ -30,10 +31,10 @@ flowchart LR
     E --> G[pytest / CI]
 ```
 
-[Documentation](https://hsaghir.github.io/looplet/) ·
-[Why Looplet](https://hsaghir.github.io/looplet/why-looplet/) ·
-[Failure → regression proof](https://hsaghir.github.io/looplet/regression-demo/) ·
-[Evals](https://hsaghir.github.io/looplet/evals/)
+[Documentation](https://hsaghir.com/looplet/) ·
+[Why Looplet](https://hsaghir.com/looplet/why-looplet/) ·
+[Failure → regression proof](https://hsaghir.com/looplet/regression-demo/) ·
+[Evals](https://hsaghir.com/looplet/evals/)
 
 ---
 
@@ -71,7 +72,7 @@ executes again.
 > Captured model responses are held constant. Tools, clocks, networks, and other
 > side effects are fresh unless you isolate or mock them.
 
-Read the [walkthrough](https://hsaghir.github.io/looplet/regression-demo/) or inspect the
+Read the [walkthrough](https://hsaghir.com/looplet/regression-demo/) or inspect the
 [source](https://github.com/hsaghir/looplet/tree/master/examples/regression_demo).
 
 ---
@@ -134,7 +135,7 @@ For a zero-network first run:
 python -m looplet.examples.hello_world --scripted
 ```
 
-Continue with the [quickstart](https://hsaghir.github.io/looplet/quickstart/).
+Continue with the [quickstart](https://hsaghir.com/looplet/quickstart/).
 
 ---
 
@@ -172,9 +173,9 @@ The prompt, tool, hook, and self-test change live next to the behavioral
 contract they affect. A promotion holdout belongs in a separate host-owned
 runner and requires an isolation boundary outside candidate authority.
 
-See the [cartridge guide](https://hsaghir.github.io/looplet/cartridge/). If a brief is a useful
+See the [cartridge guide](https://hsaghir.com/looplet/cartridge/). If a brief is a useful
 starting point, `looplet new` can scaffold a cartridge. The
-[agent factory](https://hsaghir.github.io/looplet/agent-factory/) is onboarding, not the product
+[agent factory](https://hsaghir.com/looplet/agent-factory/) is onboarding, not the product
 boundary, so review and test what it writes.
 
 ---
@@ -219,7 +220,7 @@ self-tests; a promotion oracle must stay in a host-owned runner and out of the
 candidate task, runtime, resources, tools, and writable files. Arbitrary
 candidate code requires OS or process isolation.
 
-Read [behavioral evals](https://hsaghir.github.io/looplet/evals/).
+Read [behavioral evals](https://hsaghir.com/looplet/evals/).
 
 ---
 
@@ -242,7 +243,7 @@ Use something else when:
 
 Looplet can run inside a workflow engine and export to observability
 services. It does not try to become either one. See the
-[selection guide](https://hsaghir.github.io/looplet/why-looplet/) and [FAQ](https://hsaghir.github.io/looplet/faq/).
+[selection guide](https://hsaghir.com/looplet/why-looplet/) and [FAQ](https://hsaghir.com/looplet/faq/).
 
 ## Shipped examples
 
@@ -254,21 +255,26 @@ services. It does not try to become either one. See the
 - [`regression_demo`](https://github.com/hsaghir/looplet/tree/master/examples/regression_demo): scripted, network-free captured-response replay and eval proof.
 
 Portable twins demonstrate MCP/LEP boundaries where needed; see
-[portability](https://hsaghir.github.io/looplet/portability/) for the exact supported tiers rather
+[portability](https://hsaghir.com/looplet/portability/) for the exact supported tiers rather
 than a blanket runtime-agnostic claim.
 
 ## Documentation
 
 | Start here | Purpose |
 | --- | --- |
-| [Why Looplet](https://hsaghir.github.io/looplet/why-looplet/) | Category, fit, tradeoffs, and boundaries |
-| [Quickstart](https://hsaghir.github.io/looplet/quickstart/) | Build, capture, and test a first loop |
-| [Failure → regression](https://hsaghir.github.io/looplet/regression-demo/) | Run the core claim without a model or network |
-| [Cartridges](https://hsaghir.github.io/looplet/cartridge/) | Reviewable harness layout and round-trip behavior |
-| [Provenance](https://hsaghir.github.io/looplet/provenance/) | Capture and captured-response replay |
-| [Evals](https://hsaghir.github.io/looplet/evals/) | Outcome collectors, grader-only data, trust boundaries, pytest, and CI |
-| [Hooks](https://hsaghir.github.io/looplet/hooks/) | Lifecycle interception and composition |
-| [FAQ](https://hsaghir.github.io/looplet/faq/) | Selection guidance and honest limitations |
+| [Install and configure](https://hsaghir.com/looplet/install/) | Provider extras, environment setup, and network-free verification |
+| [Why Looplet](https://hsaghir.com/looplet/why-looplet/) | Category, fit, tradeoffs, and boundaries |
+| [Quickstart](https://hsaghir.com/looplet/quickstart/) | Build, capture, and test a first loop |
+| [Migrate an existing loop](https://hsaghir.com/looplet/migrate/) | Adopt the loop boundary without rewriting tools or changing providers |
+| [Failure → regression](https://hsaghir.com/looplet/regression-demo/) | Run the core claim without a model or network |
+| [Choose an experiment](https://hsaghir.com/looplet/experiments/) | Decide between replay, scripted backends, sandboxes, and fresh samples |
+| [Cartridges](https://hsaghir.com/looplet/cartridge/) | Reviewable harness layout and round-trip behavior |
+| [Provenance](https://hsaghir.com/looplet/provenance/) | Capture and captured-response replay |
+| [Evals](https://hsaghir.com/looplet/evals/) | Outcome collectors, grader-only data, trust boundaries, pytest, and CI |
+| [Hooks](https://hsaghir.com/looplet/hooks/) | Lifecycle interception and composition |
+| [Runtime operations](https://hsaghir.com/looplet/operations/) | Async loops, retries, compaction, permissions, events, metrics, and checkpoints |
+| [CLI](https://hsaghir.com/looplet/cli/) · [Python API](https://hsaghir.com/looplet/api/) · [Artifacts](https://hsaghir.com/looplet/artifacts/) | Command, interface, and saved-evidence references |
+| [FAQ](https://hsaghir.com/looplet/faq/) | Selection guidance and honest limitations |
 | [Roadmap](https://github.com/hsaghir/looplet/blob/master/ROADMAP.md) | Core boundaries and explicit non-goals |
 
 ## Stability

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,9 +82,10 @@ Planned work:
 - improve errors for invalid required graders, malformed bundles, and unsafe
   case paths;
 - make persisted eval runs easy to inspect and attach to pull requests;
-- document clear choices between replay, mocks, and fresh model sampling;
-- publish migration recipes for teams replacing a private raw loop without
-  rewriting their tools.
+- keep the replay, mock, sandbox, and fresh-sampling decision guide aligned
+  with the supported evidence formats;
+- expand the migration guide with verified recipes for teams replacing a
+  private raw loop without rewriting their tools.
 
 ## Priority 2: behavioral contract ergonomics
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,198 @@
+# Python API map
+
+Looplet exposes a small execution core and several optional layers around it.
+This page is a curated map for choosing the right surface. It is not a dump of
+every exported helper.
+
+Most applications should begin with imports from `looplet`:
+
+```python
+from looplet import composable_loop, tool, tools_from
+```
+
+Provider-specific, streaming, and lower-level compatibility APIs may live in
+their defining submodule. The package-level `looplet.__all__` is the canonical
+list of re-exported names for a given release.
+
+## Execution core
+
+| API | Use it for |
+| --- | --- |
+| `composable_loop(...)` | Synchronous iterator-first tool loop that yields one `Step` per dispatch. |
+| `async_composable_loop(...)` | Async generator with the same loop contract. |
+| `LoopConfig` | Runtime limits, prompt settings, native tools, compaction, checkpointing, cancellation, and related policy. |
+| `LoopContext` | Host context made available to loop and tool execution. |
+| `DefaultState` | Default mutable loop state. Supply a compatible custom state when the domain needs more fields. |
+| `Step` | One parsed tool call and its result, timing, classification, and related metadata. |
+| `ToolCall` / `ToolResult` | Typed call and result records used by registries, hooks, and tests. |
+
+The loop accepts explicit dependencies and returns control after each
+dispatch:
+
+```python
+for step in composable_loop(
+    llm=llm,
+    tools=tools,
+    task={"goal": "Inspect the repository and report one risk."},
+    hooks=hooks,
+    config=LoopConfig(max_steps=8),
+):
+    route(step)
+```
+
+Use `async for` with `async_composable_loop()`. Do not run the synchronous
+generator in an async request handler when provider calls or tools may block
+the event loop. See [runtime operations](operations.md#asynchronous-loops).
+
+## Tools
+
+| API | Use it for |
+| --- | --- |
+| `@tool(...)` | Build a `ToolSpec` from an ordinary typed callable. |
+| `tools_from([...])` | Create a registry from tool specs and optionally add the standard `done` tool. |
+| `ToolSpec` | Inspect or construct a tool name, description, schema, and implementation explicitly. |
+| `BaseToolRegistry` | Register, validate, look up, and dispatch tools. |
+| `register_done_tool(...)` | Add the completion tool to a custom registry. |
+| `ToolContext` | Access host resources, workspace details, cancellation, progress, and the selected backend inside a tool. |
+| `ToolError` / `ToolValidationError` | Return or test structured failures without parsing exception text. |
+
+Prefer explicit schemas for public or high-risk tools. Decorator inference is
+convenient, but a release contract should still test required fields, invalid
+arguments, and side effects.
+
+## Backends
+
+| API | Import | Notes |
+| --- | --- | --- |
+| `OpenAIBackend` | `from looplet import OpenAIBackend` | Sync OpenAI and OpenAI-compatible adapter with native tool support. |
+| `AnthropicBackend` | `from looplet import AnthropicBackend` | Sync Anthropic adapter with native tool support. |
+| `AsyncOpenAIBackend` | `from looplet.backends import AsyncOpenAIBackend` | Async OpenAI-compatible adapter. |
+| `OpenAIStreamingBackend` | `from looplet.backends import OpenAIStreamingBackend` | OpenAI adapter exposing token chunks. |
+| `LLMBackend` | `from looplet import LLMBackend` | Runtime-checkable shape for custom synchronous backends. |
+| `ResilientBackend` | `from looplet import ResilientBackend` | Sync retry, backoff, and caller-side timeout wrapper. |
+
+Install provider extras separately. See [install and configure](install.md).
+
+`ResilientBackend` is synchronous. Its timeout abandons a daemon worker from
+the caller's perspective; it cannot guarantee that a provider SDK cancels the
+underlying socket operation. Configure provider-level timeouts too.
+
+## Hook decisions
+
+Hooks are duck-typed objects. Implement only the lifecycle methods the policy
+needs. Return values are normalized through these decisions:
+
+| Decision | Meaning |
+| --- | --- |
+| `Continue()` | Proceed without changing the current operation. |
+| `Allow()` / `Deny(reason)` | Resolve a permission boundary. |
+| `Block(reason)` | Reject completion or another gated transition with feedback. |
+| `Stop(reason)` | Terminate the loop with an explicit stop reason. |
+| `InjectContext(text)` | Add host context to a subsequent prompt. |
+| `RewriteThread(...)` | Apply a declarative thread or metadata rewrite. |
+
+`HookDecision` is the underlying normalized form. The convenience constructors
+make intent easier to review. The [hook guide](hooks.md) documents lifecycle
+order, method signatures, composition, and error handling.
+
+## Cartridges and presets
+
+| API | Use it for |
+| --- | --- |
+| `AgentPreset` | In-memory composition of backend-independent harness pieces. |
+| `Cartridge` / `CartridgeLayout` | Parsed file-native harness and its paths. |
+| `cartridge_to_preset(...)` | Load a cartridge into the same preset used by Python callers. |
+| `preset_to_cartridge(...)` | Write a supported preset surface as reviewable files. |
+| `scaffold_cartridge(...)` | Create the initial cartridge structure programmatically. |
+| `resource_ref_for(...)` | Resolve a host resource reference during round-trip serialization. |
+
+Use a cartridge when prompts, tools, hooks, resources, and self-tests benefit
+from one review and distribution unit. It is optional. Read
+[cartridges](cartridge.md) for schema, inheritance, references, and trust
+boundaries.
+
+## Evidence and replay
+
+| API | Use it for |
+| --- | --- |
+| `ProvenanceSink` | Capture model calls and trajectory records into readable files. |
+| `TrajectoryRecorder` | Record step-level trajectory evidence directly. |
+| `replay_loop(...)` | Feed captured model responses through fresh harness execution. |
+| `serialize_harness(...)` | Preserve a reviewable snapshot of the active harness. |
+
+Replay fixes recorded model responses only. It does not freeze tools, clocks,
+networks, state, permissions, or randomness. Start with
+[capture and replay](provenance.md), then use the
+[experiment guide](experiments.md) to choose the right control.
+
+## Behavioral evals
+
+| API | Use it for |
+| --- | --- |
+| `EvalCase` | Task input, grader-only expected data, marks, and notes. |
+| `EvalContext` | Final output, observed artifacts, steps, stop reason, and grader task view. |
+| `EvalResult` | Normalized score, label, metrics, and error information. |
+| `EvalHook` | Collect and score at the end of a live loop. |
+| `eval_discover(...)` | Find locally defined `eval_*` functions. |
+| `eval_run(...)` / `eval_run_batch(...)` | Execute graders for one or many contexts. |
+| `eval_mark(...)` | Attach selection marks such as `required`, `smoke`, or `slow`. |
+| `load_cases(...)` / `save_case(...)` | Read and write JSON case corpora. |
+| `parametrize_cases(...)` | Turn case files into ordinary pytest parameters. |
+| `assert_evals_pass(...)` | Run discovered graders and raise one useful assertion on failure. |
+| `run_cartridge_evals(...)` | Execute a cartridge's cases, collectors, and graders end to end. |
+| `save_eval_run(...)` / `load_eval_run(...)` | Persist and restore one self-contained eval record. |
+
+Required graders fail closed when skipped, errored, or below the pass boundary.
+Collector errors are explicit results rather than silent missing evidence. See
+[behavioral evals](evals.md).
+
+## Runtime controls
+
+| Concern | Primary API |
+| --- | --- |
+| Context pressure | `ContextBudget`, `ThresholdCompactHook`, `DefaultCompactService` |
+| Deterministic truncation | `TruncateCompact` |
+| Model-assisted summary | `SummarizeCompact` |
+| Large tool payloads | `PruneToolResults` |
+| Permissions | `PermissionEngine`, `PermissionRule`, `PermissionHook` |
+| Human approval boundary | `ApprovalHook` |
+| Repeated actions | `StagnationHook` |
+| Step budget warnings | `BudgetWarningHook` |
+| Per-tool call caps | `PerToolLimitHook` |
+| Cooperative cancellation | `CancelToken` |
+| JSON checkpoints | `FileCheckpointStore` and `LoopConfig.checkpoint_dir` |
+| Spans and aggregate metrics | `Tracer`, `TracingHook`, `MetricsCollector`, `MetricsHook` |
+| Typed live events | `StreamingHook` and emitters from `looplet.streaming` |
+
+These controls are opt-in. Add one because an observed failure or operational
+requirement justifies it, then test that boundary. See
+[runtime operations](operations.md).
+
+## Testing helpers
+
+`MockLLMBackend` and `AsyncMockLLMBackend` return scripted responses without a
+network. `LLMResponsesExhausted` makes missing scripted responses explicit.
+Use them for deterministic harness mechanics, not as evidence that a real
+model will choose the same actions.
+
+```python
+from looplet.testing import MockLLMBackend
+
+llm = MockLLMBackend(responses=[first_tool_call, done_call])
+```
+
+## Specialized surfaces
+
+Looplet also exports bundle and blueprint analysis, MCP tools, native-tool
+probing, state and model gateway clients, memory sources, skills, and preset
+helpers. These support cartridge portability, factory output, and advanced
+host integrations. Start from their task guide rather than selecting them by
+name:
+
+- [Skills and bundles](skills.md)
+- [Agent factory](agent-factory.md)
+- [Portability](portability.md)
+- [Recipes](recipes.md)
+
+Before `1.0`, minor releases may revise public APIs. Pin the minor line and
+review the [changelog](changelog.md) when upgrading.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,196 @@
+# Saved artifact reference
+
+Looplet writes ordinary text and JSON so a run can be reviewed without a
+proprietary viewer. This page identifies each file, who should own it, and
+which reader to use.
+
+Saved run directories are evidence, not harmless logs. They can contain full
+prompts, tool schemas, model responses, task data, filesystem observations,
+and grader expectations.
+
+## Provenance trace
+
+`ProvenanceSink` combines model-call capture with step-level trajectory
+capture:
+
+```text
+traces/run-42/
+├── trajectory.json
+├── steps/
+│   ├── step_00.json
+│   └── step_01.json
+├── manifest.jsonl
+├── call_00_prompt.txt
+├── call_00_response.txt
+├── call_01_prompt.txt
+└── call_01_response.txt
+```
+
+| Path | Contents | Primary reader |
+| --- | --- | --- |
+| `trajectory.json` | Run metadata, task view, steps, stop reason, timing, and captured context. | `EvalContext.from_trajectory_dir()` or JSON tooling |
+| `steps/step_NN.json` | One review-friendly copy of each step record. | Humans, diffs, JSON tooling |
+| `manifest.jsonl` | One structured summary per model call. | `looplet show`, replay loader, line-oriented tooling |
+| `call_NN_prompt.txt` | Exact recorded system prompt, user prompt, tool schemas, and call settings. | Humans and replay diagnostics |
+| `call_NN_response.txt` | Exact recorded model response or captured error. | Replay loader and humans |
+
+Create and inspect a trace:
+
+```python
+from looplet import ProvenanceSink
+
+
+sink = ProvenanceSink(dir="traces/run-42", redact=scrub_secrets)
+recorded_llm = sink.wrap_llm(llm)
+
+for step in composable_loop(
+    llm=recorded_llm,
+    tools=tools,
+    hooks=[sink.trajectory_hook()],
+    task=task,
+):
+    route(step)
+
+sink.flush()
+```
+
+```bash
+looplet show traces/run-42
+```
+
+The prompt and response text files are deliberately readable. Do not publish
+them without inspection and redaction.
+
+## Persisted eval run
+
+`save_eval_run()` and `looplet eval run --out` add independent outcome data,
+grader results, and case identity to the trajectory:
+
+```text
+eval-runs/regression-42/
+├── trajectory.json
+├── steps/
+├── manifest.jsonl              # when a recording backend was attached
+├── call_NN_prompt.txt          # when model calls were recorded
+├── call_NN_response.txt
+├── artifacts.json
+├── evals.json
+├── expected.json               # when the case has expectations
+└── case.json                   # when the case was supplied
+```
+
+| Path | Contents | Trust role |
+| --- | --- | --- |
+| `artifacts.json` | Collector-observed world state used by graders. | Host observation |
+| `evals.json` | Normalized grader scores, labels, metrics, and errors. | Decision evidence |
+| `expected.json` | Grader-only expected data restored into `ctx.task["expected"]` after the run. | Promotion oracle input |
+| `case.json` | The source case: id, task, expected data, marks, and notes. | Corpus identity and review |
+
+Load the complete record through the supported reader:
+
+```python
+from looplet import load_eval_run
+
+
+record = load_eval_run("eval-runs/regression-42")
+print(record.context.artifacts)
+print([result.pretty() for result in record.results])
+print(record.case.id if record.case else "no case metadata")
+```
+
+A missing `trajectory.json` or malformed JSON fails loudly. Collector errors
+remain explicit eval results rather than disappearing as absent data.
+
+### Agent-visible and grader-only data
+
+During a cartridge eval, only `case.task` is sent to the agent. The top-level
+`case.expected` object is withheld, persisted separately as `expected.json`,
+and restored for graders after execution.
+
+That separation prevents accidental prompt leakage. It is not a security
+sandbox. Candidate code running with the same filesystem or process authority
+may still inspect runner files or memory. Keep promotion cases, expected data,
+collectors, graders, and capabilities in a host-owned runner, and use OS or
+process isolation for untrusted candidates.
+
+## Checkpoints
+
+`LoopConfig(checkpoint_dir=...)` writes one JSON checkpoint per completed step:
+
+```text
+.looplet/checkpoints/task-42/
+├── step_1.json
+├── step_2.json
+└── step_3.json
+```
+
+A checkpoint stores the step number, session log, conversation, selected
+configuration fields, tool-result store, metadata, and creation timestamp.
+When the same checkpoint directory is used again and `initial_checkpoint` is
+unset, Looplet resumes the highest-step valid checkpoint.
+
+Checkpoints are recovery state, not provenance or eval evidence. Use a unique
+directory per logical task and apply the same access and retention policy as
+traces.
+
+## Legacy compatibility inputs
+
+`EvalContext.from_trajectory_dir()` can read selected top-level fields from a
+legacy `metrics.json` used by older benchmark traces. New eval runs should
+write collector output to `artifacts.json` and top-level case expectations to
+`expected.json`. Do not create new dependencies on the legacy convention.
+
+## Compatibility policy
+
+The cartridge format has its own schema version. Saved provenance and eval
+run directories in `0.3` do not yet declare a separate stable artifact schema
+version.
+
+For automation:
+
+1. pin the Looplet minor line;
+2. prefer `load_eval_run()` and `EvalContext.from_trajectory_dir()` over
+   reconstructing dataclasses from JSON fields;
+3. tolerate additional object fields when consuming JSON;
+4. fail on missing required evidence rather than substituting success;
+5. preserve the producing Looplet version and cartridge hash beside exported
+   artifacts;
+6. review the changelog before upgrading the reader or producer.
+
+The roadmap includes explicit schema-version and compatibility guarantees for
+saved evidence. Until those land, readable files aid review and portability
+but are not a frozen cross-version wire contract.
+
+## Redaction and retention
+
+Use `ProvenanceSink(redact=...)` to transform persisted prompt and result text.
+By default, the sink also applies the redactor before forwarding captured
+content upstream. Verify that behavior against the application's privacy
+requirements rather than assuming storage-only redaction.
+
+A production policy should state:
+
+- which prompts, responses, tool results, and task fields may be retained;
+- which values are removed before provider calls and before disk writes;
+- who can read traces, eval expectations, and checkpoints;
+- how long each artifact type is retained;
+- whether CI artifacts cross repository or organizational boundaries;
+- how deletion requests and incident response apply to saved runs.
+
+Never place credentials in case files, command arguments, or grader notes.
+Do not upload unreviewed traces to a public issue.
+
+## Which artifact should I use?
+
+| Need | Artifact |
+| --- | --- |
+| Inspect what the model saw and returned | Provenance trace |
+| Re-execute recorded responses through changed harness code | Provenance trace with recorded calls |
+| Re-grade an observed product outcome | Persisted eval run |
+| Review one step in a pull request | `steps/step_NN.json` |
+| Resume an interrupted logical task | Checkpoint directory |
+| Compare prompt or model quality | Fresh sampled runs plus persisted eval records |
+
+Read [capture and replay](provenance.md) for execution semantics,
+[behavioral evals](evals.md) for graders and cases, and
+[experiment design](experiments.md) before choosing replay as a control.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Task-oriented documentation.** New guides cover installation, migration
+  from a private tool loop, troubleshooting, experiment selection, runtime
+  operations, the CLI and Python API surfaces, and saved artifact layouts.
+
+### Changed
+
+- **Documentation front door and navigation.** The site now routes readers by
+  task, uses the custom domain as its canonical URL, preserves the
+  network-free regression proof as the primary demonstration, and adopts a
+  restrained engineering-focused visual system.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,195 @@
+# CLI reference
+
+The `looplet` command exposes the same harness, evidence, and eval surfaces as
+the Python package. Use `python -m looplet` when an environment does not place
+console scripts on `PATH`.
+
+```bash
+looplet --help
+looplet <command> --help
+```
+
+There are two runnable file formats:
+
+- a **cartridge** is a reviewable agent harness containing prompts, tools,
+  hooks, resources, and optional evals;
+- a **skill bundle** is an executable packaged skill with a Python entrypoint.
+
+Use `run-cartridge` for the first and `run` for the second. The formats serve
+different jobs and the commands are not aliases.
+
+## Diagnose and inspect runs
+
+### `looplet doctor`
+
+Check Python, package version, provider environment, and OpenAI-compatible
+native-tool support.
+
+```bash
+looplet doctor
+looplet doctor --no-backend
+looplet doctor --json
+looplet doctor --strict
+```
+
+`--no-backend` performs no provider call. `--strict` makes warnings produce a
+non-zero exit, which is useful for CI configuration checks. The doctor command
+currently probes OpenAI-compatible configuration; see
+[install and configure](install.md) for Anthropic smoke testing.
+
+### `looplet show <trace-dir>`
+
+Print a one-page summary of `trajectory.json` and `manifest.jsonl`, including
+steps, failures, LLM-call counts, and timing when recorded.
+
+```bash
+looplet show traces/incident-42
+```
+
+The command returns non-zero for a missing, malformed, or empty trace
+directory. Read [saved artifacts](artifacts.md) for the complete layout.
+
+## Build and run cartridges
+
+### `looplet new <description> [target]`
+
+Use an OpenAI-compatible backend to scaffold a cartridge draft from a brief.
+Generated files are a starting point, not a release-ready agent.
+
+```bash
+looplet new \
+  "Inspect a repository and report dependency risks" \
+  ./dependency-review.cartridge \
+  --tool read_file \
+  --tool run_tests
+```
+
+Useful options include repeatable `--tool`, `--name`, `--max-steps`, `--quiet`,
+and `--pretty`. Review the generated prompt, schemas, implementations, and
+runtime policy, then add an outcome contract before release.
+
+### `looplet run-cartridge <cartridge> <task>`
+
+Load a cartridge and run one task:
+
+```bash
+looplet run-cartridge ./agent.cartridge \
+  "Inspect the current change" \
+  --project-root . \
+  --max-steps 20
+```
+
+`--project-root` controls the directory available to project-aware tools. It
+defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
+directory. `run-workspace` remains a compatibility alias.
+
+### Review commands
+
+| Command | Purpose |
+| --- | --- |
+| `looplet describe <cartridge>` | Print tools, hooks, config, and a prompt preview. |
+| `looplet diff <before> <after> [--show]` | Group cartridge changes by prompt, tool, hook, resource, or config. |
+| `looplet hash <cartridge> [--show-files]` | Compute a stable SHA-256 hash over content-bearing harness files. |
+| `looplet portability <cartridge> [--json]` | Classify protocol, standard-library, runtime, and Python-host dependencies. |
+| `looplet conform [fixtures] [-v]` | Run Cartridge Spec conformance fixtures against the loader. |
+| `looplet migrate <cartridge> [--dry-run]` | Upgrade a v1 cartridge to schema version 2. |
+
+Use `diff` in review, `hash` in deployment metadata, and `portability
+--require-portable` as a CI gate when a protocol-portable cartridge is a hard
+requirement. That gate exits with code 2 when the profile is not portable.
+Always run `migrate --dry-run` first and review the resulting files.
+
+## Run behavioral evals
+
+### Run shipped cartridge cases
+
+```bash
+looplet eval run ./agent.cartridge \
+  --out ./eval-runs \
+  --threshold 1.0
+```
+
+Notable options:
+
+| Option | Effect |
+| --- | --- |
+| `--case ID` | Run one case; repeat to select several. |
+| `--max-steps N` | Override the per-case tool-call budget. |
+| `--model NAME` / `--base-url URL` | Override OpenAI-compatible environment configuration. |
+| `--judge` | Enable graders whose signature requests an LLM. |
+| `--judge-model NAME` | Use a separate judge model and imply `--judge`. |
+| `--out DIR` | Persist each case under `DIR/<case-id>/`. |
+| `--threshold VALUE` | Fail when any scored grader falls below the value. |
+
+Required graders, explicit failures, collector errors, malformed records,
+unknown cases, and empty required suites also fail the command. Persisted case
+runs use the [eval artifact layout](artifacts.md#persisted-eval-run).
+
+### Grade saved trajectories
+
+```bash
+looplet eval traces/ \
+  --evals eval_agent.py \
+  --include required smoke \
+  --threshold 1.0 \
+  --verbose
+```
+
+Use `--exclude slow` to omit marked graders. This path grades existing traces;
+it does not execute a cartridge or make new agent model calls unless a grader
+requests a judge backend supplied by the host.
+
+### Browse case data
+
+```bash
+looplet eval cases ls evals/cases/
+looplet eval cases show evals/cases/ regression_42
+```
+
+Cases are JSON source data. Keep agent-visible task input under `task` and
+protected expectations in the top-level `expected` object.
+
+## Work with skill bundles
+
+### `looplet run <bundle> <task>`
+
+Run a packaged skill bundle. Provenance capture is enabled by default:
+
+```bash
+looplet run ./skills/code-review \
+  "Review this repository" \
+  --workspace . \
+  --trace-dir traces/code-review
+```
+
+Use `--scripted` for bundle-provided deterministic responses, repeat
+`--scripted-response` to supply responses directly, or `--no-trace` when the
+host deliberately disables capture.
+
+### Bundle inspection and packaging
+
+| Command | Purpose |
+| --- | --- |
+| `looplet list-bundles <roots...> [--json]` | Discover runnable bundles under one or more roots. |
+| `looplet blueprint <bundle>` | Print the loaded bundle blueprint as JSON. |
+| `looplet export-code <bundle> <file>` | Export exact Python wrapper code for a bundle. |
+| `looplet package <module:factory> <dir>` | Package an importable `AgentPreset` factory as a bundle. |
+| `looplet wrap-claude-skill <skill> <dir>` | Wrap a Claude or Agent Skills directory as a Looplet bundle. |
+
+Packaging requires `--name` and `--description`; repeat `--tag` to attach
+searchable tags. Validate and run the output before distributing it.
+
+## Automation conventions
+
+- Treat exit code 0 as success and any non-zero code as a failed operation.
+- Use `--json` only on commands that advertise it; do not parse human output.
+- Pin the Looplet minor version when a script depends on output fields.
+- Capture stdout, stderr, command arguments, package version, and artifact hash
+  in release automation.
+- Keep API keys out of command arguments and persisted logs.
+- Prefer the Python API when the host needs structured objects that a command
+  does not expose as JSON.
+
+Before `1.0`, command options and machine-readable fields may change in a minor
+release. Pin `looplet>=0.3,<0.4` and review the [changelog](changelog.md) when
+upgrading.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,251 @@
+# Choose the right experiment
+
+Agent changes are easy to compare and hard to interpret. Before running an
+eval, name the variable you want to study and decide what must remain fixed.
+
+## Decision table
+
+| Question | Use | Hold fixed | What it does not prove |
+| --- | --- | --- | --- |
+| Did changed tool or hook code fix this captured run? | Captured-response replay | Recorded model responses | That a future model run chooses the same actions |
+| Does loop wiring dispatch, stop, and grade correctly? | Scripted backend | All model responses | Real model quality |
+| Does a prompt or model change improve outcomes? | Fresh sampled runs | Cases, graders, environment, sampling policy where possible | Universal performance from one sample |
+| Does code behave correctly against a controlled external system? | Mock, fixture, or sandbox | External side effects | Production service behavior outside the simulation |
+| Is a release candidate safe to promote? | Fresh cases plus host-owned holdouts and graders | Promotion policy and isolated oracle | Protection from candidate code without an OS or process boundary |
+
+Do not choose replay because it is cheap. Choose it when fixed model responses
+are the correct control for the question.
+
+## Captured-response replay
+
+Replay is useful for changes below the model decision boundary:
+
+- tool implementation;
+- hook behavior;
+- permission evaluation;
+- state mutation;
+- parsing and dispatch;
+- loop runtime behavior.
+
+It reuses recorded model responses while running fresh harness code. Tools,
+clocks, networks, randomness, filesystem state, permissions, and other side
+effects run again.
+
+```python
+result = replay_loop(
+    "traces/failure/trajectory.json",
+    tools=fixed_tools,
+    hooks=fixed_hooks,
+)
+```
+
+A red-to-green grader demonstrates that the changed execution produced a
+different observed outcome under the same model decisions. It does not show
+that a changed prompt causes better decisions. Run the
+[network-free proof](regression-demo.md) for the complete example and its
+limitations.
+
+## Scripted backends
+
+Use `MockLLMBackend` or `AsyncMockLLMBackend` for deterministic harness
+mechanics:
+
+```python
+from looplet.testing import MockLLMBackend
+
+
+llm = MockLLMBackend(responses=[tool_call_json, done_json])
+```
+
+This is appropriate for:
+
+- schema validation and dispatch;
+- hook order and decisions;
+- stop reasons;
+- collector and grader plumbing;
+- persistence and reload behavior;
+- required-check exit semantics.
+
+It is not evidence that a live model will emit those responses. Keep scripted
+harness tests fast and run them with ordinary pytest.
+
+## Fresh sampled runs
+
+Use new provider calls when changing anything that can alter model decisions:
+
+- system prompt or task wording;
+- model or serving connection;
+- tool name, description, or schema;
+- available context or memory;
+- temperature or sampling policy;
+- context compaction visible to the model.
+
+Record at least:
+
+- exact model identifier requested;
+- serving endpoint or provider path;
+- prompt and tool schema versions;
+- sampling settings;
+- case identifiers and grader versions;
+- timestamp and relevant external-system version;
+- raw per-case outcomes, not only an aggregate.
+
+Matching a requested model family across different serving paths does not make
+the underlying systems identical. State that limitation when comparing
+harnesses.
+
+One generation per case is useful for debugging but weak evidence for a
+quality claim. Repeat noisy cases, preserve failures, and avoid presenting
+small score differences as durable rankings without uncertainty analysis.
+
+## Mocks and sandboxes
+
+Use a mock when the contract is the request your code sends or the response it
+handles. Use a sandbox when real side effects matter but must remain contained.
+
+Examples:
+
+| Outcome | Appropriate control |
+| --- | --- |
+| File contents | Fresh temporary directory |
+| Git mutation | Disposable repository |
+| SQL write | Transaction or isolated database |
+| Shell command | Restricted process and temporary workspace |
+| HTTP integration | Recorded fixture for mechanics; test service for integration |
+| Untrusted candidate code | OS or process isolation with withheld oracle capabilities |
+
+Directory separation is organization, not a security boundary, when arbitrary
+same-user code can read the filesystem or inspect the runner process.
+
+## Collect outcomes, not historical routes
+
+A collector runs after the loop and inspects the resulting world. A grader
+compares that evidence with grader-only expectations.
+
+### File artifact
+
+```python
+import json
+from pathlib import Path
+
+
+def collect_report(state, runtime):
+    path = Path(runtime["project_root"]) / "report.json"
+    if not path.is_file():
+        return {"report_exists": False, "report": None}
+    return {
+        "report_exists": True,
+        "report": json.loads(path.read_text()),
+    }
+
+
+def eval_report(ctx):
+    return ctx.artifacts["report"] == ctx.task["expected"]["report"]
+```
+
+### Command result
+
+```python
+import subprocess
+
+
+def collect_tests(state, runtime):
+    completed = subprocess.run(
+        ["pytest", "-q"],
+        cwd=runtime["project_root"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "tests_exit_code": completed.returncode,
+        "tests_output": completed.stdout[-4000:],
+    }
+
+
+def eval_tests_pass(ctx):
+    return ctx.artifacts["tests_exit_code"] == 0
+```
+
+### Structured product state
+
+```python
+def collect_order(state, runtime):
+    order = runtime["orders"].get(runtime["order_id"])
+    return {
+        "order_status": order.status,
+        "charge_count": len(order.charges),
+    }
+
+
+def eval_order_completed_once(ctx):
+    return (
+        ctx.artifacts["order_status"] == "completed"
+        and ctx.artifacts["charge_count"] == 1
+    )
+```
+
+The runner owns collectors and runtime capabilities. Do not expose a protected
+database client, hidden path, grader callable, or expected result through the
+agent task, cartridge resource, or candidate-visible runtime.
+
+## Separate quality from cost
+
+Steps, tokens, latency, and provider cost are useful metrics. They should not
+let a fast but wrong run outrank a correct run.
+
+Use required graders for release invariants, scored graders for continuous
+quality, and `EvalResult.metrics` or operational telemetry for efficiency.
+Compare cost only among runs that meet the required quality boundary.
+
+## Layer CI by evidence type
+
+A practical pipeline separates deterministic mechanics from sampled behavior:
+
+```yaml title=".github/workflows/agent-evals.yml"
+- name: Harness mechanics
+  run: uv run pytest -q tests/test_harness.py
+
+- name: Behavioral gate
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+  run: >-
+    uv run looplet eval run ./agent.cartridge
+    --out ./eval-runs --threshold 1.0
+```
+
+Decide whether a provider outage should block a release, retry, or move a job
+to a separate required environment. Do not convert unavailable evidence into a
+passing score.
+
+Persist enough evidence to answer:
+
+1. what candidate and cases ran;
+2. what the model and tools actually did;
+3. what world state collectors observed;
+4. which grader version made the decision;
+5. why any case was skipped or unavailable.
+
+## Holdout boundary
+
+Cartridge-shipped evals are versioned self-tests. They are valuable, but a
+candidate that can edit the cartridge can also edit those tests.
+
+For promotion decisions, keep holdout cases, expected data, collectors,
+graders, and capabilities in a host-owned runner. Withhold them from the task,
+runtime, resources, tools, prompt, and writable files. If candidate code is
+untrusted, enforce the boundary with OS or process isolation.
+
+## Review checklist
+
+Before accepting an experiment result:
+
+1. Is the tested variable named precisely?
+2. Is the chosen method capable of varying that variable?
+3. Are important serving paths and external systems recorded?
+4. Does the grader inspect an independent outcome?
+5. Are required checks fail-closed on errors and missing evidence?
+6. Are efficiency metrics separated from correctness?
+7. Are sample size and uncertainty stated honestly?
+8. Can another engineer inspect the cases, artifacts, and grader version?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,61 +1,59 @@
 ---
+title: Test-driven harness engineering for Python agents
+description: Own, inspect, and regression-test Python agent harnesses with reviewable files, captured evidence, and outcome-based release gates.
 hide:
   - navigation
   - toc
 ---
 
-<div class="hero" markdown>
+<!-- markdownlint-disable MD025 MD033 MD036 -->
+
+<section class="hero" markdown>
 
 <p class="hero-eyebrow">Test-driven harness engineering for Python agents</p>
 
-# Own the loop. Test every change.
+# Looplet
+
+<p class="hero-kicker">Own the loop. Test every change.</p>
 
 <p class="hero-sub" markdown>
-Looplet keeps prompts, tools, hooks, memory, and evals in reviewable
-files. Capture what the model saw, replay recorded responses against
-fresh harness code, and gate changes with outcome-based pytest evals.
-No graph DSL or hosted platform is required.
-</p>
-
-<p class="hero-badges" markdown>
-[![PyPI](https://img.shields.io/pypi/v/looplet?label=pypi&color=4F46E5)](https://pypi.org/project/looplet/)
-[![Python](https://img.shields.io/pypi/pyversions/looplet?color=4F46E5)](https://pypi.org/project/looplet/)
-[![License](https://img.shields.io/badge/license-Apache%202.0-4F46E5)](https://github.com/hsaghir/looplet/blob/master/LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/hsaghir/looplet/ci.yml?branch=master&label=CI&color=4F46E5)](https://github.com/hsaghir/looplet/actions)
+Keep prompts, tools, hooks, cases, and graders in code and files your team can
+review. Capture a failure, inspect the resulting world, and turn the behavior
+into a required pytest or CI contract.
 </p>
 
 <div class="hero-cta">
-  <a href="regression-demo/" class="md-button md-button--primary">See a failed run become a regression test</a>
-  <a href="quickstart/" class="md-button">Build your first harness</a>
+  <a href="regression-demo/" class="md-button md-button--primary">Run the network-free proof</a>
+  <a href="install/" class="md-button">Install and configure</a>
   <a href="https://github.com/hsaghir/looplet" class="md-button">GitHub</a>
 </div>
 
-</div>
+</section>
 
 <div class="proof-strip" markdown>
 
 <div class="proof-item" markdown>
 **Reviewable**
 
-Prompts, tools, hooks, cases, and graders are files.
+Harness changes are ordinary Python, YAML, Markdown, and JSON.
 </div>
 
 <div class="proof-item" markdown>
 **Observable**
 
-Every model call and tool dispatch can become durable evidence.
+Model calls and tool dispatches can become durable evidence.
 </div>
 
 <div class="proof-item" markdown>
 **Re-executable**
 
-Captured responses can drive fresh harness code without another model call.
+Recorded responses can exercise fresh tool and hook code.
 </div>
 
 <div class="proof-item" markdown>
 **Gateable**
 
-Host-observed outcomes become required pytest and CI contracts.
+Host-observed outcomes become required release checks.
 </div>
 
 </div>
@@ -66,7 +64,6 @@ Host-observed outcomes become required pytest and CI contracts.
 
 ```text
 1. CAPTURE v1 with fixed model responses
-   model decisions: publish_report -> done
    collected profit: 200
    required eval: FAIL (0.00)
 
@@ -74,8 +71,8 @@ Host-observed outcomes become required pytest and CI contracts.
    - "profit": revenue + cost,
    + "profit": revenue - cost,
 
-3. REPLAY captured responses with fresh v2 tool execution
-   same decisions: true
+3. REPLAY with fresh v2 tool execution
+   same model decisions: true
    collected profit: 40
    required eval: PASS (1.00)
 ```
@@ -83,29 +80,51 @@ Host-observed outcomes become required pytest and CI contracts.
 </div>
 
 <p class="proof-caption" markdown>
-No API key. No network. One captured model decision stream, one fresh
-tool execution, one independently collected outcome. [Read exactly
-what the demo proves and what it does not.](regression-demo.md)
+No API key and no network. The response sequence stays fixed while changed
+tool code executes again and an independent collector checks the output.
+[Read the proof and its limits.](regression-demo.md)
 </p>
 
----
+## Start with the job in front of you
 
-## The problem starts after the prototype
+<div class="home-paths" markdown>
 
-Your agent runs. Then the harness starts moving:
+<div class="home-path" markdown>
 
-- a prompt edit fixes one case and silently breaks another;
-- a model upgrade chooses a different path;
-- a tool changes its side effects;
-- a permission or compaction hook alters what the model can do or see;
-- a successful-looking completion message hides a wrong world state.
+### I have a private tool loop
 
-At that point, `agent.run(task)` is not enough. You need an answer to:
+Adapt one tool, replace only the control loop, and establish parity before
+adding hooks or cartridges.
 
-> **What changed, what actually happened, and what evidence makes it safe to ship?**
+[Migrate an existing loop](migrate.md) | [Build the first loop](quickstart.md)
 
-Looplet connects the low-level loop to a local regression workflow
-without turning either into a platform.
+</div>
+
+<div class="home-path" markdown>
+
+### I have a failure worth preserving
+
+Capture the run, collect the real outcome, and decide whether replay, a mock,
+or fresh model samples answer the question.
+
+[Failure to regression](regression-demo.md) | [Choose an experiment](experiments.md)
+
+</div>
+
+<div class="home-path" markdown>
+
+### I need the exact interface
+
+Find commands, Python entry points, artifact files, and operational controls
+without reading the package source.
+
+[CLI](cli.md) | [Python API](api.md) | [Saved artifacts](artifacts.md)
+
+</div>
+
+</div>
+
+## One workflow from prototype to release
 
 <div class="workflow" markdown>
 
@@ -114,7 +133,7 @@ without turning either into a platform.
 
 **Build**
 
-Write normal Python or keep the harness in a cartridge that Git can diff.
+Own the model, tools, state, and dispatch loop in Python or a cartridge.
 </div>
 
 <div class="workflow-step" markdown>
@@ -130,7 +149,7 @@ Persist prompts, responses, steps, stop reasons, and metadata as readable files.
 
 **Test**
 
-Collect world state after the run and grade outcomes with grader-only expectations.
+Collect resulting world state and compare it with grader-only expectations.
 </div>
 
 <div class="workflow-step" markdown>
@@ -143,264 +162,95 @@ Make required graders and thresholds fail closed in pytest or CI.
 
 </div>
 
----
+## The execution boundary stays visible
 
-## One loop you can actually intercept
-
-```python
+```python title="owner_lookup.py"
 from looplet import OpenAIBackend, composable_loop, tool, tools_from
 
 
-@tool(description="Look up one fact by key.")
-def lookup(key: str) -> dict:
-    return {"key": key, "value": {"owner": "platform"}.get(key)}
+@tool(description="Look up one service owner by name.")
+def lookup_owner(service: str) -> dict:
+    owners = {"payments": "fintech-platform", "search": "discovery"}
+    return {"service": service, "owner": owners.get(service)}
 
-
-tools = tools_from([lookup], include_done=True)
 
 for step in composable_loop(
     llm=OpenAIBackend.from_env(),
-    tools=tools,
-    task={"goal": "Find the owner, then finish."},
+    tools=tools_from([lookup_owner], include_done=True),
+    task={"goal": "Find the owner of payments, then finish."},
     max_steps=5,
 ):
     print(step.pretty())
-    if should_pause(step):
-        break
 ```
 
-Every tool call is a `Step` object returned to your code. Hooks can
-intercept the prompt, dispatch, result, stop decision, and lifecycle
-without mandatory inheritance. The loop stays an iterator rather than a graph
-you must compile or a runtime you must surrender.
+Every dispatch returns to the caller as a typed `Step`. Hooks can observe or
+steer prompt construction, permissions, dispatch, completion, compaction, and
+lifecycle events without requiring a graph runtime. Cartridges are optional;
+they package the same harness as reviewable files when that helps distribution
+or code review.
 
-```mermaid
-flowchart LR
-    accTitle: One tool-calling loop with hooks and outcome collection
-    T[Task] --> P[Build prompt]
-    P --> M[Model proposes tool]
-    M --> D[Validate + dispatch]
-    D --> S[Yield Step]
-    S --> C{Done?}
-    C -- no --> P
-    C -- yes --> O[Outcome collectors]
-    H[Hooks] -. pre_prompt .-> P
-    H -. pre/post_dispatch .-> D
-    H -. check_done .-> C
-```
+[Follow the quickstart](quickstart.md) | [Read the hook protocol](hooks.md) |
+[Inspect cartridge boundaries](cartridge.md)
 
-[Understand the design →](why-looplet.md){ .md-button }
-[Learn hooks →](hooks.md){ .md-button }
+## Evidence has different jobs
 
----
+| Evidence | Use it for | Do not claim |
+| --- | --- | --- |
+| Yielded `Step` stream | Live routing, approval, display, and instrumentation | Independent product correctness |
+| Provenance trace | What the model saw, returned, and dispatched | That recorded prompts are safe to publish |
+| Captured-response replay | Tool, hook, permission, state, and dispatch changes under fixed model responses | Better future model decisions |
+| Outcome collector and grader | Whether the resulting file, command, record, or service state is correct | Isolation when the candidate owns the runner |
+| Fresh sampled cases | Prompt, model, schema, and context changes that affect decisions | Universal performance from one sample |
 
-## The harness is the review unit
+Looplet calls replay **captured-response replay** because tools, clocks,
+networks, randomness, and side effects execute again. Protected promotion
+oracles belong in a host-owned runner; arbitrary untrusted code also requires
+OS or process isolation.
 
-A cartridge is the optional file-native form of the runnable harness:
+[Capture and replay](provenance.md) | [Behavioral evals](evals.md) |
+[Saved artifact reference](artifacts.md)
 
-```text
-agent.cartridge/
-├── cartridge.json
-├── config.yaml
-├── runtime.yaml
-├── prompts/system.md
-├── tools/<name>/{tool.yaml, execute.py}
-├── hooks/<order>_<name>/{config.yaml, hook.py}
-├── resources/<name>.py
-├── memory/*.md
-└── evals/
-    ├── cases/*.json
-    ├── collect_*.py
-    └── eval_*.py
-```
-
-```bash
-looplet describe ./agent.cartridge
-looplet diff ./agent-v1.cartridge ./agent-v2.cartridge --show
-looplet hash ./agent.cartridge
-looplet eval run ./agent.cartridge --out ./eval-runs --threshold 1.0
-```
-
-The prompt or tool change sits beside the case and grader that cover it.
-Cartridge evals are versioned self-tests. A promotion oracle must remain in a
-host-owned runner and outside every task, runtime value, resource, tool, and
-file available to the candidate.
-
-[Cartridge layout and boundaries →](cartridge.md){ .md-button .md-button--primary }
-
----
-
-## Evidence has layers
-
-<div class="grid cards" markdown>
-
--   :material-console-line:{ .lg .middle } **Step stream**
-
-    ---
-
-    Print, route, approve, stop, or instrument each dispatch while the
-    loop is live.
-
-    [:octicons-arrow-right-24: Quickstart](quickstart.md)
-
--   :material-file-eye:{ .lg .middle } **Provenance**
-
-    ---
-
-    Save exact model inputs and outputs, tool steps, stop reasons, and
-    metadata to diff-friendly files.
-
-    [:octicons-arrow-right-24: Capture and replay](provenance.md)
-
--   :material-refresh:{ .lg .middle } **Captured-response replay**
-
-    ---
-
-    Hold model responses constant while fresh tools, hooks, state, and
-    permissions execute again.
-
-    [:octicons-arrow-right-24: Run the proof](regression-demo.md)
-
--   :material-test-tube:{ .lg .middle } **Behavioral contracts**
-
-    ---
-
-    Collect actual world state, keep expectations grader-only, and make
-    required evals fail CI.
-
-    [:octicons-arrow-right-24: Evals](evals.md)
-
-</div>
-
-!!! info "Replay is intentionally not called deterministic"
-    It holds recorded model responses constant. Tools and side effects execute
-    again. Use mocks or sandboxes when the world also needs to be
-    controlled. Use new sampled runs, not replay, to measure whether a
-    prompt or model change improves decisions.
-
----
-
-## Outcome-grounded by default
-
-Do not freeze yesterday's model trajectory as tomorrow's quality
-ceiling. A better model may use different tools and still produce a
-better result.
-
-```python
-def collect_tests(state):
-    result = subprocess.run(["pytest", "-q"], check=False)
-    return {"tests_passing": result.returncode == 0}
-
-
-@eval_mark("required")
-def eval_tests_pass(ctx):
-    return ctx.artifacts["tests_passing"]
-```
-
-Collectors inspect the world after the run. Evals grade that evidence.
-Trajectory assertions remain useful for harness mechanics, including whether a
-permission rule fired or the right stop reason was recorded, but not as
-a default proxy for product quality.
-
-[Learn the eval philosophy →](evals.md){ .md-button .md-button--primary }
-
----
-
-## Built for a specific team and stage
+## Designed for a specific team and stage
 
 <div class="fit-grid" markdown>
 
 <div class="fit-panel fit-panel--yes" markdown>
 
-### Use Looplet when
+### Looplet is a good fit when
 
 - one model calls tools until it is done;
-- you already review Python, files, pytest, and CI;
-- prompt, model, tool, or hook changes need regression evidence;
-- exact interception points matter;
-- local artifacts matter more than a hosted dashboard.
+- your team already reviews Python, files, pytest, and CI;
+- prompt, tool, model, or hook changes need regression evidence;
+- exact interception points and local artifacts matter;
+- you want to own execution rather than adopt a hosted control plane.
 
 </div>
 
 <div class="fit-panel fit-panel--no" markdown>
 
-### Choose something else when
+### Choose another layer when
 
-- the system is naturally a durable branching graph;
+- the workflow is naturally a durable branching graph;
 - a managed control plane should be the source of truth;
-- you want a turnkey assistant rather than a toolkit;
-- you do not want to own execution or the test contract.
+- you need a finished assistant, sandbox, or annotation product;
+- your main need is fleet analytics or a hosted experiment dashboard;
+- a small disposable loop is still enough.
 
 </div>
 
 </div>
 
-Looplet can run inside a workflow engine and export to observability
-services. It does not try to become either one. Core uses only the
-Python standard library; provider SDKs are optional extras.
+Looplet can run inside a workflow engine and export to observability systems.
+It does not try to replace either one. Core uses only the Python standard
+library; provider SDKs are optional extras.
 
-[Read the selection guide →](why-looplet.md){ .md-button }
-[Read the honest FAQ →](faq.md){ .md-button }
-
----
-
-## Start where you are
-
-<div class="grid cards" markdown>
-
--   :material-flask-outline:{ .lg .middle } **[Run the proof](regression-demo.md)**
-
-    ---
-
-    See capture → change → replay → collect → gate with no model or network.
-
--   :material-speedometer:{ .lg .middle } **[Quickstart](quickstart.md)**
-
-    ---
-
-    Build one loop, capture it, and add a behavioral contract.
-
--   :material-school:{ .lg .middle } **[Tutorial](tutorial.md)**
-
-    ---
-
-    Turn a small agent into a reviewable, testable harness step by step.
-
--   :material-file-cabinet:{ .lg .middle } **[Cartridges](cartridge.md)**
-
-    ---
-
-    Package prompts, tools, hooks, resources, memory, and evals as files.
-
--   :material-database-eye:{ .lg .middle } **[Provenance](provenance.md)**
-
-    ---
-
-    Capture model calls and re-execute recorded responses through fresh code.
-
--   :material-chart-check:{ .lg .middle } **[Evals](evals.md)**
-
-    ---
-
-    Build outcome collectors, grader-only cases, trust boundaries, and CI gates.
-
-</div>
-
----
-
-## Scaffolding is optional
-
-Already have tools and a prompt? Start in Python or copy a shipped
-cartridge. If an English brief is useful for bootstrapping,
-`looplet new` can scaffold the first version. Treat that output like any
-generated code: inspect it, edit it, and add a contract before shipping.
-
-[Use the agent factory as a scaffold →](agent-factory.md){ .md-button }
-
----
+[Read the selection guide](why-looplet.md) | [Check the FAQ](faq.md) |
+[Operate a production loop](operations.md)
 
 <p class="home-footer" markdown>
 [Run the proof](regression-demo.md){ .md-button .md-button--primary }
-[GitHub](https://github.com/hsaghir/looplet){ .md-button }
-[PyPI](https://pypi.org/project/looplet/){ .md-button }
+[Install Looplet](install.md){ .md-button }
+[Browse the tutorial](tutorial.md){ .md-button }
 </p>
+
+<!-- markdownlint-enable MD025 MD033 MD036 -->

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,150 @@
+# Install and configure
+
+Looplet requires Python 3.11 or newer. The core package has no third-party
+runtime dependencies. Provider SDKs are optional extras, so install only the
+adapter you plan to use.
+
+## Choose an installation
+
+| Goal | Command |
+| --- | --- |
+| Scripted runs, custom backend, or core APIs only | `pip install looplet` |
+| OpenAI or an OpenAI-compatible endpoint | `pip install "looplet[openai]"` |
+| Anthropic | `pip install "looplet[anthropic]"` |
+| Both bundled provider adapters | `pip install "looplet[all]"` |
+
+Use a virtual environment and pin the current minor line in applications:
+
+```toml title="pyproject.toml"
+dependencies = ["looplet>=0.3,<0.4"]
+```
+
+Before `1.0`, a minor release may include breaking changes. Read the
+[changelog](changelog.md) before moving to a new minor line.
+
+## Verify without a provider
+
+This command runs a scripted loop and its live evals. It does not need an API
+key or network connection:
+
+```bash
+python -m looplet.examples.hello_world --scripted
+```
+
+For the complete capture, change, replay, and gate workflow, clone the
+repository and run the network-free [regression proof](regression-demo.md):
+
+```bash
+uv sync
+uv run python examples/regression_demo/run_demo.py
+```
+
+## Configure OpenAI
+
+```bash
+export OPENAI_API_KEY=...
+export OPENAI_MODEL=gpt-4o
+```
+
+```python
+from looplet import OpenAIBackend
+
+llm = OpenAIBackend.from_env()
+```
+
+`OPENAI_MODEL` is optional and defaults to `gpt-4o`. `OPENAI_BASE_URL` is
+optional for the OpenAI cloud endpoint.
+
+## Configure an OpenAI-compatible endpoint
+
+Looplet uses the same adapter for Ollama, vLLM, llama.cpp servers, and hosted
+OpenAI-compatible APIs:
+
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL=llama3.1:8b
+export OPENAI_API_KEY=x
+```
+
+`OpenAIBackend.from_env()` supplies a non-empty sentinel key when a base URL is
+set without a key. Setting `OPENAI_API_KEY=x` explicitly is still useful when
+other clients inspect the same environment.
+
+Compatible endpoints do not all implement native tool calling the same way.
+Probe the endpoint before enabling it in a release harness:
+
+```bash
+looplet doctor
+```
+
+If the probe reports that native tools are unsupported, use text-mode tool
+calling explicitly:
+
+```python
+from looplet import LoopConfig
+
+config = LoopConfig(use_native_tools=False)
+```
+
+See [provider recipes](recipes.md) for Ollama, Groq, Together, and explicit
+client construction.
+
+## Configure Anthropic
+
+```bash
+export ANTHROPIC_API_KEY=...
+export ANTHROPIC_MODEL=claude-sonnet-4-20250514
+```
+
+```python
+from looplet import AnthropicBackend
+
+llm = AnthropicBackend.from_env()
+```
+
+`ANTHROPIC_MODEL` is optional. Pin an explicit model in release environments
+rather than relying on the library default.
+
+## Bring your own backend
+
+Any object with the small synchronous backend method can drive
+`composable_loop()`:
+
+```python
+class MyBackend:
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 2000,
+        system_prompt: str = "",
+        temperature: float = 0.2,
+    ) -> str:
+        return my_client.complete(prompt)
+```
+
+If it also exposes `generate_with_tools(...)`, Looplet can use native tool
+schemas. Otherwise set `LoopConfig(use_native_tools=False)` and Looplet uses
+its text tool protocol. See the [Python API map](api.md) for the backend
+protocol surface.
+
+## Diagnose the environment
+
+```bash
+looplet doctor                 # local checks and backend probe
+looplet doctor --no-backend    # no network, suitable for CI
+looplet doctor --json          # machine-readable output
+looplet doctor --strict        # warnings also produce a non-zero exit
+```
+
+`doctor` currently probes OpenAI-compatible environment configuration. For an
+Anthropic-only setup, use the network-free check above and construct
+`AnthropicBackend.from_env()` in a small smoke test.
+
+## Next
+
+- [Quickstart](quickstart.md): build, capture, and test one loop.
+- [Migrate an existing loop](migrate.md): adopt Looplet without rewriting the
+  whole harness.
+- [Troubleshooting](troubleshooting.md): diagnose provider, tool, hook, replay,
+  and eval failures.

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,5 +1,7 @@
 # Looplet relaunch kit
 
+<!-- markdownlint-disable MD034 -->
+
 This directory is the operational source of truth for relaunching Looplet as:
 
 > **Test-driven harness engineering for Python agents.**
@@ -30,9 +32,9 @@ it and inspect its artifacts.
 ## Canonical links
 
 - Repository: https://github.com/hsaghir/looplet
-- Documentation: https://hsaghir.github.io/looplet/
-- Proof: https://hsaghir.github.io/looplet/regression-demo/
-- Selection guide: https://hsaghir.github.io/looplet/why-looplet/
+- Documentation: https://hsaghir.com/looplet/
+- Proof: https://hsaghir.com/looplet/regression-demo/
+- Selection guide: https://hsaghir.com/looplet/why-looplet/
 - PyPI: https://pypi.org/project/looplet/
 
 ## Publication rule

--- a/docs/launch/release-announcement.md
+++ b/docs/launch/release-announcement.md
@@ -1,5 +1,7 @@
 # Release / repository announcement
 
+<!-- markdownlint-disable MD034 MD036 -->
+
 ## Title
 
 **Looplet, relaunched: own the loop, test every harness change**
@@ -60,7 +62,7 @@ harness versions, the captured model-call cassette, fresh workspaces,
 trajectories, independently collected artifacts, grader-only expected data, and
 grader results.
 
-Proof walkthrough: https://hsaghir.github.io/looplet/regression-demo/
+Proof walkthrough: https://hsaghir.com/looplet/regression-demo/
 
 ### An important boundary
 
@@ -82,9 +84,9 @@ core.
 
 Start here:
 
-- Docs: https://hsaghir.github.io/looplet/
-- Selection guide: https://hsaghir.github.io/looplet/why-looplet/
-- Quickstart: https://hsaghir.github.io/looplet/quickstart/
+- Docs: https://hsaghir.com/looplet/
+- Selection guide: https://hsaghir.com/looplet/why-looplet/
+- Quickstart: https://hsaghir.com/looplet/quickstart/
 - Repository: https://github.com/hsaghir/looplet
 
 If you maintain a real harness, open a behavioral-regression issue with a

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,5 +1,7 @@
 # Show HN draft
 
+<!-- markdownlint-disable MD034 MD036 -->
+
 ## Recommended title
 
 **Show HN: Looplet – turn failed Python agent runs into regression tests**
@@ -64,7 +66,7 @@ is naturally a durable branching graph, use a graph runtime. If you want
 hosted annotation and trace analytics, use an eval platform. If 20 lines still
 solve the problem, keep the 20 lines.
 
-Proof: https://hsaghir.github.io/looplet/regression-demo/
+Proof: https://hsaghir.com/looplet/regression-demo/
 
 Repo: https://github.com/hsaghir/looplet
 

--- a/docs/launch/social.md
+++ b/docs/launch/social.md
@@ -1,5 +1,7 @@
 # Social launch variants
 
+<!-- markdownlint-disable MD034 -->
+
 Use one primary link per post. Prefer the executable proof over the homepage.
 Do not post all variants simultaneously.
 
@@ -17,7 +19,7 @@ reviewable harness files, readable run evidence, captured-response replay, and
 outcome graders for pytest/CI.
 
 Run the proof with no model or network:
-https://hsaghir.github.io/looplet/regression-demo/
+https://hsaghir.com/looplet/regression-demo/
 
 ## Technical thread
 
@@ -44,7 +46,7 @@ cases, collectors, and graders. The loop still yields every `Step` to Python.
 graph runtime for a real graph, a hosted eval platform for annotation and
 analytics, or keep a raw loop while it is enough.
 
-Proof: https://hsaghir.github.io/looplet/regression-demo/
+Proof: https://hsaghir.com/looplet/regression-demo/
 
 ## LinkedIn / engineering-lead version
 
@@ -70,7 +72,7 @@ line changes, and the same required grader goes red → green.
 Captured-response replay is not deterministic simulation; side effects execute
 again. That limitation is part of the design, not buried in fine print.
 
-https://hsaghir.github.io/looplet/regression-demo/
+https://hsaghir.com/looplet/regression-demo/
 
 ## Reddit / forum version
 
@@ -91,7 +93,7 @@ I would value criticism of the experiment boundary and eval trust model,
 especially from teams keeping hidden holdouts outside candidate-editable agent
 files.
 
-Proof/source: https://hsaghir.github.io/looplet/regression-demo/
+Proof/source: https://hsaghir.com/looplet/regression-demo/
 
 ## Newsletter blurb
 
@@ -101,7 +103,7 @@ responses, change one tool implementation, independently collect the fresh
 artifact, and enforce the outcome with a required grader. It deliberately
 targets single-loop agents rather than graph orchestration or hosted eval
 analytics, and keeps zero third-party dependencies in core.
-[Run the proof](https://hsaghir.github.io/looplet/regression-demo/).
+[Run the proof](https://hsaghir.com/looplet/regression-demo/).
 
 ## Copy to avoid
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,0 +1,205 @@
+# Migrate an existing tool loop
+
+You do not need to rewrite a working agent into a cartridge. The safest
+migration keeps the task, provider, tool implementations, and product tests
+fixed while replacing one control boundary at a time.
+
+The first useful milestone is small: your existing tools run through
+`composable_loop()`, and every dispatch is returned to your code as a `Step`.
+Capture, hooks, cartridges, and eval gates can follow independently.
+
+## Map what you already own
+
+| Existing harness responsibility | Looplet surface |
+| --- | --- |
+| Provider client | An `LLMBackend` or bundled backend adapter |
+| Tool schema and callable | `ToolSpec`, `@tool`, and `tools_from()` |
+| Model-to-tool while-loop | `composable_loop()` |
+| Cross-cutting runtime policy | A focused hook method |
+| Run logs | `ProvenanceSink` and the yielded `Step` stream |
+| Product acceptance check | Collector plus outcome grader |
+| Versioned harness directory | Optional cartridge |
+
+Keep domain services and business rules outside Looplet. A tool can continue
+calling the same function it called before the migration.
+
+## 1. Adapt one tool
+
+Start with a read-only or otherwise low-risk tool. The decorator infers a JSON
+Schema from type hints and returns an ordinary `ToolSpec`:
+
+```python
+from looplet import tool, tools_from
+
+
+@tool(description="Look up one service owner by name.")
+def lookup_owner(service: str) -> dict:
+    return ownership_service.lookup(service)
+
+
+tools = tools_from([lookup_owner], include_done=True)
+```
+
+Do not move service clients, credentials, or persistence into the tool merely
+to satisfy Looplet. Close over existing dependencies or expose them through a
+small host-owned resource.
+
+If your harness already has a schema registry, adapt it to `ToolSpec` rather
+than adding duplicate decorators. The [API map](api.md) links to the registry
+and tool types.
+
+## 2. Replace only the control loop
+
+```python
+from looplet import LoopConfig, composable_loop
+
+
+config = LoopConfig(max_steps=8, use_native_tools=False)
+
+for step in composable_loop(
+    llm=current_backend,
+    tools=tools,
+    task={"goal": user_request},
+    config=config,
+):
+    existing_logger.info(step.pretty())
+```
+
+Keep text-mode tools for the first parity check if the previous harness used a
+text protocol. Native tool calling can be enabled and tested as a separate
+change.
+
+Run the same deterministic tool tests and a small set of representative tasks
+before adding any hook. If behavior changes, the loop replacement is the only
+new variable.
+
+## 3. Keep your provider adapter
+
+You can use an existing client through the backend protocol:
+
+```python
+class ExistingBackend:
+    def __init__(self, client):
+        self.client = client
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 2000,
+        system_prompt: str = "",
+        temperature: float = 0.2,
+    ) -> str:
+        return self.client.complete(
+            system=system_prompt,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+```
+
+Switching provider SDKs during the loop migration makes failures harder to
+attribute. Adopt `OpenAIBackend` or `AnthropicBackend` later if they remove
+real integration code.
+
+## 4. Move policy into narrow hooks
+
+Add a hook only when you can name the exact lifecycle boundary it owns. For
+example, a release guard that prevents premature completion belongs in
+`check_done`:
+
+```python
+from looplet import Block
+
+
+class RequireArtifact:
+    def check_done(self, state, session_log, context, step_num):
+        if not artifact_exists(state):
+            return Block("Create the required artifact before finishing.")
+        return None
+```
+
+Do not create one hook that contains permissions, retries, metrics, domain
+state, and acceptance logic. Compose small hooks and keep outcome acceptance in
+post-run graders. See [hooks](hooks.md) and [runtime operations](operations.md).
+
+## 5. Capture one real failure
+
+```python
+from looplet import ProvenanceSink
+
+
+sink = ProvenanceSink(dir="traces/incident-001")
+recorded_backend = sink.wrap_llm(current_backend)
+
+for step in composable_loop(
+    llm=recorded_backend,
+    tools=tools,
+    hooks=[sink.trajectory_hook()],
+    task={"goal": user_request},
+    config=config,
+):
+    existing_logger.info(step.pretty())
+
+sink.flush()
+```
+
+Treat the trace as sensitive prompt evidence. Apply `redact=` before capture
+when prompts or tool results may contain credentials or personal data.
+
+Use captured-response replay only when holding model decisions fixed answers
+the question you are testing. Tool code, clocks, networks, permissions, and
+other side effects execute again. The [experiment guide](experiments.md)
+separates replay from mocks and fresh model sampling.
+
+## 6. Turn the failure into an outcome contract
+
+Preserve the task as data, inspect the resulting world independently, and
+grade that observation:
+
+```python
+def collect_result(state):
+    result = read_product_artifact()
+    return {"observed_status": result.status}
+
+
+def eval_status_is_ready(ctx):
+    return ctx.artifacts["observed_status"] == ctx.task["expected"]["status"]
+```
+
+Avoid requiring a historical tool sequence unless the sequence itself is a
+runtime contract. A better model may take a different route to the same valid
+outcome. See [behavioral evals](evals.md) for cases, required marks, pytest,
+and host-owned holdouts.
+
+## 7. Adopt a cartridge only when it helps review
+
+Once the Python harness has parity and a useful regression contract, a
+cartridge can colocate its prompt, tools, hooks, resources, and self-tests:
+
+```bash
+looplet describe ./agent.cartridge
+looplet diff ./agent-v1.cartridge ./agent-v2.cartridge --show
+looplet hash ./agent.cartridge
+```
+
+Cartridges are a file representation of the same `AgentPreset` used by the
+Python API. They are not required to use the loop, hooks, provenance, replay,
+or eval primitives.
+
+## Migration sequence
+
+Use separate commits or pull requests for these checkpoints:
+
+1. adapt tools without changing their implementation;
+2. replace the control loop and establish behavior parity;
+3. capture run evidence with redaction;
+4. add one failure-derived case, collector, and required grader;
+5. add only the hooks needed by observed runtime policy;
+6. package the harness as a cartridge if file-native review helps;
+7. enable native tools, compaction, or other operational controls one at a
+   time.
+
+At every checkpoint, keep one cheap parity test that can disprove the current
+migration assumption. The goal is not to use every Looplet feature. The goal
+is to make the harness boundary inspectable and each future change testable.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,299 @@
+# Runtime operations
+
+Operational controls should remain separate, composable layers around the
+loop. Add one when a measured failure mode justifies it, and preserve a test
+for the boundary it owns.
+
+| Need | Start with |
+| --- | --- |
+| Async provider calls or async host | `async_composable_loop()` |
+| Transient provider failures | `ResilientBackend` |
+| Growing prompt context | `ContextBudget` plus a compaction service |
+| Repeated or wasteful actions | `StagnationHook`, tool limits, budget warnings |
+| Tool authorization | `PermissionEngine` and `PermissionHook` |
+| Live events | `StreamingHook` and an emitter |
+| Local traces and aggregate metrics | `TracingHook` and `MetricsHook` |
+| Crash recovery | `LoopConfig(checkpoint_dir=...)` |
+| Cooperative stop | `CancelToken` |
+
+## Asynchronous loops
+
+Use the async loop when the host already owns an event loop or the provider
+adapter is asynchronous:
+
+```python
+from looplet import async_composable_loop, tools_from
+from looplet.backends import AsyncOpenAIBackend
+
+
+llm = AsyncOpenAIBackend.from_env()
+
+async for step in async_composable_loop(
+    llm=llm,
+    tools=tools_from([lookup_owner], include_done=True),
+    task={"goal": "Find the payments owner, then finish."},
+    max_steps=5,
+):
+    await publish_step(step)
+```
+
+The async loop yields the same `Step` contract. A synchronous tool may still
+block the event loop if its implementation performs slow I/O directly. Use an
+async-aware tool boundary or move blocking work to a worker owned by the host.
+
+`ResilientBackend` wraps the synchronous backend protocol. Do not use it as an
+async retry layer. Configure retries and timeouts in the async provider client
+or an async adapter instead.
+
+## Provider retries and timeouts
+
+```python
+from looplet import OpenAIBackend, ResilientBackend
+
+
+base = OpenAIBackend.from_env()
+llm = ResilientBackend(
+    base,
+    retries=3,
+    timeout_s=30,
+    base_delay_s=0.5,
+    max_delay_s=8,
+    jitter=0.2,
+    retry_on=lambda exc: isinstance(exc, (TimeoutError, ConnectionError)),
+)
+```
+
+`retries` is the total number of attempts, so `retries=1` performs no retry.
+A non-retriable exception is raised immediately. Exhausted retriable failures
+raise `RetryExhausted`, whose `attempts` list preserves every exception.
+
+The caller-side timeout uses a daemon worker thread. It stops waiting but
+cannot force every provider SDK to cancel its underlying request. Set socket
+and request timeouts in the provider client as well. Avoid retrying validation,
+authentication, permission, and other permanent failures.
+
+## Context pressure and compaction
+
+Thresholds classify an approximate token count. A threshold hook requests
+compaction, while `LoopConfig.compact_service` decides how to compact:
+
+```python
+from looplet import (
+    ContextBudget,
+    DefaultCompactService,
+    LoopConfig,
+    ThresholdCompactHook,
+)
+
+
+budget = ContextBudget(
+    context_window=128_000,
+    warning_at=76_000,
+    error_at=102_000,
+    compact_buffer=10_000,
+)
+
+config = LoopConfig(compact_service=DefaultCompactService())
+hooks = [ThresholdCompactHook(budget, fire_tier="error")]
+```
+
+The ordering must remain `warning_at < error_at < blocking_at`, where
+`blocking_at` is `context_window - compact_buffer`. Keep enough buffer for the
+next response and provider-added framing.
+
+### Choose a compaction strategy
+
+| Service | Tradeoff |
+| --- | --- |
+| `DefaultCompactService` | Recommended starting chain: prune bulky results, preserve a summary where possible, and fall back safely. |
+| `TruncateCompact(keep_recent=N)` | No model call and deterministic, but discarded middle context is gone. |
+| `SummarizeCompact(keep_recent=N)` | Retains a compact narrative but spends a model call and can omit details. |
+| `PruneToolResults(keep_recent=N)` | Clears old bulky payloads while preserving conversation structure. |
+
+Compaction is a harness behavior. Test what must survive it, such as user
+constraints, artifact paths, accepted decisions, and unresolved work. Observe
+`PRE_COMPACT` and `POST_COMPACT` lifecycle events when production diagnostics
+need the boundary.
+
+The estimate is intentionally approximate. Provider tokenization, tool
+schemas, and hidden framing may differ. Thresholds should be conservative.
+
+## Stagnation and call limits
+
+Use a stagnation nudge when repeated actions indicate no progress:
+
+```python
+from looplet import StagnationHook, result_size_fingerprint
+
+
+stagnation = StagnationHook(
+    fingerprint=result_size_fingerprint,
+    threshold=3,
+    ignore_tools={"done", "note"},
+    nudge="The last actions did not add evidence. Try a different approach.",
+)
+```
+
+The default fingerprint compares tool name and arguments. The result-size
+fingerprint also considers the coarse result shape. For domain progress,
+provide a monotonic `progress(state)` counter, such as accepted artifacts or
+distinct verified records.
+
+Stagnation detection nudges; it does not stop the loop. Add hard limits when a
+resource needs an enforceable cap:
+
+```python
+from looplet import BudgetWarningHook, PerToolLimitHook
+
+
+hooks = [
+    BudgetWarningHook(thresholds=(0.5, 0.2)),
+    PerToolLimitHook(limits={"web_search": 5, "write_file": 3}),
+]
+```
+
+Tune these limits from traces. Speculative low caps often prevent valid work.
+
+## Permissions and approval
+
+Rules are evaluated in order; the first match wins:
+
+```python
+from looplet import PermissionDecision, PermissionEngine, PermissionHook
+
+
+def approve(call, rule):
+    return prompt_operator(call.tool, call.args, rule.reason)
+
+
+engine = PermissionEngine(
+    default=PermissionDecision.DENY,
+    ask_handler=approve,
+)
+engine.allow("read_file", reason="read-only workspace access")
+engine.ask("write_file", reason="writes need operator approval")
+engine.deny(
+    "bash",
+    arg_matcher=lambda args: "rm " in args.get("command", ""),
+    reason="destructive shell command",
+)
+
+hooks = [PermissionHook(engine)]
+```
+
+An `ASK` rule without a handler falls back to the engine default. An invalid
+handler result collapses to deny. Matcher failures also fail closed: a failing
+deny matcher blocks, while a failing allow matcher does not grant access.
+
+`engine.denials` is an append-only in-memory audit list with internal
+scaffolding arguments removed. Export it through a host-controlled logger if a
+durable audit record is required. Permission rules are policy, not a process
+sandbox. Untrusted code still needs OS or process isolation.
+
+## Structured events
+
+Use a callback emitter for a local UI, logger, or adapter:
+
+```python
+from looplet import StreamingHook
+from looplet.streaming import CallbackEmitter
+
+
+events = []
+
+
+def handle_event(event):
+    events.append(event)
+
+
+hooks = [StreamingHook(CallbackEmitter(handle_event))]
+```
+
+`QueueEmitter` bridges to a consumer thread. `CompositeEmitter` fans out to
+multiple sinks. Events include loop, step, tool dispatch, tool result, hook,
+recovery, and context-pressure records. Token-level `LLMChunkEvent` requires a
+streaming backend and loop stream emitter.
+
+Choose either the loop's `stream=` parameter or a `StreamingHook` for the same
+emitter path. Installing both can duplicate lifecycle events.
+
+## Traces and aggregate metrics
+
+```python
+from looplet import MetricsCollector, MetricsHook, Tracer, TracingHook
+
+
+tracer = Tracer()
+metrics = MetricsCollector()
+hooks = [TracingHook(tracer), MetricsHook(metrics)]
+
+for step in composable_loop(..., hooks=hooks):
+    route(step)
+
+print(metrics.report())
+for root_span in tracer.root_spans:
+    export_span(root_span)
+```
+
+`TracingHook` builds local loop and tool spans. `MetricsHook` counts steps,
+tool calls, errors, durations, and LLM response events. Its token fields remain
+zero unless the host records provider usage separately. These are in-memory
+structures, not a hosted telemetry service. Export them through an adapter
+owned by the application. The [OpenTelemetry recipe](recipes.md#opentelemetry)
+shows one integration shape.
+
+Use `ProvenanceSink` when the goal is durable, replayable run evidence. Use
+streaming events, spans, and metrics when the goal is live operational
+visibility. They can coexist but answer different questions.
+
+## Checkpoints and cancellation
+
+Set a checkpoint directory to save JSON checkpoints and automatically resume
+the latest checkpoint on a later run:
+
+```python
+from looplet import LoopConfig
+
+
+config = LoopConfig(
+    max_steps=100,
+    checkpoint_dir=".looplet/checkpoints/task-42",
+)
+```
+
+Use a unique directory per logical task. If the directory already contains
+checkpoints and `initial_checkpoint` is unset, Looplet loads the checkpoint
+with the highest step number.
+
+Cancellation is cooperative:
+
+```python
+from looplet import CancelToken, LoopConfig
+
+
+cancel = CancelToken()
+config = LoopConfig(cancel_token=cancel)
+
+# Another host-controlled path may call:
+cancel.cancel()
+```
+
+The loop checks between turns and passes the token through `ToolContext`.
+Long-running tools must poll `ctx.cancel_token.is_cancelled` or call
+`raise_if_cancelled()` at safe points. Cancellation does not terminate an
+arbitrary blocking system call.
+
+Checkpoint and trace files may contain prompts, tool results, and task data.
+Apply explicit access, redaction, retention, and deletion policies.
+
+## Release checklist
+
+Before enabling an operational control in a release harness:
+
+1. name the observed failure or requirement it addresses;
+2. add one focused test that can disprove the configuration;
+3. record its thresholds, defaults, and failure mode in reviewable config;
+4. preserve stop reasons and errors instead of turning them into success;
+5. inspect redaction and secret exposure in logs, traces, and checkpoints;
+6. keep acceptance graders independent from the model's own completion claim;
+7. use process or OS isolation when candidate code is untrusted.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5,<10
+mkdocs-redirects>=1.2,<2

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,9 +82,10 @@ Planned work:
 - improve errors for invalid required graders, malformed bundles, and unsafe
   case paths;
 - make persisted eval runs easy to inspect and attach to pull requests;
-- document clear choices between replay, mocks, and fresh model sampling;
-- publish migration recipes for teams replacing a private raw loop without
-  rewriting their tools.
+- keep the replay, mock, sandbox, and fresh-sampling decision guide aligned
+  with the supported evidence formats;
+- expand the migration guide with verified recipes for teams replacing a
+  private raw loop without rewriting their tools.
 
 ## Priority 2: behavioral contract ergonomics
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,22 +3,22 @@
    ───────────────────────────────────────────────────────────── */
 
 :root {
-  --ll-indigo-50:  #EEF2FF;
-  --ll-indigo-100: #E0E7FF;
-  --ll-indigo-300: #A5B4FC;
-  --ll-indigo-500: #6366F1;
-  --ll-indigo-600: #4F46E5;
-  --ll-indigo-700: #4338CA;
-  --ll-indigo-900: #312E81;
-  --ll-pink:   #EC4899;
-  --ll-amber:  #F59E0B;
-  --ll-teal:   #14B8A6;
+  --ll-indigo-50: #f2f8f7;
+  --ll-indigo-100: #ddedea;
+  --ll-indigo-300: #74b7b0;
+  --ll-indigo-500: #17847d;
+  --ll-indigo-600: #0d6f69;
+  --ll-indigo-700: #195653;
+  --ll-indigo-900: #1d292d;
+  --ll-pink: #c55343;
+  --ll-amber: #b7791f;
+  --ll-teal: #17847d;
 
-  --md-primary-fg-color:        var(--ll-indigo-600);
+  --md-primary-fg-color: var(--ll-indigo-600);
   --md-primary-fg-color--light: var(--ll-indigo-500);
-  --md-primary-fg-color--dark:  var(--ll-indigo-700);
-  --md-accent-fg-color:         var(--ll-indigo-600);
-  --md-accent-fg-color--transparent: rgba(79, 70, 229, 0.1);
+  --md-primary-fg-color--dark: var(--ll-indigo-700);
+  --md-accent-fg-color: var(--ll-indigo-600);
+  --md-accent-fg-color--transparent: rgba(13, 111, 105, 0.1);
 }
 
 /* ── Global typography polish ────────────────────────────────── */
@@ -29,13 +29,13 @@
 
 .md-typeset h1 {
   font-weight: 800;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
   line-height: 1.08;
 }
 
 .md-typeset h2 {
   font-weight: 700;
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   margin-top: 2.5rem;
   padding-top: 0.5rem;
   position: relative;
@@ -48,13 +48,12 @@
   left: 0;
   width: 2.5rem;
   height: 3px;
-  background: linear-gradient(90deg, var(--ll-indigo-600), var(--ll-pink));
-  border-radius: 2px;
+  background: var(--ll-indigo-600);
 }
 
 .md-typeset h3 {
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 
 .md-typeset code {
@@ -67,13 +66,13 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset code {
-  background: rgba(99, 102, 241, 0.15);
+  background: rgba(23, 132, 125, 0.15);
   color: var(--ll-indigo-300);
 }
 
 [data-md-color-scheme="slate"] {
-  --md-code-hl-keyword-color: #82AAFF;
-  --md-code-hl-constant-color: #B8A6FF;
+  --md-code-hl-keyword-color: #8bd5ca;
+  --md-code-hl-constant-color: #e7a86e;
 }
 .md-typeset pre > code {
   font-size: 0.82em;
@@ -96,134 +95,75 @@
   margin: 3rem 0;
 }
 
-/* ── Header bar - gradient ──────────────────────────────────── */
+/* ── Header bar ─────────────────────────────────────────────── */
 
 .md-header {
-  background: linear-gradient(
-    135deg,
-    var(--ll-indigo-700) 0%,
-    var(--ll-indigo-600) 50%,
-    var(--ll-indigo-500) 100%
-  );
-  box-shadow: 0 2px 10px rgba(79, 70, 229, 0.15);
+  background: var(--ll-indigo-900);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .md-tabs {
-  background: linear-gradient(
-    135deg,
-    var(--ll-indigo-700) 0%,
-    var(--ll-indigo-600) 100%
-  );
+  background: var(--ll-indigo-900);
 }
 
 /* ── Hero ────────────────────────────────────────────────────── */
 
 .hero {
   display: grid;
-  gap: 1.2rem;
-  padding: 4rem 2rem 3rem;
-  margin: -1.5rem -1.5rem 3rem;
-  text-align: center;
-  justify-items: center;
+  gap: 0.8rem;
+  padding: 2.75rem 2rem 2.25rem;
+  margin: -1.5rem -1.5rem 1.5rem;
+  text-align: left;
+  justify-items: start;
   position: relative;
-  overflow: hidden;
-  border-radius: 0 0 1.5rem 1.5rem;
-  background:
-    radial-gradient(circle at 20% 30%, rgba(99, 102, 241, 0.18), transparent 45%),
-    radial-gradient(circle at 80% 70%, rgba(236, 72, 153, 0.12), transparent 45%),
-    linear-gradient(180deg, var(--ll-indigo-50) 0%, transparent 100%);
+  border-bottom: 1px solid var(--ll-indigo-100);
+  background: var(--ll-indigo-50);
 }
 
 [data-md-color-scheme="slate"] .hero {
-  background:
-    radial-gradient(circle at 20% 30%, rgba(99, 102, 241, 0.28), transparent 45%),
-    radial-gradient(circle at 80% 70%, rgba(236, 72, 153, 0.2), transparent 45%),
-    linear-gradient(180deg, rgba(79, 70, 229, 0.08) 0%, transparent 100%);
+  background: #172326;
+  border-bottom-color: rgba(116, 183, 176, 0.28);
 }
 
-/* Animated shimmer ring behind the title */
 .hero::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 560px;
-  height: 560px;
-  transform: translate(-50%, -50%);
-  background: conic-gradient(
-    from 0deg,
-    transparent 0%,
-    rgba(99, 102, 241, 0.08) 25%,
-    rgba(236, 72, 153, 0.06) 50%,
-    transparent 75%,
-    transparent 100%
-  );
-  border-radius: 50%;
-  animation: hero-spin 20s linear infinite;
-  z-index: 0;
-  pointer-events: none;
+  display: none;
 }
 
-@keyframes hero-spin {
-  to { transform: translate(-50%, -50%) rotate(360deg); }
+.hero > * {
+  position: relative;
+  z-index: 1;
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .hero::before { animation: none; }
-}
-
-.hero > * { position: relative; z-index: 1; }
 
 .hero-eyebrow {
   font-size: 0.78rem;
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0;
   text-transform: uppercase;
   color: var(--ll-indigo-600);
   margin: 0;
-  padding: 0.3rem 0.85rem;
-  background: var(--ll-indigo-50);
-  border: 1px solid var(--ll-indigo-100);
-  border-radius: 999px;
-  display: inline-block;
+  padding: 0;
 }
 
 [data-md-color-scheme="slate"] .hero-eyebrow {
-  background: rgba(99, 102, 241, 0.15);
-  border-color: rgba(99, 102, 241, 0.3);
   color: var(--ll-indigo-300);
 }
 
 .md-typeset .hero h1 {
-  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  font-size: 3rem;
   font-weight: 800;
-  letter-spacing: -0.035em;
+  letter-spacing: 0;
   line-height: 1.02;
-  margin: 0.5rem 0 0;
-  background: linear-gradient(
-    135deg,
-    var(--ll-indigo-900) 0%,
-    var(--ll-indigo-600) 50%,
-    var(--ll-pink) 100%
-  );
-  -webkit-background-clip: text;
-          background-clip: text;
-  -webkit-text-fill-color: transparent;
+  margin: 0.2rem 0 0;
+  color: var(--ll-indigo-900);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .hero h1 {
-  background: linear-gradient(
-    135deg,
-    #FFFFFF 0%,
-    var(--ll-indigo-300) 50%,
-    var(--ll-pink) 100%
-  );
-  -webkit-background-clip: text;
-          background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: #f7fafa;
 }
 
-.md-typeset .hero h1::before { display: none; }
+.md-typeset .hero h1::before {
+  display: none;
+}
 
 /* The generated H1 permalink inherits the large gradient text treatment and
   becomes a distracting paragraph glyph on hover/touch. The heading keeps its
@@ -231,11 +171,17 @@
 .md-typeset .hero h1 .headerlink {
   display: none;
 }
+.hero-kicker {
+  margin: 0;
+  color: var(--ll-pink);
+  font-size: 1.25rem;
+  font-weight: 700;
+}
 .hero-sub {
-  font-size: 1.2rem;
+  font-size: 1.08rem;
   line-height: 1.55;
   color: var(--md-default-fg-color--light);
-  max-width: 44rem;
+  max-width: 46rem;
   margin: 0;
 }
 
@@ -258,26 +204,27 @@
   flex-wrap: wrap;
   gap: 0.6rem;
   margin-top: 0.6rem;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .hero-cta a.md-button {
   font-weight: 600;
   padding: 0.55rem 1.3rem;
   font-size: 0.95rem;
-  border-radius: 0.5rem;
-  transition: transform 160ms ease, box-shadow 160ms ease;
+  border-radius: 0.375rem;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
 }
 
 .hero-cta a.md-button--primary {
   background: var(--ll-indigo-600);
   border-color: var(--ll-indigo-600);
-  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.35);
+  box-shadow: none;
 }
 
 .hero-cta a.md-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.3);
+  box-shadow: none;
 }
 
 .hero-cta a.md-button--primary:hover {
@@ -287,11 +234,13 @@
 
 [data-md-color-scheme="slate"] .hero-cta a.md-button:not(.md-button--primary) {
   color: var(--ll-indigo-100);
-  border-color: rgba(165, 180, 252, 0.65);
+  border-color: rgba(116, 183, 176, 0.65);
 }
 
-[data-md-color-scheme="slate"] .hero-cta a.md-button:not(.md-button--primary):hover {
-  color: #FFFFFF;
+[data-md-color-scheme="slate"]
+  .hero-cta
+  a.md-button:not(.md-button--primary):hover {
+  color: #ffffff;
   border-color: var(--ll-indigo-300);
 }
 
@@ -300,23 +249,23 @@
 .proof-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
-  margin: -1.6rem 0 2rem;
-  position: relative;
-  z-index: 2;
+  gap: 0;
+  margin: 0 0 2rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
 .proof-item {
-  padding: 1rem 1.05rem;
-  background: var(--md-default-bg-color);
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.75rem;
-  box-shadow: 0 8px 24px -18px rgba(49, 46, 129, 0.45);
+  padding: 1rem;
+  border-right: 1px solid var(--md-default-fg-color--lightest);
   color: var(--md-default-fg-color--light);
   font-size: 0.78rem;
   line-height: 1.45;
 }
 
+.proof-item:last-child {
+  border-right: 0;
+}
 .proof-item p {
   margin: 0;
 }
@@ -335,15 +284,15 @@
   max-width: 52rem;
   margin: 2rem auto 0.75rem;
   overflow: hidden;
-  border: 1px solid rgba(165, 180, 252, 0.35);
-  border-radius: 0.85rem;
+  border: 1px solid rgba(116, 183, 176, 0.35);
+  border-radius: 0.375rem;
   background: #0b1020;
-  box-shadow: 0 24px 60px -30px rgba(49, 46, 129, 0.8);
+  box-shadow: 0 16px 40px -32px rgba(29, 41, 45, 0.9);
 }
 
 .proof-terminal__title {
   padding: 0.65rem 1rem;
-  border-bottom: 1px solid rgba(165, 180, 252, 0.18);
+  border-bottom: 1px solid rgba(116, 183, 176, 0.18);
   background: #151d38;
   color: #a5b4fc;
   font-family: "JetBrains Mono", monospace;
@@ -358,7 +307,7 @@
   background: transparent;
 }
 
-.md-typeset .proof-terminal pre>code {
+.md-typeset .proof-terminal pre > code {
   padding: 1.25rem 1.35rem;
   background: transparent;
   color: #e2e8f0;
@@ -369,7 +318,7 @@
 .proof-caption {
   max-width: 44rem;
   margin: 0 auto 2.5rem;
-  text-align: center;
+  text-align: left;
   color: var(--md-default-fg-color--light);
   font-size: 0.84rem;
 }
@@ -380,7 +329,7 @@
   gap: 0;
   margin: 2rem 0 2.5rem;
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.85rem;
+  border-radius: 0.375rem;
   overflow: hidden;
 }
 
@@ -414,7 +363,7 @@
   font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0;
 }
 
 [data-md-color-scheme="slate"] .workflow-step__num {
@@ -429,18 +378,16 @@
 }
 
 .fit-panel {
-  padding: 0.3rem 1.3rem 1rem;
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.75rem;
-  background: var(--md-default-bg-color);
+  padding: 0.2rem 1.3rem 0.5rem;
+  border-left: 3px solid var(--md-default-fg-color--lightest);
 }
 
 .fit-panel--yes {
-  border-top: 3px solid var(--ll-teal);
+  border-left-color: var(--ll-teal);
 }
 
 .fit-panel--no {
-  border-top: 3px solid var(--ll-amber);
+  border-left-color: var(--ll-amber);
 }
 
 .fit-panel h3 {
@@ -450,6 +397,38 @@
 .fit-panel li {
   margin-bottom: 0.35rem;
   color: var(--md-default-fg-color--light);
+}
+/* ── Homepage task paths ────────────────────────────────────── */
+
+.home-paths {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.home-path {
+  min-width: 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--ll-indigo-300);
+}
+
+.home-path:nth-child(2) {
+  border-left-color: var(--ll-pink);
+}
+
+.home-path:nth-child(3) {
+  border-left-color: var(--ll-amber);
+}
+
+.home-path h3 {
+  margin-top: 0;
+  font-size: 1rem;
+}
+
+.home-path p {
+  font-size: 0.88rem;
+  line-height: 1.55;
 }
 /* ── Grid cards ──────────────────────────────────────────────── */
 
@@ -472,37 +451,22 @@
   padding: 1.25rem 1.4rem;
   background: var(--md-default-bg-color);
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.75rem;
+  border-radius: 0.375rem;
   margin: 0;
   position: relative;
   overflow: hidden;
-  transition: border-color 160ms ease,
-              transform 160ms ease,
-              box-shadow 160ms ease;
+  transition: border-color 160ms ease;
 }
 
 /* Gradient accent bar on card top */
 .grid.cards > :is(ul, ol) > li::before,
 .grid.cards > .card::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--ll-indigo-600), var(--ll-pink));
-  opacity: 0;
-  transition: opacity 160ms ease;
+  display: none;
 }
 
 .grid.cards > :is(ul, ol) > li:hover,
 .grid.cards > .card:hover {
   border-color: var(--ll-indigo-300);
-  transform: translateY(-3px);
-  box-shadow: 0 12px 24px -10px rgba(79, 70, 229, 0.2);
-}
-
-.grid.cards > :is(ul, ol) > li:hover::before,
-.grid.cards > .card:hover::before {
-  opacity: 1;
 }
 
 .grid.cards .twemoji,
@@ -542,7 +506,7 @@
 /* ── Tables - comparison polish ──────────────────────────────── */
 
 .md-typeset table:not([class]) {
-  border-radius: 0.5rem;
+  border-radius: 0.375rem;
   overflow: hidden;
   border: 1px solid var(--md-default-fg-color--lightest);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
@@ -551,7 +515,7 @@
 .md-typeset table:not([class]) th {
   padding: 0.7rem 0.9rem;
   font-size: 0.75rem;
-  letter-spacing: 0.06em;
+  letter-spacing: 0;
   text-transform: uppercase;
   font-weight: 700;
   color: var(--md-default-fg-color--light);
@@ -560,8 +524,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
-  background: rgba(99, 102, 241, 0.12);
-  border-bottom-color: rgba(99, 102, 241, 0.3);
+  background: rgba(23, 132, 125, 0.12);
+  border-bottom-color: rgba(23, 132, 125, 0.3);
 }
 
 .md-typeset table:not([class]) td {
@@ -576,11 +540,7 @@
 
 /* Highlight the first-column "looplet" row */
 .md-typeset table:not([class]) tr:has(td strong:first-child) {
-  background: linear-gradient(
-    90deg,
-    rgba(79, 70, 229, 0.08),
-    rgba(236, 72, 153, 0.04)
-  );
+  background: var(--ll-indigo-50);
 }
 
 .md-typeset table:not([class]) tr:has(td strong:first-child) td {
@@ -590,12 +550,12 @@
 /* ── Code blocks - softer surface ────────────────────────────── */
 
 .md-typeset pre {
-  border-radius: 0.6rem;
+  border-radius: 0.375rem;
   overflow: hidden;
 }
 
 .md-typeset .highlight {
-  border-radius: 0.6rem;
+  border-radius: 0.375rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
@@ -604,19 +564,15 @@
 }
 
 .md-typeset .highlighttable .linenos {
-  background: rgba(79, 70, 229, 0.04);
+  background: rgba(13, 111, 105, 0.04);
 }
 
 /* Code block titles */
 .md-typeset .highlight .filename {
-  background: linear-gradient(
-    135deg,
-    var(--ll-indigo-600) 0%,
-    var(--ll-indigo-500) 100%
-  );
+  background: var(--ll-indigo-700);
   color: white;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
   padding: 0.4rem 0.9rem;
   font-size: 0.78rem;
   border-radius: 0;
@@ -625,7 +581,7 @@
 /* ── Tabbed panels ──────────────────────────────────────────── */
 
 .md-typeset .tabbed-set {
-  border-radius: 0.6rem;
+  border-radius: 0.375rem;
   overflow: hidden;
   border: 1px solid var(--md-default-fg-color--lightest);
   margin: 1.5rem 0;
@@ -654,7 +610,7 @@
 
 .md-typeset .admonition,
 .md-typeset details {
-  border-radius: 0.5rem;
+  border-radius: 0.375rem;
   border-width: 1px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
@@ -665,21 +621,17 @@
   text-align: center;
   margin: 2rem 0;
   padding: 1.5rem;
-  background: linear-gradient(
-    135deg,
-    rgba(79, 70, 229, 0.03),
-    rgba(236, 72, 153, 0.02)
-  );
-  border-radius: 0.75rem;
+  background: var(--ll-indigo-50);
+  border-radius: 0.375rem;
   border: 1px solid var(--md-default-fg-color--lightest);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .looplet-mermaid {
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(116, 183, 176, 0.08);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .looplet-mermaid .edgeLabel p {
-  color: #F8FAFC !important;
+  color: #f8fafc !important;
 }
 /* ── Admonition callout variants ────────────────────────────── */
 
@@ -689,7 +641,7 @@
 }
 .md-typeset .speed > .admonition-title,
 .md-typeset .speed > summary {
-  background: rgba(99, 102, 241, 0.12);
+  background: rgba(23, 132, 125, 0.12);
   color: var(--ll-indigo-700);
   font-weight: 600;
 }
@@ -697,33 +649,31 @@
 .md-typeset .speed > summary::before {
   background: var(--ll-indigo-600);
   -webkit-mask-image: var(--md-admonition-icon--tip);
-          mask-image: var(--md-admonition-icon--tip);
+  mask-image: var(--md-admonition-icon--tip);
 }
 
 /* ── Links - subtle underline on hover ──────────────────────── */
 
 .md-typeset a:not(.md-button):not(.md-tabs__link):not(.headerlink) {
   text-decoration: none;
-  background-image: linear-gradient(var(--ll-indigo-600), var(--ll-indigo-600));
-  background-repeat: no-repeat;
-  background-size: 0% 1.5px;
-  background-position: 0 100%;
-  transition: background-size 200ms ease;
   padding-bottom: 1px;
 }
 
 .md-typeset a:not(.md-button):not(.md-tabs__link):not(.headerlink):hover {
-  background-size: 100% 1.5px;
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
   color: var(--ll-indigo-600);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .md-button:not(.md-button--primary) {
   color: var(--ll-indigo-300);
-  border-color: rgba(165, 180, 252, 0.65);
+  border-color: rgba(116, 183, 176, 0.65);
 }
 
-[data-md-color-scheme="slate"] .md-typeset .md-button:not(.md-button--primary):hover {
-  color: #FFFFFF;
+[data-md-color-scheme="slate"]
+  .md-typeset
+  .md-button:not(.md-button--primary):hover {
+  color: #ffffff;
   border-color: var(--ll-indigo-300);
 }
 /* ── Stats row (headline numbers) ───────────────────────────── */
@@ -741,10 +691,12 @@
   padding: 1.1rem 1rem;
   background: var(--md-default-bg-color);
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.75rem;
+  border-radius: 0.375rem;
   position: relative;
   overflow: hidden;
-  transition: transform 160ms ease, border-color 160ms ease;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease;
 }
 
 .stat:hover {
@@ -757,16 +709,13 @@
   font-size: 2.1rem;
   font-weight: 800;
   line-height: 1.1;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
   margin: 0;
 }
 
 .md-typeset .stat .stat-num strong,
 .md-typeset .stat p.stat-num strong {
-  background: linear-gradient(135deg, var(--ll-indigo-600), var(--ll-pink));
-  -webkit-background-clip: text;
-          background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--ll-indigo-600);
   font-weight: 800;
 }
 
@@ -774,7 +723,7 @@
 .md-typeset .stat p.stat-label {
   font-size: 0.78rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   text-transform: uppercase;
   color: var(--md-default-fg-color--light);
   margin: 0.3rem 0 0;
@@ -789,7 +738,7 @@
   padding: 1.25rem 1.4rem;
   background: var(--md-default-bg-color);
   border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.75rem;
+  border-radius: 0.375rem;
 }
 
 .md-typeset .bench-row {
@@ -810,15 +759,15 @@
 .bench-bar {
   display: block;
   height: 14px;
-  background: linear-gradient(90deg, var(--ll-indigo-500), var(--ll-pink));
-  border-radius: 999px;
+  background: var(--ll-pink);
+  border-radius: 2px;
   width: var(--pct);
   min-width: 8px;
-  box-shadow: 0 1px 3px rgba(79, 70, 229, 0.2);
+  box-shadow: 0 1px 3px rgba(13, 111, 105, 0.2);
 }
 
 .md-typeset .bench-row:first-child .bench-bar {
-  background: linear-gradient(90deg, var(--ll-teal), var(--ll-indigo-500));
+  background: var(--ll-teal);
 }
 
 .bench-val {
@@ -833,7 +782,9 @@
     grid-template-columns: 1fr;
     gap: 0.3rem;
   }
-  .bench-val { font-size: 0.8rem; }
+  .bench-val {
+    font-size: 0.8rem;
+  }
 }
 
 /* ── Home footer row ─────────────────────────────────────────── */
@@ -850,16 +801,14 @@
 /* ── Footer ──────────────────────────────────────────────────── */
 
 .md-footer-meta {
-  background: linear-gradient(
-    135deg,
-    var(--ll-indigo-900) 0%,
-    var(--ll-indigo-700) 100%
-  );
+  background: var(--ll-indigo-900);
 }
 
 /* ── Accessibility ──────────────────────────────────────────── */
 
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+}
 
 a:focus-visible,
 button:focus-visible,
@@ -876,8 +825,16 @@ button:focus-visible,
     padding: 2.5rem 1rem 2rem;
     margin: -1rem -1rem 2rem;
   }
-  .hero-sub { font-size: 1.05rem; }
-  .grid.cards { grid-template-columns: 1fr; }
+  .hero-sub {
+    font-size: 1.05rem;
+  }
+  .grid.cards {
+    grid-template-columns: 1fr;
+  }
+  .home-paths {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+  }
   .proof-strip {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -898,7 +855,7 @@ button:focus-visible,
 @media (max-width: 35em) {
   .hero-eyebrow {
     font-size: 0.68rem;
-    letter-spacing: 0.08em;
+    letter-spacing: 0;
   }
   .md-typeset .hero h1 {
     font-size: 2.15rem;
@@ -914,6 +871,13 @@ button:focus-visible,
   }
   .proof-strip {
     grid-template-columns: 1fr;
+  }
+  .proof-item {
+    border-right: 0;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  }
+  .proof-item:last-child {
+    border-bottom: 0;
   }
   .workflow {
     grid-template-columns: 1fr;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,202 @@
+# Troubleshooting
+
+Start with the smallest failing layer. A provider probe does not test your
+tools, a scripted run does not test a provider, and captured-response replay
+does not test how a model will respond to a changed prompt.
+
+## First checks
+
+```bash
+python --version
+python -m pip show looplet
+looplet doctor --no-backend
+python -m looplet.examples.hello_world --scripted
+```
+
+Looplet requires Python 3.11 or newer. The scripted example verifies the
+installed package, loop, tool dispatch, and eval path without a provider or
+network.
+
+For a machine-readable environment report:
+
+```bash
+looplet doctor --json --no-backend
+```
+
+Do not attach API keys, prompts, raw traces, or unredacted tool results to a
+public issue.
+
+## Installation and command failures
+
+| Symptom | Check |
+| --- | --- |
+| `ModuleNotFoundError: looplet` | Confirm `python` and `pip` point at the same virtual environment. |
+| `looplet: command not found` | Run `python -m looplet --help`; then inspect the environment's scripts directory. |
+| Provider import fails | Install `looplet[openai]` or `looplet[anthropic]` in the active environment. |
+| A new API is missing | Print `looplet.__version__` and compare it with the version you installed. |
+
+The documentation may describe the next release before that release reaches
+PyPI. Pin and inspect the package version rather than inferring it from the
+website.
+
+## OpenAI-compatible backend configuration
+
+`OpenAIBackend.from_env()` needs either `OPENAI_API_KEY` or
+`OPENAI_BASE_URL`. It reads `OPENAI_MODEL` when provided.
+
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_MODEL=llama3.1:8b
+export OPENAI_API_KEY=x
+looplet doctor
+```
+
+If the endpoint accepts chat completions but not native tool schemas, the
+probe reports that distinction. Select text-mode tools explicitly:
+
+```python
+from looplet import LoopConfig
+
+config = LoopConfig(use_native_tools=False)
+```
+
+Do not silently fall back in a release harness. Record the selected protocol
+in configuration and test it.
+
+## Anthropic backend configuration
+
+`AnthropicBackend.from_env()` requires `ANTHROPIC_API_KEY` and optionally reads
+`ANTHROPIC_MODEL`:
+
+```bash
+export ANTHROPIC_API_KEY=...
+export ANTHROPIC_MODEL=claude-sonnet-4-20250514
+```
+
+`looplet doctor` currently probes the OpenAI-compatible environment. For an
+Anthropic-only deployment, construct `AnthropicBackend.from_env()` in a smoke
+test and make one explicitly budgeted provider call.
+
+## The loop produces no steps
+
+`composable_loop()` is a generator. Calling it does not execute the loop until
+you iterate:
+
+```python
+# This creates a generator but does not run it.
+run = composable_loop(...)
+
+# This executes the loop.
+steps = list(run)
+```
+
+For live handling, prefer `for step in composable_loop(...):` so each dispatch
+is visible as it happens.
+
+## Tools are not called
+
+Check these boundaries in order:
+
+1. Confirm the registry contains the expected tool names.
+2. Print or save the prompt and verify the tool schema is present.
+3. Confirm `use_native_tools` matches the endpoint's actual capabilities.
+4. Inspect the yielded error `Step` instead of relying on the final response.
+5. Run the same tool directly with representative arguments.
+
+Use `looplet doctor` for an OpenAI-compatible native-tool probe. Use
+`looplet describe` for a cartridge's loaded structure.
+
+## A hook does not fire
+
+Hooks are protocol-based. The method name and signature must match the
+lifecycle slot. Start with one hook and one test that exercises the exact
+boundary. The [hook guide](hooks.md) lists every supported method and return
+type.
+
+Common mistakes include:
+
+- returning a briefing string from a method that expects `HookDecision`;
+- treating `should_stop` as if it ran before the current dispatch;
+- registering a hook on a preset but running a different hooks list;
+- swallowing exceptions and turning a failed policy check into a no-op.
+
+## An eval passes when the product is wrong
+
+Inspect what the grader reads. The final response and `done()` arguments are
+agent claims, not independent evidence. A collector should inspect the file,
+database record, command result, API response, or other world state that users
+actually depend on.
+
+Required graders, collector errors, malformed records, explicit failure
+labels, and empty required suites fail closed in the CLI. If a grader was
+skipped unexpectedly, verify its marks and the `--include` or `--exclude`
+filters.
+
+See [behavioral evals](evals.md) and [experiment design](experiments.md).
+
+## Replay changed the result
+
+Captured-response replay holds model responses constant. It deliberately runs
+fresh tool code, hooks, permissions, state, clocks, networks, and side effects.
+A changed result is expected when one of those surfaces changed.
+
+Use a mock or sandbox when the external world must also remain fixed. Use new
+sampled model calls when the prompt, model, sampling policy, or tool
+description is the variable.
+
+## Context grows until the provider rejects it
+
+Configure both a compaction service and a threshold hook. The hook requests
+compaction; the service performs it:
+
+```python
+from looplet import (
+    ContextBudget,
+    DefaultCompactService,
+    LoopConfig,
+    ThresholdCompactHook,
+)
+
+config = LoopConfig(compact_service=DefaultCompactService())
+hooks = [ThresholdCompactHook(ContextBudget(context_window=128_000))]
+```
+
+The token estimate is approximate. Set thresholds below the provider's hard
+limit and preserve output headroom. Read [runtime operations](operations.md)
+before enabling summarization in a release harness.
+
+## A run resumes old state
+
+When `LoopConfig(checkpoint_dir=...)` points at a directory containing
+checkpoints and no explicit `initial_checkpoint` is supplied, Looplet loads the
+latest checkpoint automatically. Use a fresh directory for a new run, or
+remove stale checkpoint files intentionally.
+
+Checkpoint JSON may contain task and conversation data. Apply the same access,
+retention, and redaction policy used for traces.
+
+## MCP tools hang or fail at startup
+
+Verify the server command independently before loading the cartridge. The MCP
+adapter expects newline-delimited JSON over stdio, a bounded response timeout,
+and a process that keeps stdout reserved for protocol messages. Send human
+diagnostics to stderr.
+
+Reduce the case to one server and one tool. Include the server command, Python
+version, timeout, and redacted stderr in a bug report. Never include secrets or
+unredacted tool payloads.
+
+## Prepare a useful bug report
+
+Include:
+
+```bash
+python --version
+python -c "import looplet; print(looplet.__version__)"
+looplet doctor --json --no-backend
+```
+
+Also include the smallest scripted reproduction, expected behavior, observed
+behavior, and the relevant yielded `Step` or redacted trace fragment. State
+whether the failure occurs in a live provider call, a scripted backend, replay,
+or offline grading. Those are different execution paths.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: looplet
+site_name: Looplet
 site_description: Test-driven harness engineering for Python agents. Own the loop. Test every change.
-site_url: https://hsaghir.github.io/looplet/
+site_url: https://hsaghir.com/looplet/
 repo_url: https://github.com/hsaghir/looplet
 repo_name: hsaghir/looplet
 edit_uri: edit/master/docs/
@@ -15,8 +15,8 @@ theme:
     repo: fontawesome/brands/github
     logo: material/sync
   font:
-    text: Inter
-    code: JetBrains Mono
+    text: IBM Plex Sans
+    code: IBM Plex Mono
   features:
     - navigation.tabs
     - navigation.tabs.sticky
@@ -105,32 +105,47 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Understand:
-      - Why looplet: why-looplet.md
-      - Quickstart: quickstart.md
-      - Tutorial: tutorial.md
-      - FAQ: faq.md
-  - Build:
+  - Start:
+    - Install and configure: install.md
+    - Quickstart: quickstart.md
+    - Tutorial: tutorial.md
+    - Migrate an existing loop: migrate.md
+    - Troubleshooting: troubleshooting.md
+  - Guides:
+    - Build:
       - Cartridges: cartridge.md
       - Hooks: hooks.md
       - Skills and bundles: skills.md
-      - Recipes: recipes.md
       - Agent factory: agent-factory.md
-      - Portability: portability.md
-  - Test:
+    - Test:
       - Failure to regression: regression-demo.md
+      - Choose the right experiment: experiments.md
       - Capture and replay: provenance.md
       - Behavioral evals: evals.md
-  - Ship:
-      - Pitfalls: pitfalls.md
-      - Benchmarks: benchmarks.md
-      - Roadmap: roadmap.md
-      - Changelog: changelog.md
+    - Operate:
+      - Runtime operations: operations.md
+      - Recipes: recipes.md
+      - Portability: portability.md
+  - Reference:
+    - CLI: cli.md
+    - Python API map: api.md
+    - Saved artifacts: artifacts.md
+    - Pitfalls: pitfalls.md
+  - Concepts:
+    - Why Looplet: why-looplet.md
+    - FAQ: faq.md
+    - Evidence and benchmarks: benchmarks.md
+  - Project:
+    - Roadmap: roadmap.md
+    - Changelog: changelog.md
   - Contribute:
-      - Contributing: contributing.md
-      - Good first issues: good-first-issues.md
-      - Demo script: demo-script.md
+    - Contributing: contributing.md
+    - Good first issues: good-first-issues.md
+    - Demo recording: demo-script.md
 
 plugins:
   - search:
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+  - redirects:
+      redirect_maps:
+        getting-started.md: quickstart.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ openai = ["openai>=1.30"]
 all = ["anthropic>=0.34", "openai>=1.30"]
 
 [project.urls]
-Homepage = "https://hsaghir.github.io/looplet/"
-Documentation = "https://hsaghir.github.io/looplet/"
+Homepage = "https://hsaghir.com/looplet/"
+Documentation = "https://hsaghir.com/looplet/"
 Repository = "https://github.com/hsaghir/looplet"
 Issues = "https://github.com/hsaghir/looplet/issues"
 Changelog = "https://github.com/hsaghir/looplet/blob/master/CHANGELOG.md"


### PR DESCRIPTION
## Summary

- reorganize the documentation around Start, Guides, Reference, Concepts, and Project tasks
- replace the launch-style homepage with a compact product and workflow entry point
- add installation, migration, troubleshooting, experiment, operations, CLI, API, and artifact guides
- use `hsaghir.com/looplet` for canonical, sitemap, package, README, and launch URLs
- add the `/getting-started/` compatibility redirect and pin the docs build dependencies
- refresh the visual system with a restrained teal, coral, and charcoal engineering theme

## Validation

- `mkdocs build --strict`
- `pytest -q tests/test_release_metadata.py tests/test_launch_cleanup_regressions.py` (11 passed)
- `python scripts/check_text_style.py`
- `git diff --check`
- generated canonical, sitemap, redirect, and eight new public pages verified
- desktop and 390px mobile browser checks passed with no horizontal overflow