### PR TITLE
release: ship portable coder reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Build sdist + wheel
         run: uv build
 
+      - name: Smoke-test installed wheel
+        run: |
+          smoke_env=$(mktemp -d)
+          uv venv "$smoke_env" --python 3.12
+          uv pip install --python "$smoke_env/bin/python" dist/*.whl
+          "$smoke_env/bin/python" scripts/smoke_built_wheel.py
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -75,3 +82,45 @@ jobs:
           # Uses PyPI trusted publishing - no API token needed.
           # Configure at: https://pypi.org/manage/project/looplet/settings/publishing/
           skip-existing: true
+
+  release:
+    name: create GitHub release
+    needs: [build, publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract release notes
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" { capture = 1; next }
+            capture && $0 ~ "^## \\[" { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+
+      - name: Create or repair GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "Looplet ${GITHUB_REF_NAME#v}" \
+              --notes-file release-notes.md
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --verify-tag \
+              --title "Looplet ${GITHUB_REF_NAME#v}" \
+              --notes-file release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-
-- **Task-oriented documentation.** New guides cover installation, migration
-  from a private tool loop, troubleshooting, experiment selection, runtime
-  operations, the CLI and Python API surfaces, and saved artifact layouts.
-
-### Changed
-
-- **Documentation front door and navigation.** The site now routes readers by
-  task, uses the custom domain as its canonical URL, preserves the
-  network-free regression proof as the primary demonstration, and adopts a
-  restrained engineering-focused visual system.
-
 ## [0.3.0] - 2026-07-16
 
 ### Added
@@ -51,6 +38,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **Public regression proof.** A network-free example captures fixed model
   responses, changes one tool implementation, independently collects the fresh
   artifact, and moves a required grader from red to green.
+- **Task-oriented documentation.** New guides cover installation, migration
+  from a private tool loop, troubleshooting, experiment selection, runtime
+  operations, the CLI and Python API surfaces, and saved artifact layouts.
+- **Bundled portable coder reference.** Wheels and sdists include
+  `coder_portable.cartridge`; `bundled_cartridge_path()` resolves shipped
+  cartridges in source and installed environments. The portable coder moves 16
+  tools, five hooks, shared cache state, and model access behind MCP, LEP, SSP,
+  and MGP with zero in-process analyzer blockers.
 
 ### Changed
 
@@ -72,6 +67,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **Same-model harness evidence is documented with caveats.** Reproducible
   benchmark reports compare harness scaffolding rather than claiming universal
   model or framework superiority.
+- **Documentation front door and navigation.** The site now routes readers by
+  task, uses the custom domain as its canonical URL, preserves the
+  network-free regression proof as the primary demonstration, and adopts a
+  restrained engineering-focused visual system.
+- **Portability claims match the evidence.** The portable coder is a flagship
+  reference architecture while the Python-host coder remains the factory
+  default. Documentation distinguishes loader portability from subprocess
+  language, Unix-socket support, and full non-Python runtime execution.
 
 ### Fixed
 
@@ -103,6 +106,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   CI enforces the no-em-dash rule across tracked UTF-8 files.
 - Release metadata, mirrored documentation, lockfile version, changelog date,
   strict docs build, and publication tag are covered by automated gates.
+- Tag publication creates an idempotent GitHub Release after PyPI succeeds,
+  attaches the built wheel and sdist, and uses the matching changelog section
+  as release notes.
 - The public issue backlog is split into independent evidence, compatibility,
   and provider work with explicit dependencies and non-goals.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ starting point, `looplet new` can scaffold a cartridge. The
 [agent factory](https://hsaghir.com/looplet/agent-factory/) is onboarding, not the product
 boundary, so review and test what it writes.
 
+## One harness, explicit runtime boundaries
+
+Looplet ships `coder_portable`, a coding-harness reference architecture with
+zero in-process portability blockers. Its 16 tools run over MCP, policy and
+cache hooks run over LEP, shared file-cache state runs over SSP, and
+model-backed tools call the host through MGP.
+
+```python
+from looplet import bundled_cartridge_path
+from looplet.cartridge import analyse_cartridge
+
+
+coder = bundled_cartridge_path("coder_portable")
+assert analyse_cartridge(coder).profile == "portable"
+```
+
+This is protocol portability, not a claim that no Python process is involved.
+The bundled servers are Python programs launched with the active Looplet
+interpreter, SSP and MGP use Unix sockets, and a complete Rust, Go, or
+TypeScript host has not yet executed the coder. The Python-host coder remains
+the factory default because it also carries host-owned eval and dynamic-memory
+behavior.
+
+[Read the portability model and evidence limits](https://hsaghir.com/looplet/portability/).
+
 ---
 
 ## Four pieces, one narrow job
@@ -248,15 +273,17 @@ services. It does not try to become either one. See the
 ## Shipped examples
 
 - [`coder.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/coder.cartridge): tool-heavy coding harness with colocated cases, collectors, and required graders.
+- [`coder_portable.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/coder_portable.cartridge): the same coding architecture moved behind MCP, LEP, SSP, and MGP boundaries; bundled in the distribution as a reference artifact.
 - [`dep_doctor.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/dep_doctor.cartridge): repository dependency audit.
 - [`git_detective.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/git_detective.cartridge): repository-health investigation.
 - [`threat_intel.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/threat_intel.cartridge): local-first security briefing.
 - [`planner.cartridge`](https://github.com/hsaghir/looplet/tree/master/examples/planner.cartridge): planning composed as a subagent, not a loop phase.
 - [`regression_demo`](https://github.com/hsaghir/looplet/tree/master/examples/regression_demo): scripted, network-free captured-response replay and eval proof.
 
-Portable twins demonstrate MCP/LEP boundaries where needed; see
-[portability](https://hsaghir.com/looplet/portability/) for the exact supported tiers rather
-than a blanket runtime-agnostic claim.
+Portable twins demonstrate explicit protocol boundaries where needed; see
+[portability](https://hsaghir.com/looplet/portability/) for the supported tiers,
+cross-process evidence, and non-Python-loader limits rather than a blanket
+runtime-agnostic claim.
 
 ## Documentation
 
@@ -286,7 +313,7 @@ changes; pin to the current minor line:
 looplet>=0.3,<0.4
 ```
 
-The next launch release is `0.3.0`. See the
+The current launch release is `0.3.0`. See the
 [changelog](https://github.com/hsaghir/looplet/blob/master/CHANGELOG.md) and
 [path to 1.0](https://github.com/hsaghir/looplet/blob/master/ROADMAP.md#path-to-10).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,6 +100,7 @@ order, method signatures, composition, and error handling.
 | API | Use it for |
 | --- | --- |
 | `AgentPreset` | In-memory composition of backend-independent harness pieces. |
+| `bundled_cartridge_path(name)` | Resolve a reference cartridge shipped in the source tree or installed distribution. |
 | `Cartridge` / `CartridgeLayout` | Parsed file-native harness and its paths. |
 | `cartridge_to_preset(...)` | Load a cartridge into the same preset used by Python callers. |
 | `preset_to_cartridge(...)` | Write a supported preset surface as reviewable files. |

--- a/docs/cartridge.md
+++ b/docs/cartridge.md
@@ -30,6 +30,21 @@ for step in composable_loop(
 A cartridge is a normal directory; everything below is plain text or
 Python. Diff-friendly. Git-friendly. Editor-friendly. Agent-friendly.
 
+Cartridges support two honest execution profiles. A **Python-host** cartridge
+may keep tool bodies, hook classes, and shared objects in process. A
+**portable** cartridge keeps the contract in data and moves author-owned
+capabilities behind MCP tools, LEP hooks, SSP state services, and the MGP model
+gateway. `looplet portability <path>` identifies every blocker without
+importing the cartridge.
+
+Looplet ships both profiles of its coding harness. `coder.cartridge` remains
+the agent factory default and includes host-owned eval plus dynamic memory.
+`coder_portable.cartridge` is the bundled protocol reference: 16 tools, five
+hooks, shared file-cache state, and model-backed subagents cross explicit
+process boundaries with zero in-process analyzer blockers. See
+[cross-runtime portability](portability.md#the-portable-coder-reference) for
+the evidence and limitations.
+
 ---
 
 ## Principled exclusions: what cartridges deliberately don't do

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,19 +6,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-
-- **Task-oriented documentation.** New guides cover installation, migration
-  from a private tool loop, troubleshooting, experiment selection, runtime
-  operations, the CLI and Python API surfaces, and saved artifact layouts.
-
-### Changed
-
-- **Documentation front door and navigation.** The site now routes readers by
-  task, uses the custom domain as its canonical URL, preserves the
-  network-free regression proof as the primary demonstration, and adopts a
-  restrained engineering-focused visual system.
-
 ## [0.3.0] - 2026-07-16
 
 ### Added
@@ -51,6 +38,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **Public regression proof.** A network-free example captures fixed model
   responses, changes one tool implementation, independently collects the fresh
   artifact, and moves a required grader from red to green.
+- **Task-oriented documentation.** New guides cover installation, migration
+  from a private tool loop, troubleshooting, experiment selection, runtime
+  operations, the CLI and Python API surfaces, and saved artifact layouts.
+- **Bundled portable coder reference.** Wheels and sdists include
+  `coder_portable.cartridge`; `bundled_cartridge_path()` resolves shipped
+  cartridges in source and installed environments. The portable coder moves 16
+  tools, five hooks, shared cache state, and model access behind MCP, LEP, SSP,
+  and MGP with zero in-process analyzer blockers.
 
 ### Changed
 
@@ -72,6 +67,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - **Same-model harness evidence is documented with caveats.** Reproducible
   benchmark reports compare harness scaffolding rather than claiming universal
   model or framework superiority.
+- **Documentation front door and navigation.** The site now routes readers by
+  task, uses the custom domain as its canonical URL, preserves the
+  network-free regression proof as the primary demonstration, and adopts a
+  restrained engineering-focused visual system.
+- **Portability claims match the evidence.** The portable coder is a flagship
+  reference architecture while the Python-host coder remains the factory
+  default. Documentation distinguishes loader portability from subprocess
+  language, Unix-socket support, and full non-Python runtime execution.
 
 ### Fixed
 
@@ -103,6 +106,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   CI enforces the no-em-dash rule across tracked UTF-8 files.
 - Release metadata, mirrored documentation, lockfile version, changelog date,
   strict docs build, and publication tag are covered by automated gates.
+- Tag publication creates an idempotent GitHub Release after PyPI succeeds,
+  attaches the built wheel and sdist, and uses the matching changelog section
+  as release notes.
 - The public issue backlog is split into independent evidence, compatibility,
   and provider work with explicit dependencies and non-goals.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,6 +192,37 @@ or code review.
 [Follow the quickstart](quickstart.md) | [Read the hook protocol](hooks.md) |
 [Inspect cartridge boundaries](cartridge.md)
 
+## The harness can cross runtime boundaries
+
+The shipped `coder_portable` cartridge is the complete coding-harness
+reference architecture with zero in-process portability blockers:
+
+| Boundary | What crosses it |
+| --- | --- |
+| MCP | All 16 coding tools |
+| LEP | Permission, test, cache, stale-file, and linter hooks |
+| SSP | Shared mutable file-cache state |
+| MGP | Host model access for `web_fetch` and subagents |
+
+```python
+from looplet import bundled_cartridge_path
+from looplet.cartridge import analyse_cartridge
+
+
+coder = bundled_cartridge_path("coder_portable")
+assert analyse_cartridge(coder).profile == "portable"
+```
+
+Portable means the loader does not import author-owned tool, hook, or state
+code. The bundled protocol servers are Python programs launched with the
+active Looplet interpreter, SSP and MGP use Unix sockets, and the full coder
+has not yet run on a production Rust, Go, or TypeScript loader. The Python-host
+coder remains the agent factory default and keeps host-owned eval and
+dynamic-memory behavior that the portable reference deliberately omits.
+
+[Study the portable coder](portability.md#the-portable-coder-reference) |
+[Inspect the cartridge format](cartridge.md)
+
 ## Evidence has different jobs
 
 | Evidence | Use it for | Do not claim |

--- a/docs/launch/claims-ledger.md
+++ b/docs/launch/claims-ledger.md
@@ -15,6 +15,7 @@ and language that must not be substituted for it.
 | Top-level case expected data is withheld from the live agent task. | Eval runner/persistence implementation and integrity tests. | Candidate runtime and files are not protected; promotion needs a host-owned runner and OS/process isolation against arbitrary code. | "All cartridge evals are hidden." |
 | Required graders and collector/evaluator errors fail the CLI. | Eval CLI implementation and focused integrity suite. | State the exact command/configuration; library users can choose other handling. | "Looplet guarantees no false greens." |
 | Cartridges are reviewable harness directories. | Cartridge format, describe/diff/hash commands, round-trip tests. | Round-trip is defined for supported serializable fields; Python escape hatches remain. | "Lossless serialization of arbitrary Python." |
+| The bundled portable coder has zero in-process analyzer blockers. | `looplet portability`, installed-wheel smoke, cross-process MCP/LEP/SSP/MGP tests. | Loader portability: protocol servers currently use Python, SSP/MGP use Unix sockets, host eval/dynamic memory are omitted, and no full production non-Python loader has run it. | "Runs anywhere," "language-independent coder," or "no Python required." |
 | A compact Looplet coder matched Copilot correctness in recorded small same-model suites. | `benchmarks/coder_vs_agents/*` reports. | Historical, small samples; serving stacks differ; open-ended judging is noisy. | "Looplet beats Copilot" or universal speed/cost claims. |
 | Looplet is appropriate for one model calling tools in a loop. | Architecture and API. | Graph runtimes are a better fit for genuine branching workflows. | "Most/all agents are just loops" or unsupported percentages. |
 
@@ -49,4 +50,5 @@ level 4 into a headline.
 - Say **core runtime**, not whole development environment, for dependency
   claims.
 - Say **can fail closed under the CLI contract**, not guarantees safety.
+- Say **zero in-process analyzer blockers**, not no Python or universal runtime portability.
 - Distinguish a scripted harness regression from sampled model evaluation.

--- a/docs/launch/launch-checklist.md
+++ b/docs/launch/launch-checklist.md
@@ -17,10 +17,15 @@ No launch date overrides a failed integrity or evidence gate.
       alternatives are described honestly.
 - [ ] Factory-generated cartridges are described as drafts, not validated
       production agents.
+- [ ] Portable-coder copy says zero in-process analyzer blockers and includes
+      subprocess-language, socket, omitted-behavior, and non-Python-loader
+      qualifiers.
 
 ## 2. Executable proof gates
 
 - [ ] Fresh checkout/install instructions succeed.
+- [ ] The installed-wheel smoke resolves `coder_portable` and reports the
+      portable profile with zero blockers.
 - [ ] `uv run python examples/regression_demo/run_demo.py` exits 0.
 - [ ] Stable output shows 200/FAIL → one-line diff → 40/PASS.
 - [ ] `tests/test_regression_demo.py` passes independently.
@@ -78,9 +83,13 @@ No launch date overrides a failed integrity or evidence gate.
 - [ ] Planned issues were searched for duplicates and only launch-ready items
       were opened.
 - [ ] Release/discussion copy uses live canonical URLs.
+- [ ] Tag publication creates both the PyPI distribution and a GitHub Release
+      with the wheel, sdist, and matching changelog notes.
 
 ## 7. Publication
 
+- [ ] PyPI, GitHub Releases, the repository badge, package metadata, and docs
+      all show the same release version.
 - [ ] Show HN post uses the recommended technical title and caveat.
 - [ ] First comment links source and explains trace/replay/eval separation.
 - [ ] Social copy is adapted per audience rather than pasted everywhere.

--- a/docs/launch/release-announcement.md
+++ b/docs/launch/release-announcement.md
@@ -11,8 +11,8 @@
 Looplet is being relaunched around the job it is best at: **test-driven harness
 engineering for Python agents**.
 
-The relaunch will ship as `looplet==0.3.0`; `0.2.0` remains the earlier
-published distribution with the old public story until release.
+The relaunch ships as `looplet==0.3.0`; `0.2.0` is the previous published
+distribution with the old public story.
 
 The new entry point is a network-free regression proof. It captures one failed
 run, changes one reviewable tool line, replays the same model responses through
@@ -45,6 +45,9 @@ and behavioral evidence close to pytest and CI.
 - **Outcome contracts:** collectors inspect world state; graders use
   grader-only expected data; discovered required checks fail closed in pytest
   or CI.
+- **Portable harness boundaries:** the bundled `coder_portable` reference moves
+  16 tools, five hooks, shared state, and host model access across MCP, LEP,
+  SSP, and MGP with zero in-process analyzer blockers.
 
 ### Run the proof
 
@@ -55,7 +58,7 @@ uv sync
 uv run python examples/regression_demo/run_demo.py
 ```
 
-After publication, install it with `pip install --upgrade looplet==0.3.0`.
+Install it with `pip install --upgrade looplet==0.3.0`.
 
 It requires no API key or network. The generated directory contains both
 harness versions, the captured model-call cassette, fresh workspaces,
@@ -74,6 +77,10 @@ Looplet also does not try to become a graph runtime, hosted eval platform,
 turnkey assistant, or automatic optimizer. Those systems can consume its
 steps, artifacts, cartridges, and behavioral contracts without being pulled
 into core.
+
+Portable means the loader does not import author-owned capability code. The
+reference servers currently use Python, SSP/MGP use Unix sockets, and the full
+coder has not yet run under a production non-Python loader.
 
 ### Existing users
 

--- a/docs/launch/social.md
+++ b/docs/launch/social.md
@@ -46,6 +46,11 @@ cases, collectors, and graders. The loop still yields every `Step` to Python.
 graph runtime for a real graph, a hosted eval platform for annotation and
 analytics, or keep a raw loop while it is enough.
 
+**7/** The bundled portable coder moves 16 tools, five hooks, shared state, and
+model access across MCP, LEP, SSP, and MGP with zero in-process analyzer
+blockers. The servers still use Python/Unix sockets; this is not a universal
+"runs anywhere" claim.
+
 Proof: https://hsaghir.com/looplet/regression-demo/
 
 ## LinkedIn / engineering-lead version

--- a/docs/launch/strategy.md
+++ b/docs/launch/strategy.md
@@ -53,13 +53,16 @@ Not the primary ICP:
    replay + collectors/graders.
 4. **Review unit:** cartridges keep prompts, tools, hooks, resources, cases,
    and graders in ordinary files.
-5. **Boundary:** one loop, no graph DSL, no hosted control plane, no automatic
+5. **Portable reference:** the bundled coder demonstrates explicit MCP, LEP,
+   SSP, and MGP boundaries with zero in-process analyzer blockers.
+6. **Boundary:** one loop, no graph DSL, no hosted control plane, no automatic
    optimization, zero third-party core runtime dependencies.
-6. **Caveat:** replay holds model responses constant; fresh tools and side effects still
+7. **Caveat:** replay holds model responses constant; fresh tools and side effects still
    execute.
 
 Do not lead with protocol count, import time, generated agents, or feature
-breadth. Those can support a decision after the behavioral proof is clear.
+breadth. Portability supports the decision after the behavioral proof is clear,
+and must retain its subprocess-language, socket, and non-Python-loader caveats.
 
 ## Proof ladder
 
@@ -73,7 +76,9 @@ Use claims in this order:
    parity. Host-owned promotion isolation remains a separate runner concern.
 5. **Same-model study:** optional evidence that a compact owned harness can be
    competitive; never the hero claim.
-6. **Package property:** zero third-party core runtime dependencies.
+6. **Portable architecture:** analyzer + cross-process MCP/LEP/SSP/MGP tests;
+   not evidence of full production execution on a non-Python loader.
+7. **Package property:** zero third-party core runtime dependencies.
 
 ## Primary call to action
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -30,7 +30,7 @@ portability). A cartridge is in the **portable profile** when it has
 `INPROCESS` components are the exact blockers.
 
 | Tier | Symbol | Meaning | Blocker? |
-|------|--------|---------|----------|
+| --- | --- | --- | --- |
 | `PROTOCOL` | ● | Pure data or out-of-process protocol - `config.yaml`, `prompts/`, `mcp_servers:` tools, `kind: lep` hooks. Runs on any conforming loader with no shared code. | no |
 | `STDLIB` | ◐ | Declarative reference to a looplet-shipped archetype (`builtin_tools:` / `builtin_hooks:`). No Python body in the cartridge. | no |
 | `RUNTIME` | ◈ | A `resources/*.py` whose only job is to wrap a host-provided *service* (compaction, the skill manager) via a looplet factory like `default_compact_service`. The service is a host responsibility every loader ships its own equivalent of. | no |
@@ -40,37 +40,64 @@ portability). A cartridge is in the **portable profile** when it has
 parent's components (and therefore its parent's blockers), tagged
 `(inherited)` in the report.
 
-## The three protocol surfaces
+## The four protocol surfaces
 
 A fully-portable cartridge moves every author-owned capability onto one
-of looplet's three out-of-process protocol surfaces:
+of looplet's four out-of-process protocol surfaces:
 
 | Surface | Carries | Transport | Cardinality |
-|---------|---------|-----------|-------------|
+| --- | --- | --- | --- |
 | **MCP** | tools | stdio JSON-RPC | 1 server : N tools |
 | **LEP** (Loop Effect Protocol) | hooks (permission / done policies) | stdio JSON-RPC | 1 server : 1 hook |
 | **SSP** (State Service Protocol) | shared mutable state | `AF_UNIX` SOCK_STREAM | 1 service : N clients |
+| **MGP** (Model Gateway Protocol) | host model access | `AF_UNIX` SOCK_STREAM | 1 gateway : N clients |
 
 The host ships only a declared **view** to a hook; the hook returns a
-decision. The host spawns an MCP server and calls its tools. Neither
-requires the host to execute any author Python.
+decision. The host spawns MCP and LEP servers, brokers shared state through
+SSP, and exposes the active model through MGP. The loader does not import
+author-owned tool, hook, or state code.
+
+## The portable coder reference
+
+`coder_portable.cartridge` is the flagship protocol composition. It moves the
+complete 16-tool coding surface behind one MCP server, five policy/cache hooks
+behind LEP, the shared `FileCache` behind SSP, and model-backed `web_fetch` and
+`subagent` calls through MGP. Compaction remains a host-provided runtime
+service. The analyzer reports `portable` with zero `INPROCESS` blockers.
+
+```python
+from looplet import bundled_cartridge_path
+from looplet.cartridge import analyse_cartridge
+
+
+report = analyse_cartridge(bundled_cartridge_path("coder_portable"))
+assert report.profile == "portable"
+assert report.blockers == ()
+```
+
+The wheel and sdist include this cartridge as a reference artifact. The agent
+factory still extends `coder.cartridge`, the Python-host profile, because it
+retains host-side `EvalHook` wiring and dynamic instruction/project memory.
+Those behaviors have no portable protocol equivalent yet and are explicitly
+omitted from the portable twin.
 
 ## Portable example cartridges
 
-Each non-trivial example ships a `*_portable` twin that is byte-for-byte
-behaviour-faithful to its in-process original, but classifies as
-`portable`. Every twin has an end-to-end *cross-process* dogfood test in
-`tests/test_example_*_portable_cartridge.py`.
+The repository ships portable twins for its major examples. They preserve the
+documented tool and policy behavior that has a protocol equivalent and
+classify as `portable`. Each twin has an end-to-end *cross-process* dogfood
+test in `tests/test_example_*_portable_cartridge.py`.
 
 | Portable twin | Original | What moved | Notes |
-|---------------|----------|------------|-------|
+| --- | --- | --- | --- |
+| `coder_portable` | `coder` | 16 tools → MCP, 5 hooks → LEP, FileCache → SSP, model access → MGP | bundled flagship; host eval and dynamic memory intentionally omitted |
 | `hello_portable` | `hello` | greet/done → MCP | smallest demo |
 | `mcp_demo_portable` | `mcp_demo` | add + done → MCP, CalcGuard → LEP | both tools served by one MCP server |
 | `planner_portable` | `planner` | done → MCP; nested `planner_child` twin | `subagent` builtin tool + LEP guard |
 | `skillful_analyst_portable` | `skillful_analyst` | done/read_text/write_text → MCP, WriteScopeGuard → LEP | skill system via `search_skills`/`activate_skill` builtins + RUNTIME `skill_manager` |
-| `dep_doctor_portable` | `dep_doctor` | 7 audit tools → MCP, RegistryGuard → LEP | `find_alternatives` degrades to empty (no host LLM in the MCP subprocess) |
-| `threat_intel_portable` | `threat_intel` | 7 tools → MCP, FeedAllowlistGuard → LEP | regex IOC extraction preserved; LLM severity/risk degrade gracefully |
-| `git_detective_portable` | `git_detective` | 10 tools → MCP, CouplingGuard → LEP | INPROCESS `repo_config` replaced by `$LOOPLET_PROJECT_ROOT` resolution; the server only needs `git` |
+| `dep_doctor_portable` | `dep_doctor` | 7 audit tools → MCP, RegistryGuard → LEP | `find_alternatives` reaches the bound host model through MGP |
+| `threat_intel_portable` | `threat_intel` | 7 tools → MCP, FeedAllowlistGuard → LEP | deterministic extraction plus MGP-backed severity/risk parity |
+| `git_detective_portable` | `git_detective` | 10 tools → MCP, CouplingGuard → LEP | repo root via host env; LLM assessment through MGP |
 
 ### The mechanical port recipe
 
@@ -83,7 +110,7 @@ Porting an in-process cartridge to a portable twin is a fixed procedure:
    ```yaml
    mcp_servers:
      my_tools:
-       command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+      command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
    ```
 
 2. **Keep `kind: lep` hooks verbatim** - they are already PROTOCOL-tier.
@@ -98,48 +125,62 @@ Porting an in-process cartridge to a portable twin is a fixed procedure:
    `$LOOPLET_PROJECT_ROOT` env lookup inside the server; genuine shared
    *mutable* state would move to an SSP service instead.
 
-6. **Anchor relative paths to the host root** - the MCP subprocess
+6. **Use MGP for model-backed tools** - the loader binds its active backend to
+   the model gateway and exports `LOOPLET_LLM_SOCKET` to child processes.
+   Tools degrade through their documented no-model branch when no backend is
+   bound.
+
+7. **Anchor relative paths to the host root** - the MCP subprocess
    resolves relative paths against `os.getcwd()` (the host project
    root), the portable equivalent of `resolve_project_root(runtime)`.
 
-!!! note "LLM-backed tools degrade, they don't break"
-    A tool that calls the host LLM (`ctx.llm`) can't reach it from a
-    separate MCP process. The faithful port returns the same fallback
-    the original takes when `ctx.llm is None` (e.g.
-    `find_alternatives` → empty list, `assess_risk` → severity-only
-    summary). Deterministic logic (regex extraction, git statistics) is
-    preserved in full. True host-LLM access from a server would require
-    MCP `sampling/createMessage` callbacks - out of scope for v1.x.
+!!! note "Model access is explicit"
+   MGP lets an out-of-process tool call the backend currently bound by the
+   host. With no backend bound, the tool takes the same graceful-degradation
+   branch as the in-process implementation with `ctx.llm is None`.
 
-## Inherently python-host cartridges
+## Python-host defaults and portable twins
 
-Two shipped cartridges are **deliberately** python-host. They are not
-ported; their whole purpose is to host and execute Python.
+The default and portable profiles coexist. Portability is not automatically
+better when a host explicitly wants in-process Python composition.
 
-### `coder`
+### `coder` and `coder_portable`
 
-A general software-engineering agent: ~16 substantial tools
-(`bash`, `edit_file`, `grep`, `subagent`, `worktree`, …), 5 class
-hooks, and 7 resources. Several resources (`file_cache`,
-`workspace_config`, `eval_*`) are **genuine** `INPROCESS` shared
-mutable state, and the tools execute arbitrary code in the host
-environment. The mechanical recipe above *would* apply tool-by-tool
-(bodies → an MCP server, class hooks → LEP, shared state → SSP), but the
-result would still need a host that can run a shell and edit a live
-workspace - the very thing that makes it useful. Porting it buys no
-portability; it stays python-host by design.
+`coder.cartridge` is the Python-host source used by the agent factory. It keeps
+tool bodies, several hooks, dynamic memory, and eval wiring in the host.
+`coder_portable.cartridge` moves every capability with a protocol equivalent
+out of process. Both still need an execution environment that permits shell
+commands and workspace edits; the portability distinction is where authored
+code runs, not whether the agent has side effects.
 
 ### `agent_factory`
 
-`agent_factory` does `extends: ../coder.cartridge`, so the analyser
+`agent_factory` does `extends: ../coder.cartridge`, so the analyzer
 reports its blockers as **its own** (`validate_workspace`) **plus all of
 `coder`'s** (tagged `(inherited)`). Its one bespoke tool,
-`validate_workspace`, exists to *import and validate a Python workspace*
-and is python-host by definition. Like `coder`, it is documented as
-inherently python-host rather than ported.
+`validate_workspace`, exists to *import and validate a Python cartridge* and
+is Python-host by definition.
 
 ```python
 report = analyse_cartridge("examples/agent_factory.cartridge")
 assert report.profile == "python-host"
 # blockers = validate_workspace + every coder component, via extends
 ```
+
+## What the evidence proves
+
+The portability claim has three layers:
+
+1. The static analyzer reports zero in-process blockers for each portable
+   twin.
+2. Dogfood tests execute MCP, LEP, SSP, and MGP boundaries as separate
+   processes and verify shared-state and model-call behavior.
+3. `examples/alt_runtime/tinyloop.py` is an independent loader that matches the
+   reference loader on the spec-pinned declarative subset.
+
+It does not yet prove that the full coder runs under a production Rust, Go, or
+TypeScript loader. The bundled protocol servers are currently Python programs,
+and SSP/MGP require `AF_UNIX` sockets. Therefore the precise claim is:
+
+> The cartridge has no author-owned code that the loader must import. A
+> conforming host can replace or execute the declared protocol services.

--- a/examples/coder_portable.cartridge/config.yaml
+++ b/examples/coder_portable.cartridge/config.yaml
@@ -86,11 +86,11 @@ builtin_hooks:
 # read and write the SAME FileCache, exactly as the @ref demo did.
 state_services:
   file_cache:
-    command: "python3 ${runtime.cartridge_root}/_state/file_cache.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_state/file_cache.py"'
     timeout_s: 10
 
 # Out-of-process tools (MCP stdio transport). Exposes all 16 coder tools.
 mcp_servers:
   tools:
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 10

--- a/examples/dep_doctor_portable.cartridge/config.yaml
+++ b/examples/dep_doctor_portable.cartridge/config.yaml
@@ -29,6 +29,6 @@ mcp_servers:
     # Self-contained stdio MCP server - no npm/Node/PyPI access required.
     # ${runtime.cartridge_root} is injected by the loader so the spawned
     # command finds the bundled server regardless of checkout location.
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 10
     # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/git_detective_portable.cartridge/config.yaml
+++ b/examples/git_detective_portable.cartridge/config.yaml
@@ -31,6 +31,6 @@ mcp_servers:
     # Self-contained stdio MCP server - shells out to `git` only.
     # ${runtime.cartridge_root} is injected by the loader so the spawned
     # command finds the bundled server regardless of checkout location.
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 35
     # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/hello_portable.cartridge/config.yaml
+++ b/examples/hello_portable.cartridge/config.yaml
@@ -29,11 +29,11 @@ done_tool: done
 # servers (all separate processes) can connect to the same state.
 state_services:
   greeting_log:
-    command: "python3 ${runtime.cartridge_root}/_state/greeting_log.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_state/greeting_log.py"'
     timeout_s: 10
 
 # Out-of-process tools (MCP stdio transport). Exposes greet + done.
 mcp_servers:
   tools:
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 10

--- a/examples/mcp_demo.cartridge/config.yaml
+++ b/examples/mcp_demo.cartridge/config.yaml
@@ -21,6 +21,6 @@ mcp_servers:
     # absolute path of this cartridge's root directory, injected by
     # the loader so the spawned command finds the bundled server
     # regardless of where the cartridge was checked out.
-    command: "python3 ${runtime.cartridge_root}/_server/calc.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_server/calc.py"'
     timeout_s: 10
     # No `tools:` allow-list → register every tool the server exposes.

--- a/examples/mcp_demo_portable.cartridge/config.yaml
+++ b/examples/mcp_demo_portable.cartridge/config.yaml
@@ -17,7 +17,7 @@ mcp_servers:
     # ${runtime.cartridge_root} is injected by the loader so the
     # spawned command finds the bundled server regardless of where the
     # cartridge was checked out.
-    command: "python3 ${runtime.cartridge_root}/_server/calc.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_server/calc.py"'
     timeout_s: 10
     # No `tools:` allow-list → register every tool the server exposes
     # (add + done).

--- a/examples/planner_portable.cartridge/config.yaml
+++ b/examples/planner_portable.cartridge/config.yaml
@@ -6,5 +6,5 @@ builtin_tools:
 mcp_servers:
   planner_tools:
     # done() served out of process so no Python tool body is required.
-    command: "python3 ${runtime.cartridge_root}/_mcp/done_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/done_server.py"'
     timeout_s: 10

--- a/examples/planner_portable.cartridge/planner_child.cartridge/config.yaml
+++ b/examples/planner_portable.cartridge/planner_child.cartridge/config.yaml
@@ -3,5 +3,5 @@ done_tool: done
 
 mcp_servers:
   planner_tools:
-    command: "python3 ${runtime.cartridge_root}/_mcp/done_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/done_server.py"'
     timeout_s: 10

--- a/examples/skillful_analyst_portable.cartridge/config.yaml
+++ b/examples/skillful_analyst_portable.cartridge/config.yaml
@@ -10,5 +10,5 @@ mcp_servers:
   analyst_tools:
     # done / read_text / write_text served out of process so no Python
     # tool body is required by the host.
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 10

--- a/examples/threat_intel_portable.cartridge/config.yaml
+++ b/examples/threat_intel_portable.cartridge/config.yaml
@@ -29,6 +29,6 @@ mcp_servers:
     # Self-contained stdio MCP server - no network/API access required.
     # ${runtime.cartridge_root} is injected by the loader so the spawned
     # command finds the bundled server regardless of checkout location.
-    command: "python3 ${runtime.cartridge_root}/_mcp/tools_server.py"
+    command: '"${runtime.python_executable}" "${runtime.cartridge_root}/_mcp/tools_server.py"'
     timeout_s: 10
     # No `tools:` allow-list → register every tool the server exposes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,9 @@ packages = ["src/looplet"]
 [tool.hatch.build.targets.wheel.force-include]
 "examples/agent_factory.cartridge" = "looplet/_bundled/agent_factory.cartridge"
 "examples/coder.cartridge" = "looplet/_bundled/coder.cartridge"
+"examples/coder_portable.cartridge" = "looplet/_bundled/coder_portable.cartridge"
 "tests/fixtures/coder_skill_bundle/SKILL.md" = "tests/fixtures/coder_skill_bundle/SKILL.md"
+"tests/fixtures/coder_skill_bundle/__init__.py" = "tests/fixtures/coder_skill_bundle/__init__.py"
 "tests/fixtures/coder_skill_bundle/looplet.py" = "tests/fixtures/coder_skill_bundle/looplet.py"
 "tests/fixtures/coder_skill_bundle/tools.py" = "tests/fixtures/coder_skill_bundle/tools.py"
 "tests/fixtures/coder_skill_bundle/hooks.py" = "tests/fixtures/coder_skill_bundle/hooks.py"
@@ -90,6 +92,7 @@ include = [
     "docs/skills.md",
     "examples/agent_factory.cartridge",
     "examples/coder.cartridge",
+    "examples/coder_portable.cartridge",
     "tests/fixtures/coder_skill_bundle/SKILL.md",
     "tests/fixtures/coder_skill_bundle/looplet.py",
     "tests/fixtures/coder_skill_bundle/tools.py",

--- a/scripts/smoke_built_wheel.py
+++ b/scripts/smoke_built_wheel.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 
 import looplet
+from looplet.bundles import load_skill_bundle
+from looplet.cartridge import analyse_cartridge
 from looplet.cli.factory_commands import _factory_workspace_path
 
 
@@ -18,6 +20,33 @@ def main() -> int:
     assert package_root in factory.parents
     assert factory == package_root / "_bundled" / "agent_factory.cartridge"
     assert (factory.parent / "coder.cartridge" / "cartridge.json").is_file()
+
+    portable_coder = looplet.bundled_cartridge_path("coder_portable").resolve()
+    assert portable_coder == package_root / "_bundled" / "coder_portable.cartridge"
+    portability = analyse_cartridge(portable_coder)
+    assert portability.profile == "portable"
+    assert portability.blockers == ()
+
+    portable_preset = looplet.cartridge_to_preset(portable_coder, strict=True)
+    try:
+        assert len(portable_preset.mcp_adapters) == 1
+        assert len(portable_preset.state_service_handles) == 1
+        assert {
+            "bash",
+            "read_file",
+            "write_file",
+            "edit_file",
+            "grep",
+            "subagent",
+            "done",
+        } <= set(portable_preset.tools.tool_names)
+    finally:
+        portable_preset.close()
+
+    coder_bundle_path = package_root.parent / "tests" / "fixtures" / "coder_skill_bundle"
+    coder_bundle = load_skill_bundle(coder_bundle_path)
+    assert coder_bundle.skill.name == "coder"
+    assert coder_bundle.card.name == "coder"
 
     preset = looplet.cartridge_to_preset(factory)
     try:

--- a/src/looplet/__init__.py
+++ b/src/looplet/__init__.py
@@ -34,6 +34,7 @@ from looplet.blueprints import (
     wrap_claude_skill_as_bundle,
 )
 from looplet.budget import ContextBudget, ThresholdCompactHook
+from looplet.bundled import bundled_cartridge_path
 from looplet.bundles import (
     BundleCard,
     BundleValidation,
@@ -239,6 +240,7 @@ __all__ = [
     "load_skill_bundle",
     "validate_skill_bundle",
     "run_skill_bundle",
+    "bundled_cartridge_path",
     "blueprint_from_bundle",
     "blueprint_from_preset",
     "compare_blueprints",

--- a/src/looplet/bundled.py
+++ b/src/looplet/bundled.py
@@ -1,0 +1,42 @@
+"""Locate reference cartridges shipped with Looplet."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["bundled_cartridge_path"]
+
+
+def bundled_cartridge_path(name: str) -> Path:
+    """Return a shipped cartridge from a source checkout or installed package.
+
+    ``name`` may be supplied with or without the ``.cartridge`` suffix. Only a
+    single path component is accepted; callers cannot escape the bundled
+    cartridge directory.
+    """
+    if (
+        not isinstance(name, str)
+        or not name
+        or name != name.strip()
+        or name in {".", ".."}
+        or Path(name).name != name
+        or "/" in name
+        or "\\" in name
+    ):
+        raise ValueError("cartridge name must be one non-empty path component")
+
+    directory_name = name if name.endswith(".cartridge") else f"{name}.cartridge"
+    here = Path(__file__).resolve()
+
+    installed_candidate = here.parent / "_bundled" / directory_name
+    if installed_candidate.is_dir():
+        return installed_candidate
+
+    for parent in here.parents:
+        source_candidate = parent / "examples" / directory_name
+        if source_candidate.is_dir():
+            return source_candidate
+
+    raise FileNotFoundError(
+        f"Could not locate bundled cartridge {directory_name!r}. Reinstall looplet."
+    )

--- a/src/looplet/cartridge/_load.py
+++ b/src/looplet/cartridge/_load.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -212,15 +213,13 @@ def cartridge_to_preset(
     #   * ``from <resource_name> import helper`` resolves to a
     #     ``resources/<resource_name>.py`` module (lets tools call back
     #     into resource modules without forcing a setup.py shim).
-    import sys as _sys  # noqa: PLC0415
-
     root_str = str(root)
     resources_dir_str = str(root / CartridgeLayout.RESOURCES_DIR)
     pushed_paths: list[str] = []
     for p in (root_str, resources_dir_str):
         if (root / CartridgeLayout.RESOURCES_DIR).is_dir() or p == root_str:
-            if p not in _sys.path:
-                _sys.path.insert(0, p)
+            if p not in sys.path:
+                sys.path.insert(0, p)
                 pushed_paths.append(p)
     try:
         preset = _workspace_to_preset_inner(
@@ -237,7 +236,7 @@ def cartridge_to_preset(
     finally:
         for p in pushed_paths:
             try:
-                _sys.path.remove(p)
+                sys.path.remove(p)
             except ValueError:
                 pass
 
@@ -539,6 +538,9 @@ def _workspace_to_preset_inner(
     from looplet.tools import BaseToolRegistry, ToolSpec  # noqa: PLC0415
     from looplet.types import DefaultState  # noqa: PLC0415
 
+    render_runtime = dict(runtime_dict)
+    render_runtime.setdefault("python_executable", sys.executable)
+
     # ── Spec version gate ──────────────────────────────────────
     # Cartridge spec v2 is the only supported version. v1 cartridges
     # are rejected at load time; upgrade with ``looplet migrate``.
@@ -586,7 +588,7 @@ def _workspace_to_preset_inner(
         raw_cfg_text = cfg_path.read_text(encoding="utf-8")
         # Apply ``${runtime.<key>}`` substitution before YAML parsing so
         # cartridge authors can parameterise config.yaml declaratively.
-        raw_cfg_text = _apply_runtime_substitutions(raw_cfg_text, runtime_dict)
+        raw_cfg_text = _apply_runtime_substitutions(raw_cfg_text, render_runtime)
         cfg_kwargs.update(_load_yaml(raw_cfg_text, source_path=cfg_path) or {})
 
     # ── Schema-v2 sibling ``runtime.yaml`` ──────────────────────
@@ -601,7 +603,7 @@ def _workspace_to_preset_inner(
     runtime_yaml_path = root / "runtime.yaml"
     if runtime_yaml_path.is_file():
         raw_runtime_text = runtime_yaml_path.read_text(encoding="utf-8")
-        raw_runtime_text = _apply_runtime_substitutions(raw_runtime_text, runtime_dict)
+        raw_runtime_text = _apply_runtime_substitutions(raw_runtime_text, render_runtime)
         runtime_yaml_kwargs = _load_yaml(raw_runtime_text, source_path=runtime_yaml_path) or {}
         # Validate: only RUNTIME-tier keys are allowed in runtime.yaml.
         _bad = sorted(
@@ -990,7 +992,7 @@ def _workspace_to_preset_inner(
             yaml_payload = (
                 _load_yaml(
                     _apply_runtime_substitutions(
-                        spec_path.read_text(encoding="utf-8"), runtime_dict
+                        spec_path.read_text(encoding="utf-8"), render_runtime
                     ),
                     source_path=spec_path,
                 )
@@ -1313,7 +1315,7 @@ def _workspace_to_preset_inner(
                     raw = cfg_yaml.read_text(encoding="utf-8")
                     parsed = (
                         _load_yaml(
-                            _apply_runtime_substitutions(raw, runtime_dict),
+                            _apply_runtime_substitutions(raw, render_runtime),
                             source_path=cfg_yaml,
                         )
                         or {}
@@ -1347,7 +1349,7 @@ def _workspace_to_preset_inner(
             hook_cfg = (
                 _load_yaml(
                     _apply_runtime_substitutions(
-                        cfg_yaml.read_text(encoding="utf-8"), runtime_dict
+                        cfg_yaml.read_text(encoding="utf-8"), render_runtime
                     ),
                     source_path=cfg_yaml,
                 )

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -42,6 +42,8 @@ import sys
 import time
 from pathlib import Path
 
+from looplet.bundled import bundled_cartridge_path
+
 
 def _bold(s: str) -> str:
     return f"\033[1m{s}\033[0m" if sys.stdout.isatty() else s
@@ -109,21 +111,13 @@ def _factory_workspace_path() -> Path:
     if env_override and Path(env_override).is_dir():
         return Path(env_override)
 
-    # Walk up from this file looking for the bundled factory directory.
-    here = Path(__file__).resolve()
-    for parent in [here.parent, *here.parents]:
-        source_candidate = parent / "examples" / "agent_factory.cartridge"
-        if source_candidate.is_dir():
-            return source_candidate
-
-    installed_candidate = here.parents[1] / "_bundled" / "agent_factory.cartridge"
-    if installed_candidate.is_dir():
-        return installed_candidate
-
-    raise FileNotFoundError(
-        "Could not locate the bundled agent_factory.cartridge. "
-        "Reinstall looplet or set LOOPLET_FACTORY_DIR to an explicit factory cartridge."
-    )
+    try:
+        return bundled_cartridge_path("agent_factory")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            "Could not locate the bundled agent_factory.cartridge. "
+            "Reinstall looplet or set LOOPLET_FACTORY_DIR to an explicit factory cartridge."
+        ) from exc
 
 
 # ── ``looplet new`` ─────────────────────────────────────────────

--- a/src/looplet/examples/coding_agent.py
+++ b/src/looplet/examples/coding_agent.py
@@ -82,6 +82,10 @@ def _bash(*, command: str, workspace: str = "") -> dict:
     shell can do. Prefer this over specialized tools when the
     task is naturally expressed as a shell command.
     """
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join(
+        part for part in (os.path.dirname(sys.executable), env.get("PATH", "")) if part
+    )
     try:
         result = subprocess.run(
             ["bash", "-c", command],
@@ -89,6 +93,7 @@ def _bash(*, command: str, workspace: str = "") -> dict:
             text=True,
             timeout=60,
             cwd=workspace or None,
+            env=env,
         )
         output = result.stdout.strip()
         err = result.stderr.strip()

--- a/tests/test_bundled_cartridges.py
+++ b/tests/test_bundled_cartridges.py
@@ -1,0 +1,49 @@
+"""Public discovery contract for cartridges shipped inside Looplet."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from looplet import bundled_cartridge_path
+from looplet.cartridge import analyse_cartridge
+
+
+@pytest.mark.parametrize("name", ["agent_factory", "coder", "coder_portable"])
+def test_bundled_cartridge_path_resolves_source_checkout(name: str) -> None:
+    cartridge = bundled_cartridge_path(name)
+
+    assert cartridge.name == f"{name}.cartridge"
+    assert (cartridge / "cartridge.json").is_file()
+
+
+def test_bundled_portable_coder_has_no_inprocess_blockers() -> None:
+    report = analyse_cartridge(bundled_cartridge_path("coder_portable"))
+
+    assert report.profile == "portable"
+    assert report.blockers == ()
+
+
+def test_bundled_cartridge_path_resolves_installed_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from looplet import bundled
+
+    package_root = tmp_path / "site-packages" / "looplet"
+    fake_module = package_root / "bundled.py"
+    cartridge = package_root / "_bundled" / "coder_portable.cartridge"
+    fake_module.parent.mkdir(parents=True)
+    cartridge.mkdir(parents=True)
+    (cartridge / "cartridge.json").write_text('{"schema_version": 2, "name": "coder_portable"}\n')
+
+    monkeypatch.setattr(bundled, "__file__", str(fake_module))
+
+    assert bundled.bundled_cartridge_path("coder_portable") == cartridge
+
+
+@pytest.mark.parametrize("name", ["", ".", "../coder", "nested/coder", "nested\\coder"])
+def test_bundled_cartridge_path_rejects_unsafe_names(name: str) -> None:
+    with pytest.raises(ValueError, match="cartridge name"):
+        bundled_cartridge_path(name)

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -178,17 +178,18 @@ def test_factory_workspace_path_resolves_installed_bundle(
     tmp_path: Path,
 ) -> None:
     """An installed wheel resolves package data without a repo checkout."""
+    from looplet import bundled
     from looplet.cli import factory_commands
 
     package_root = tmp_path / "site-packages" / "looplet"
-    fake_module = package_root / "cli" / "factory_commands.py"
+    fake_module = package_root / "bundled.py"
     factory = package_root / "_bundled" / "agent_factory.cartridge"
     fake_module.parent.mkdir(parents=True)
     factory.mkdir(parents=True)
     (factory / "cartridge.json").write_text('{"schema_version": 2, "name": "factory"}')
 
     monkeypatch.delenv("LOOPLET_FACTORY_DIR", raising=False)
-    monkeypatch.setattr(factory_commands, "__file__", str(fake_module))
+    monkeypatch.setattr(bundled, "__file__", str(fake_module))
 
     assert factory_commands._factory_workspace_path() == factory
 

--- a/tests/test_example_coder_portable_cartridge.py
+++ b/tests/test_example_coder_portable_cartridge.py
@@ -29,6 +29,7 @@ The tests prove the twin composes across process boundaries:
 
 from __future__ import annotations
 
+import shutil
 import socket
 from pathlib import Path
 
@@ -75,6 +76,23 @@ def test_coder_portable_static_profile_is_portable() -> None:
     report = analyse_cartridge(_CARTRIDGE)
     assert report.profile == "portable"
     assert report.blockers == ()
+
+
+@pytest.mark.timeout(90)
+def test_coder_portable_loads_from_path_with_spaces(monkeypatch, tmp_path) -> None:
+    project = tmp_path / "project with spaces"
+    project.mkdir()
+    cartridge = tmp_path / "portable coder.cartridge"
+    shutil.copytree(_CARTRIDGE, cartridge)
+    monkeypatch.setenv("LOOPLET_PROJECT_ROOT", str(project))
+
+    preset = cartridge_to_preset(cartridge, strict=True)
+    try:
+        assert len(preset.state_service_handles) == 1
+        assert len(preset.mcp_adapters) == 1
+        assert set(preset.tools.tool_names) == _TOOLS
+    finally:
+        preset.close()
 
 
 @pytest.mark.timeout(90)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -60,3 +60,25 @@ def test_site_roadmap_matches_canonical_direction() -> None:
 
 def test_site_contributing_guide_matches_canonical_guide() -> None:
     assert (ROOT / "docs" / "contributing.md").read_text() == (ROOT / "CONTRIBUTING.md").read_text()
+
+
+def test_portable_coder_is_in_both_distribution_formats() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    wheel_files = project["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    sdist_files = project["tool"]["hatch"]["build"]["targets"]["sdist"]["include"]
+
+    source = "examples/coder_portable.cartridge"
+    assert wheel_files[source] == "looplet/_bundled/coder_portable.cartridge"
+    assert source in sdist_files
+    assert (
+        wheel_files["tests/fixtures/coder_skill_bundle/__init__.py"]
+        == "tests/fixtures/coder_skill_bundle/__init__.py"
+    )
+
+
+def test_tag_publish_creates_a_github_release_from_built_artifacts() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+
+    assert "name: create GitHub release" in workflow
+    assert "needs: [build, publish]" in workflow
+    assert 'gh release create "$GITHUB_REF_NAME" dist/*' in workflow


### PR DESCRIPTION
## Summary

- bundle `coder_portable.cartridge` in wheel and sdist with a public `bundled_cartridge_path()` locator
- prove the installed artifact starts MCP and SSP services and exposes the coding tool surface
- use the active Looplet interpreter for shipped Python protocol servers, including paths with spaces
- position portable coder as the flagship protocol reference with explicit evidence limits
- create an idempotent GitHub Release with wheel, sdist, and changelog notes after PyPI publication
- repair the packaged coding example so `python -m pytest` uses the active Looplet environment

## Validation

- full suite: 2,347 passed, 2 skipped
- release and portability contracts: 94 passed
- all portable examples/protocol surfaces: 76 passed
- Ruff, Ruff format, and Pyright: clean
- `mkdocs build --strict` and text-style guard: clean
- clean wheel smoke starts portable coder MCP/SSP, loads factory and coder skill bundle
- wheel/sdist archive audit: 53 portable-coder files each, zero bytecode
- desktop/mobile browser checks: no overflow; portability remains secondary to the regression proof