### PR TITLE
Recipe: migrate a private tool loop to one outcome-grounded regression contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Private-loop migration recipe.** `examples/private_loop_migration/` evolves
+  one tiny agent from a hand-written loop to `composable_loop()`, captured
+  provenance, and a required outcome grader, with no provider, network call, or
+  cartridge in any of the four stages. `docs/migrate.md` walks the stages and
+  states when the original raw loop remains the better choice.
+
 ## [0.4.0] - 2026-08-28
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Private-loop migration recipe.** `examples/private_loop_migration/` evolves
+  one tiny agent from a hand-written loop to `composable_loop()`, captured
+  provenance, and a required outcome grader, with no provider, network call, or
+  cartridge in any of the four stages. `docs/migrate.md` walks the stages and
+  states when the original raw loop remains the better choice.
+
 ## [0.4.0] - 2026-08-28
 
 ### Added

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -8,6 +8,9 @@ The first useful milestone is small: your existing tools run through
 `composable_loop()`, and every dispatch is returned to your code as a `Step`.
 Capture, hooks, cartridges, and eval gates can follow independently.
 
+The checkpoints below are executable end to end as one network-free example;
+see [run the whole recipe](#run-the-whole-recipe).
+
 ## Map what you already own
 
 | Existing harness responsibility | Looplet surface |
@@ -186,6 +189,95 @@ looplet hash ./agent.cartridge
 Cartridges are a file representation of the same `AgentPreset` used by the
 Python API. They are not required to use the loop, hooks, provenance, replay,
 or eval primitives.
+
+## Run the whole recipe
+
+The steps above are executable as one example. It migrates a tiny on-call
+handoff agent that hands resolved incidents to the next owner as if they were
+still open work. No provider, network call, or cartridge is involved.
+
+```bash
+uv run python -m examples.private_loop_migration
+```
+
+```text
+1. REPLACE the loop, keep the private tools
+   raw loop:        list_incidents -> publish_handoff -> done
+   composable_loop: list_incidents -> publish_handoff -> done
+   private callables that ran: list_incidents -> publish_handoff
+   same tools reused:      true
+   same handoff written:   true
+
+2. CAPTURE the failing run as ordinary files
+   model calls recorded: 3
+
+3. GRADE the outcome the host observed, not the route
+   collected open_count: 4 (expected 2)
+   required eval: FAIL (0.00)
+
+4. FIX one tool implementation and replay the recorded decisions
+   - return list(incidents)
+   + return [incident for incident in incidents if incident["status"] != "resolved"]
+   replayed:                list_incidents -> publish_handoff -> done
+   same recorded decisions: true
+   collected open_count: 2 (expected 2)
+   required eval: PASS (1.00)
+```
+
+Each stage is one change:
+
+1. **Replace the loop.** `tools_from([...], include_done=True)` registers the
+   callables the private loop already dispatched, and `composable_loop()` takes
+   over prompt assembly, parsing, dispatch, and the stop condition. Both loops
+   write the same wrong `handoff.json`, which is the parity check that keeps
+   the loop swap attributable.
+2. **Capture the failure.** `ProvenanceSink` writes the prompts, responses,
+   trajectory, and stop reason as files you can read and attach to an issue.
+3. **Grade the outcome.** An `EvalHook` collector reads `handoff.json` from the
+   run's workspace and a required grader compares it with grader-only expected
+   data. The collector ignores the step list, so a model that reaches the same
+   correct file by another route still passes.
+4. **Fix one implementation.** One selector loses its bug, and `replay_loop()`
+   feeds the recorded responses through the fixed tool in a fresh workspace.
+   The required grader goes green while the model decisions stay identical.
+
+The last stage also asserts that replay consumed the same recorded decisions.
+That assertion is an experiment control, not the product verdict: the verdict
+comes from the collected artifact. Grading the trajectory instead would fail
+the first time a better model reordered two safe reads.
+
+No stage loads a cartridge. Cartridges stay where step 7 puts them: optional
+packaging for review once the harness already has a contract.
+
+The pieces are deliberately separate:
+
+- [`handoff_tools.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/handoff_tools.py)
+  keeps the private tool callables and the one implementation that changes.
+- [`handoff_contract.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/handoff_contract.py)
+  holds the case, the world-state collector, and the required grader.
+- [`run_recipe.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/run_recipe.py)
+  wires the four stages and prints the summary above.
+- [`tests/test_private_loop_migration.py`](https://github.com/hsaghir/looplet/blob/master/tests/test_private_loop_migration.py)
+  is the CI gate: it proves the reuse, the red-to-green contract, and that the
+  four stages stay cartridge-free.
+
+### When the raw loop is still the better choice
+
+Keep the loop you have when:
+
+- it is a few lines around one experiment you expect to delete, and no
+  regression has cost you anything yet;
+- nobody else has to review or change it;
+- the product is naturally a branching, durable, multi-stage workflow, where a
+  graph or workflow runtime fits better than one owned loop (see the
+  [selection guide](why-looplet.md));
+- success can only be judged by reading the transcript. A collector that cannot
+  observe the outcome independently will end up encoding a preferred
+  trajectory, which is a weaker contract than a person reading the trace.
+
+Adopt a stage when it removes work you are already doing by hand. Stopping
+after step 2, with your existing tools running through `composable_loop()` and
+nothing else adopted, is a complete outcome.
 
 ## Migration sequence
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -255,6 +255,10 @@ The pieces are deliberately separate:
   keeps the private tool callables and the one implementation that changes.
 - [`handoff_contract.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/handoff_contract.py)
   holds the case, the world-state collector, and the required grader.
+- [`execution.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/execution.py)
+  keeps the raw loop, the owned loop, and replay on one inspectable boundary.
+- [`result.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/result.py)
+  records the evidence and object identities checked by the focused test.
 - [`run_recipe.py`](https://github.com/hsaghir/looplet/blob/master/examples/private_loop_migration/run_recipe.py)
   wires the four stages and prints the summary above.
 - [`tests/test_private_loop_migration.py`](https://github.com/hsaghir/looplet/blob/master/tests/test_private_loop_migration.py)

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -194,7 +194,9 @@ or eval primitives.
 
 The steps above are executable as one example. It migrates a tiny on-call
 handoff agent that hands resolved incidents to the next owner as if they were
-still open work. No provider, network call, or cartridge is involved.
+still open work. No provider, network call, or cartridge is involved. The module
+command below is a source checkout command; sdists include the recipe so the
+focused tests can run from an extracted source distribution.
 
 ```bash
 uv run python -m examples.private_loop_migration

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -227,6 +227,8 @@ and required graders before shipping.
 
 ## Next
 
+- [Migrate an existing loop](migrate.md#run-the-whole-recipe): keep your tool
+  callables, replace only the loop, and land one required outcome grader.
 - [Tutorial](tutorial.md): build a colocated case, collector, and required grader.
 - [Cartridges](cartridge.md): file layout, refs, inheritance, and boundaries.
 - [Provenance](provenance.md): capture and controlled re-execution.

--- a/docs/why-looplet.md
+++ b/docs/why-looplet.md
@@ -159,5 +159,11 @@ executable. It captures a failing run, changes one tool line, replays
 the same model decisions against fresh code, and turns an independent
 world-state check from red to green.
 
+If you already own a loop, the
+[migration recipe](migrate.md#run-the-whole-recipe) applies the same proof to
+existing code: it keeps the tool callables, replaces only the loop, and lands
+one required grader that reads world state. It also says when keeping your raw
+loop is the better call.
+
 [Run the proof →](regression-demo.md){ .md-button .md-button--primary }
 [Start with your own loop →](quickstart.md){ .md-button }

--- a/examples/private_loop_migration/README.md
+++ b/examples/private_loop_migration/README.md
@@ -13,6 +13,11 @@ Run it from the repository root:
 uv run python -m examples.private_loop_migration
 ```
 
+Without `--out`, each invocation creates a unique evidence directory under
+the system temporary directory, so overlapping runs cannot reset each other.
+Supplying `--out` makes replacement explicit; the recipe only resets a prior
+directory carrying its own marker file.
+
 Expected core output:
 
 ```text
@@ -49,7 +54,9 @@ artifacts, the grader-only expected data, and the grader results.
   owned, plus the one buggy implementation the last stage replaces.
 - `handoff_contract.py`: the case, the collector that reads the
   workspace, and the required grader.
-- `run_recipe.py`: the four stages, the summary, and the CLI.
+- `execution.py`: the raw loop, the owned loop, and captured-response replay.
+- `result.py`: the evidence and identity record returned to callers.
+- `run_recipe.py`: the four-stage orchestration, summary, and CLI.
 
 ## What this proves
 

--- a/examples/private_loop_migration/README.md
+++ b/examples/private_loop_migration/README.md
@@ -7,7 +7,7 @@ four stages with no provider, no network call, and no cartridge.
 The agent has a bug worth catching: it hands resolved incidents to the
 next owner as if they were still open work.
 
-Run it from the repository root:
+Run it from a source checkout repository root:
 
 ```bash
 uv run python -m examples.private_loop_migration

--- a/examples/private_loop_migration/README.md
+++ b/examples/private_loop_migration/README.md
@@ -1,0 +1,72 @@
+# Private tool loop → outcome-grounded regression contract
+
+A team that already owns a model/tool loop can adopt Looplet one boundary
+at a time. This example evolves one tiny on-call handoff agent through
+four stages with no provider, no network call, and no cartridge.
+
+The agent has a bug worth catching: it hands resolved incidents to the
+next owner as if they were still open work.
+
+Run it from the repository root:
+
+```bash
+uv run python -m examples.private_loop_migration
+```
+
+Expected core output:
+
+```text
+1. REPLACE the loop, keep the private tools
+   raw loop:        list_incidents -> publish_handoff -> done
+   composable_loop: list_incidents -> publish_handoff -> done
+   private callables that ran: list_incidents -> publish_handoff
+   same tools reused:      true
+   same handoff written:   true
+
+2. CAPTURE the failing run as ordinary files
+   model calls recorded: 3
+
+3. GRADE the outcome the host observed, not the route
+   collected open_count: 4 (expected 2)
+   required eval: FAIL (0.00)
+
+4. FIX one tool implementation and replay the recorded decisions
+   - return list(incidents)
+   + return [incident for incident in incidents if incident["status"] != "resolved"]
+   replayed:                list_incidents -> publish_handoff -> done
+   same recorded decisions: true
+   collected open_count: 2 (expected 2)
+   required eval: PASS (1.00)
+```
+
+The evidence directory holds a separate seeded workspace per stage, the
+captured prompts and responses, both trajectories, the collected
+artifacts, the grader-only expected data, and the grader results.
+
+## Files
+
+- `handoff_tools.py`: the tool callables the private harness already
+  owned, plus the one buggy implementation the last stage replaces.
+- `handoff_contract.py`: the case, the collector that reads the
+  workspace, and the required grader.
+- `run_recipe.py`: the four stages, the summary, and the CLI.
+
+## What this proves
+
+- A loop swap can be attributed: both loops dispatch the same callables
+  through one `tools_from(...)` registry and write the same file.
+- A failing run becomes ordinary files that a person can read.
+- A required grader can read world state instead of a preferred tool
+  sequence, so a model that takes another valid route still passes.
+- Captured-response replay isolates a tool change from model variation.
+
+## What this does not prove
+
+Replay fixes the recorded model responses; the tools execute again, so
+clocks, networks, and other side effects stay live unless you isolate
+them. It says nothing about whether a prompt change would produce better
+decisions, which needs new sampled runs.
+
+The guide that walks each stage is [`docs/migrate.md`](../../docs/migrate.md),
+and [`tests/test_private_loop_migration.py`](../../tests/test_private_loop_migration.py)
+is the gate that keeps this example honest.

--- a/examples/private_loop_migration/__init__.py
+++ b/examples/private_loop_migration/__init__.py
@@ -1,0 +1,49 @@
+"""Cartridge-free recipe: a private tool loop becomes a regression contract."""
+
+from .handoff_contract import (
+    CASE,
+    build_eval_hook,
+    eval_open_incidents_are_correct,
+    live_task,
+    make_handoff_collector,
+    required_score,
+)
+from .handoff_tools import (
+    HANDOFF_FILE,
+    INCIDENTS_FILE,
+    ToolSuite,
+    build_tool_suite,
+    changed_implementation_lines,
+    select_open_incidents,
+    select_open_incidents_with_bug,
+)
+from .run_recipe import (
+    MigrationResult,
+    build_registry,
+    render,
+    run_migration,
+    run_owned_loop,
+    run_raw_loop,
+)
+
+__all__ = [
+    "CASE",
+    "HANDOFF_FILE",
+    "INCIDENTS_FILE",
+    "MigrationResult",
+    "ToolSuite",
+    "build_eval_hook",
+    "build_registry",
+    "build_tool_suite",
+    "changed_implementation_lines",
+    "eval_open_incidents_are_correct",
+    "live_task",
+    "make_handoff_collector",
+    "render",
+    "required_score",
+    "run_migration",
+    "run_owned_loop",
+    "run_raw_loop",
+    "select_open_incidents",
+    "select_open_incidents_with_bug",
+]

--- a/examples/private_loop_migration/__init__.py
+++ b/examples/private_loop_migration/__init__.py
@@ -1,5 +1,10 @@
 """Cartridge-free recipe: a private tool loop becomes a regression contract."""
 
+from .execution import (
+    build_registry,
+    run_owned_loop,
+    run_raw_loop,
+)
 from .handoff_contract import (
     CASE,
     build_eval_hook,
@@ -17,13 +22,10 @@ from .handoff_tools import (
     select_open_incidents,
     select_open_incidents_with_bug,
 )
+from .result import MigrationResult
 from .run_recipe import (
-    MigrationResult,
-    build_registry,
     render,
     run_migration,
-    run_owned_loop,
-    run_raw_loop,
 )
 
 __all__ = [

--- a/examples/private_loop_migration/__main__.py
+++ b/examples/private_loop_migration/__main__.py
@@ -1,0 +1,8 @@
+"""Run the recipe: ``python -m examples.private_loop_migration``."""
+
+from __future__ import annotations
+
+from .run_recipe import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/private_loop_migration/execution.py
+++ b/examples/private_loop_migration/execution.py
@@ -1,0 +1,168 @@
+"""Offline raw, owned-loop, and replay execution for the migration recipe."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from looplet import (
+    BaseToolRegistry,
+    DefaultState,
+    EvalHook,
+    LoopConfig,
+    ProvenanceSink,
+    ToolCall,
+    composable_loop,
+    replay_loop,
+    tools_from,
+)
+from looplet.testing import MockLLMBackend
+
+from .handoff_contract import live_task
+from .handoff_tools import ToolSuite
+
+DONE_TOOL = "done"
+MAX_STEPS = 4
+SYSTEM_PROMPT = "You hand an on-call shift over. Record the work the next owner still carries."
+
+MODEL_RESPONSES = [
+    json.dumps(
+        {
+            "tool": "list_incidents",
+            "args": {},
+            "reasoning": "read the shift log before writing anything",
+        }
+    ),
+    json.dumps(
+        {
+            "tool": "publish_handoff",
+            "args": {"owner": "day-shift"},
+            "reasoning": "write the handoff file",
+        }
+    ),
+    json.dumps(
+        {
+            "tool": DONE_TOOL,
+            "args": {"summary": "handoff file written for day-shift"},
+            "reasoning": "the requested file exists",
+        }
+    ),
+]
+
+
+def build_registry(suite: ToolSuite) -> BaseToolRegistry:
+    """Build the one registry reused across the pre-fix stages of a run."""
+    return tools_from(list(suite.callables.values()), include_done=True)
+
+
+def run_raw_loop(
+    suite: ToolSuite,
+    *,
+    registry: BaseToolRegistry | None = None,
+    workspace: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Run the private while-loop through the supplied registry."""
+    llm = _scripted_backend()
+    active_registry = registry or build_registry(suite)
+    suite.bind_workspace(workspace or suite.workspace)
+    task = live_task()
+    decisions: list[str] = []
+    observations: list[str] = []
+    for _ in range(MAX_STEPS):
+        response = llm.generate(_raw_prompt(task, observations), system_prompt=SYSTEM_PROMPT)
+        call = _parse_call(response)
+        decisions.append(call.tool)
+        if call.tool == DONE_TOOL:
+            break
+        result = active_registry.dispatch(call)
+        if result.error is not None:
+            raise RuntimeError(f"raw loop tool {call.tool!r} failed: {result.error}")
+        observations.append(f"{call.tool} -> {json.dumps(result.data)}")
+    return tuple(decisions)
+
+
+def run_owned_loop(
+    suite: ToolSuite,
+    *,
+    registry: BaseToolRegistry | None = None,
+    workspace: str | Path | None = None,
+    sink: ProvenanceSink | None = None,
+    eval_hook: EvalHook | None = None,
+) -> tuple[str, ...]:
+    """Run the same tools through ``composable_loop()``."""
+    llm: Any = _scripted_backend()
+    hooks: list[Any] = []
+    if sink is not None:
+        llm = sink.wrap_llm(llm)
+        hooks.append(sink.trajectory_hook())
+    if eval_hook is not None:
+        hooks.append(eval_hook)
+    active_registry = registry or build_registry(suite)
+    suite.bind_workspace(workspace or suite.workspace)
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=active_registry,
+            hooks=hooks,
+            task=live_task(),
+            config=_loop_config(),
+            state=DefaultState(max_steps=MAX_STEPS),
+        )
+    )
+    if sink is not None:
+        sink.flush()
+    return tuple(step.tool_call.tool for step in steps)
+
+
+def replay_with_fixed_tools(
+    suite: ToolSuite,
+    trace_dir: Path,
+    eval_hook: EvalHook,
+    *,
+    registry: BaseToolRegistry | None = None,
+    workspace: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Re-execute recorded decisions against the fixed implementation."""
+    active_registry = registry or build_registry(suite)
+    suite.bind_workspace(workspace or suite.workspace)
+    steps = list(
+        replay_loop(
+            trace_dir,
+            tools=active_registry,
+            state=DefaultState(max_steps=MAX_STEPS),
+            hooks=[eval_hook],
+            config=_loop_config(),
+            task=live_task(),
+        )
+    )
+    return tuple(step.tool_call.tool for step in steps)
+
+
+def _scripted_backend() -> MockLLMBackend:
+    return MockLLMBackend(responses=list(MODEL_RESPONSES), cycle=False)
+
+
+def _parse_call(response: str) -> ToolCall:
+    payload = json.loads(response)
+    return ToolCall(
+        tool=str(payload["tool"]),
+        args=dict(payload.get("args", {})),
+        reasoning=str(payload.get("reasoning", "")),
+    )
+
+
+def _loop_config() -> LoopConfig:
+    return LoopConfig(max_steps=MAX_STEPS, use_native_tools=False, system_prompt=SYSTEM_PROMPT)
+
+
+def _raw_prompt(task: dict[str, Any], observations: list[str]) -> str:
+    lines = [
+        f"goal: {task['goal']}",
+        "",
+        "tools: list_incidents(), publish_handoff(owner), done(summary)",
+    ]
+    if observations:
+        lines += ["", "observations:", *observations]
+    lines += ["", 'Reply with {"tool": ..., "args": {...}}.']
+    return "\n".join(lines)

--- a/examples/private_loop_migration/handoff_contract.py
+++ b/examples/private_loop_migration/handoff_contract.py
@@ -1,0 +1,94 @@
+"""The host-owned contract: one case, one collector, one required grader.
+
+The case carries its seed files and its expected result as data. Expected
+data stays out of the task the agent receives, so the grader cannot be
+satisfied by a model that read the answer from its own prompt.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from looplet import EvalCase, EvalContext, EvalHook, EvalResult, eval_mark
+
+from .handoff_tools import HANDOFF_FILE, INCIDENTS_FILE
+
+SHIFT_LOG = {
+    "shift": "2026-07-14-night",
+    "incidents": [
+        {"id": "INC-101", "summary": "checkout latency", "status": "resolved"},
+        {"id": "INC-102", "summary": "stuck payout batch", "status": "open"},
+        {"id": "INC-103", "summary": "search replica lag", "status": "monitoring"},
+        {"id": "INC-104", "summary": "expired staging cert", "status": "resolved"},
+    ],
+}
+
+CASE = EvalCase(
+    id="night_shift_handoff",
+    task={
+        "goal": "Read the shift log, then write the handoff file for the day-shift owner.",
+        "files": {INCIDENTS_FILE: json.dumps(SHIFT_LOG, indent=2) + "\n"},
+    },
+    expected={"open_count": 2, "open_ids": ["INC-102", "INC-103"]},
+    marks=["smoke", "regression"],
+    notes="Derived from a run that handed resolved incidents to the next owner as open work.",
+)
+
+
+def live_task() -> dict[str, Any]:
+    """The task the agent sees: no seed files and no expected result."""
+    return {key: value for key, value in CASE.task.items() if key != "files"}
+
+
+def make_handoff_collector(workspace: str | Path) -> Callable[[Any], dict[str, Any]]:
+    """Build a collector that reads the workspace the run acted on."""
+    root = Path(workspace)
+
+    def collect_handoff(state: Any) -> dict[str, Any]:
+        """Report the observed handoff file, whatever route produced it."""
+        # `state` carries the step list. This collector never reads it:
+        # the verdict has to survive a model that takes another route to
+        # the same correct outcome.
+        path = root / HANDOFF_FILE
+        if not path.is_file():
+            return {"handoff_exists": False}
+        try:
+            handoff = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return {"handoff_exists": True, "handoff_error": str(exc)}
+        return {
+            "handoff_exists": True,
+            "observed_open_count": handoff.get("open_count"),
+            "observed_open_ids": handoff.get("open_ids"),
+        }
+
+    return collect_handoff
+
+
+@eval_mark("required")
+def eval_open_incidents_are_correct(ctx: EvalContext):
+    """Compare the collected handoff with the grader-only expected result."""
+    expected = ctx.task.get("expected", {})
+    return ctx.artifacts.get("observed_open_count") == expected.get(
+        "open_count"
+    ) and ctx.artifacts.get("observed_open_ids") == expected.get("open_ids")
+
+
+def build_eval_hook(workspace: str | Path) -> EvalHook:
+    """Wire the collector and the required grader for one workspace."""
+    return EvalHook(
+        evaluators=[eval_open_incidents_are_correct],
+        collectors=[make_handoff_collector(workspace)],
+        expected=CASE.expected,
+    )
+
+
+def required_score(results: list[EvalResult]) -> float:
+    """Score of the required grader, or raise when it did not run."""
+    name = eval_open_incidents_are_correct.__name__
+    for result in results:
+        if result.name == name:
+            return float(result.score if result.score is not None else 0.0)
+    raise RuntimeError(f"required grader {name} did not run")

--- a/examples/private_loop_migration/handoff_tools.py
+++ b/examples/private_loop_migration/handoff_tools.py
@@ -23,6 +23,11 @@ Selector = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
 ToolCallable = Callable[..., dict[str, Any]]
 
 
+@dataclass
+class _WorkspaceBinding:
+    path: Path
+
+
 def select_open_incidents_with_bug(incidents: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Original implementation: it never drops the resolved incidents."""
     return list(incidents)
@@ -48,10 +53,18 @@ class ToolSuite:
     rather than a rewritten copy of it.
     """
 
-    workspace: Path
+    _workspace: _WorkspaceBinding
     select_open: Selector
     callables: dict[str, ToolCallable]
     invocations: list[str]
+
+    @property
+    def workspace(self) -> Path:
+        return self._workspace.path
+
+    def bind_workspace(self, workspace: str | Path) -> None:
+        """Point this run's unchanged callables at the next stage workspace."""
+        self._workspace.path = Path(workspace)
 
 
 def build_tool_suite(
@@ -65,31 +78,31 @@ def build_tool_suite(
     taking them as model-visible arguments, which is what keeps the tool
     schemas identical before and after the migration.
     """
-    root = Path(workspace)
+    binding = _WorkspaceBinding(Path(workspace))
     invocations: list[str] = []
 
     def list_incidents() -> dict[str, Any]:
         """List every incident recorded during the finished shift."""
         invocations.append("list_incidents")
-        return {"incidents": read_incidents(root)}
+        return {"incidents": read_incidents(binding.path)}
 
     def publish_handoff(owner: str) -> dict[str, Any]:
         """Write the handoff file for the next on-call owner."""
         invocations.append("publish_handoff")
-        open_incidents = select_open(read_incidents(root))
+        open_incidents = select_open(read_incidents(binding.path))
         handoff = {
             "owner": owner,
             "open_count": len(open_incidents),
             "open_ids": [incident["id"] for incident in open_incidents],
         }
-        (root / HANDOFF_FILE).write_text(
+        (binding.path / HANDOFF_FILE).write_text(
             json.dumps(handoff, indent=2) + "\n",
             encoding="utf-8",
         )
         return {"written": HANDOFF_FILE, "open_count": handoff["open_count"]}
 
     return ToolSuite(
-        workspace=root,
+        _workspace=binding,
         select_open=select_open,
         callables={"list_incidents": list_incidents, "publish_handoff": publish_handoff},
         invocations=invocations,

--- a/examples/private_loop_migration/handoff_tools.py
+++ b/examples/private_loop_migration/handoff_tools.py
@@ -1,0 +1,116 @@
+"""Tool implementations a private on-call harness already owned.
+
+Nothing in this module imports the loop. The migration keeps these
+callables unchanged and replaces only the loop around them, so the raw
+loop and `composable_loop()` dispatch the same code.
+
+`select_open_incidents_with_bug` is the one implementation the recipe
+replaces in its final stage. Every earlier stage uses it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+INCIDENTS_FILE = "incidents.json"
+HANDOFF_FILE = "handoff.json"
+
+Selector = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+ToolCallable = Callable[..., dict[str, Any]]
+
+
+def select_open_incidents_with_bug(incidents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Original implementation: it never drops the resolved incidents."""
+    return list(incidents)
+
+
+def select_open_incidents(incidents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fixed implementation: only the work the next owner still carries."""
+    return [incident for incident in incidents if incident["status"] != "resolved"]
+
+
+def read_incidents(workspace: str | Path) -> list[dict[str, Any]]:
+    """Read the shift log the harness was pointed at."""
+    raw = (Path(workspace) / INCIDENTS_FILE).read_text(encoding="utf-8")
+    return list(json.loads(raw)["incidents"])
+
+
+@dataclass(frozen=True)
+class ToolSuite:
+    """The private tool callables, bound to one workspace.
+
+    `invocations` records the name of every private callable that ran.
+    The recipe uses it to show that the loop swap dispatched this suite
+    rather than a rewritten copy of it.
+    """
+
+    workspace: Path
+    select_open: Selector
+    callables: dict[str, ToolCallable]
+    invocations: list[str]
+
+
+def build_tool_suite(
+    workspace: str | Path,
+    *,
+    select_open: Selector = select_open_incidents_with_bug,
+) -> ToolSuite:
+    """Bind the private tool callables to `workspace`.
+
+    The callables close over the workspace and the selector instead of
+    taking them as model-visible arguments, which is what keeps the tool
+    schemas identical before and after the migration.
+    """
+    root = Path(workspace)
+    invocations: list[str] = []
+
+    def list_incidents() -> dict[str, Any]:
+        """List every incident recorded during the finished shift."""
+        invocations.append("list_incidents")
+        return {"incidents": read_incidents(root)}
+
+    def publish_handoff(owner: str) -> dict[str, Any]:
+        """Write the handoff file for the next on-call owner."""
+        invocations.append("publish_handoff")
+        open_incidents = select_open(read_incidents(root))
+        handoff = {
+            "owner": owner,
+            "open_count": len(open_incidents),
+            "open_ids": [incident["id"] for incident in open_incidents],
+        }
+        (root / HANDOFF_FILE).write_text(
+            json.dumps(handoff, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return {"written": HANDOFF_FILE, "open_count": handoff["open_count"]}
+
+    return ToolSuite(
+        workspace=root,
+        select_open=select_open,
+        callables={"list_incidents": list_incidents, "publish_handoff": publish_handoff},
+        invocations=invocations,
+    )
+
+
+def changed_implementation_lines() -> tuple[str, str]:
+    """Quote the line that differs between the two selectors.
+
+    Reading the lines from source keeps the printed change honest: edit
+    either selector and this output follows.
+    """
+    return (
+        _return_line(select_open_incidents_with_bug),
+        _return_line(select_open_incidents),
+    )
+
+
+def _return_line(fn: Selector) -> str:
+    for line in inspect.getsource(fn).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("return "):
+            return stripped
+    raise RuntimeError(f"{fn.__name__} has no return statement to quote")

--- a/examples/private_loop_migration/result.py
+++ b/examples/private_loop_migration/result.py
@@ -1,0 +1,50 @@
+"""Result record for the private-loop migration recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from looplet import BaseToolRegistry
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Evidence and control identities produced by the four stages."""
+
+    output_dir: Path
+    raw_decisions: tuple[str, ...]
+    owned_decisions: tuple[str, ...]
+    graded_decisions: tuple[str, ...]
+    replayed_decisions: tuple[str, ...]
+    raw_invocations: tuple[str, ...]
+    owned_invocations: tuple[str, ...]
+    raw_handoff: dict[str, Any]
+    owned_handoff: dict[str, Any]
+    before_fix_artifacts: dict[str, Any]
+    after_fix_artifacts: dict[str, Any]
+    before_fix_score: float
+    after_fix_score: float
+    recorded_calls: int
+    failure_run: Path
+    fixed_run: Path
+    changed_lines: tuple[str, str]
+    raw_registry: BaseToolRegistry
+    owned_registry: BaseToolRegistry
+    private_callables: dict[str, Any]
+
+    @property
+    def reuses_private_tools(self) -> bool:
+        """True when both loops dispatched the same private callables."""
+        return bool(self.raw_invocations) and self.raw_invocations == self.owned_invocations
+
+    @property
+    def loop_swap_kept_the_outcome(self) -> bool:
+        """True when replacing the loop changed neither decisions nor world state."""
+        return self.raw_decisions == self.owned_decisions and self.raw_handoff == self.owned_handoff
+
+    @property
+    def same_recorded_decisions(self) -> bool:
+        """True when replay consumed the decisions the failing run recorded."""
+        return self.replayed_decisions == self.graded_decisions

--- a/examples/private_loop_migration/run_recipe.py
+++ b/examples/private_loop_migration/run_recipe.py
@@ -1,0 +1,375 @@
+"""Migrate a private tool loop to one outcome-grounded regression contract.
+
+Four stages, no cartridge and no provider:
+
+1. the private while-loop is replaced by ``composable_loop()`` while the
+   same tool callables run through one ``tools_from(...)`` registry;
+2. the failing run is captured as readable files with ``ProvenanceSink``;
+3. an ``EvalHook`` collector reads the resulting workspace and a required
+   grader turns that observation into a contract;
+4. one tool implementation is fixed and ``replay_loop()`` re-executes the
+   recorded model decisions against it.
+
+Replay is the right tool only in stage four, because the model responses
+are the variable being held fixed. Tool code executes again, so the
+workspace, the collected artifacts, and the verdict are all fresh.
+
+Two notes on how the stages are wired. The scripted ``MockLLMBackend``
+stands in for the team's provider client so every stage runs offline;
+nothing else about the private harness is a test double. Stages two and
+three share one run, because the contract grades the failure it captured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from looplet import (
+    BaseToolRegistry,
+    DefaultState,
+    EvalHook,
+    LoopConfig,
+    ProvenanceSink,
+    composable_loop,
+    replay_loop,
+    save_eval_run,
+    seed_case_workspace,
+    tools_from,
+)
+from looplet.testing import MockLLMBackend
+
+from .handoff_contract import CASE, build_eval_hook, live_task, required_score
+from .handoff_tools import (
+    HANDOFF_FILE,
+    ToolSuite,
+    build_tool_suite,
+    changed_implementation_lines,
+    select_open_incidents,
+)
+
+DONE_TOOL = "done"
+MAX_STEPS = 4
+MARKER = ".looplet-private-loop-migration"
+SYSTEM_PROMPT = "You hand an on-call shift over. Record the work the next owner still carries."
+
+MODEL_RESPONSES = [
+    json.dumps(
+        {
+            "tool": "list_incidents",
+            "args": {},
+            "reasoning": "read the shift log before writing anything",
+        }
+    ),
+    json.dumps(
+        {
+            "tool": "publish_handoff",
+            "args": {"owner": "day-shift"},
+            "reasoning": "write the handoff file",
+        }
+    ),
+    json.dumps(
+        {
+            "tool": DONE_TOOL,
+            "args": {"summary": "handoff file written for day-shift"},
+            "reasoning": "the requested file exists",
+        }
+    ),
+]
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Evidence produced by :func:`run_migration`."""
+
+    output_dir: Path
+    raw_decisions: tuple[str, ...]
+    owned_decisions: tuple[str, ...]
+    graded_decisions: tuple[str, ...]
+    replayed_decisions: tuple[str, ...]
+    raw_invocations: tuple[str, ...]
+    owned_invocations: tuple[str, ...]
+    raw_handoff: dict[str, Any]
+    owned_handoff: dict[str, Any]
+    before_fix_artifacts: dict[str, Any]
+    after_fix_artifacts: dict[str, Any]
+    before_fix_score: float
+    after_fix_score: float
+    recorded_calls: int
+    failure_run: Path
+    fixed_run: Path
+    changed_lines: tuple[str, str]
+
+    @property
+    def reuses_private_tools(self) -> bool:
+        """True when both loops dispatched the same private callables."""
+        return bool(self.raw_invocations) and self.raw_invocations == self.owned_invocations
+
+    @property
+    def loop_swap_kept_the_outcome(self) -> bool:
+        """True when replacing the loop changed neither decisions nor world state."""
+        return self.raw_decisions == self.owned_decisions and self.raw_handoff == self.owned_handoff
+
+    @property
+    def same_recorded_decisions(self) -> bool:
+        """True when replay consumed the decisions the failing run recorded."""
+        return self.replayed_decisions == self.graded_decisions
+
+
+def build_registry(suite: ToolSuite) -> BaseToolRegistry:
+    """The one ``tools_from(...)`` registry every Looplet stage reuses."""
+    return tools_from(list(suite.callables.values()), include_done=True)
+
+
+def run_raw_loop(suite: ToolSuite) -> tuple[str, ...]:
+    """The private while-loop this recipe migrates away from.
+
+    It owns prompt assembly, response parsing, dispatch, and the stop
+    condition, and it has no interception point for capture, permissions,
+    or parse recovery. Those are the responsibilities stage one hands to
+    ``composable_loop()``.
+    """
+    llm = MockLLMBackend(responses=list(MODEL_RESPONSES), cycle=False)
+    task = live_task()
+    decisions: list[str] = []
+    observations: list[str] = []
+    for _ in range(MAX_STEPS):
+        response = llm.generate(_raw_prompt(task, observations), system_prompt=SYSTEM_PROMPT)
+        call = json.loads(response)
+        name = str(call["tool"])
+        decisions.append(name)
+        if name == DONE_TOOL:
+            break
+        result = suite.callables[name](**call.get("args", {}))
+        observations.append(f"{name} -> {json.dumps(result)}")
+    return tuple(decisions)
+
+
+def run_owned_loop(
+    suite: ToolSuite,
+    *,
+    sink: ProvenanceSink | None = None,
+    eval_hook: EvalHook | None = None,
+) -> tuple[str, ...]:
+    """Run the same tools through ``composable_loop()``.
+
+    Passing neither ``sink`` nor ``eval_hook`` is stage one: the loop is
+    the only thing that changed. Stages two and three add each argument
+    without touching the tools.
+    """
+    llm: Any = MockLLMBackend(responses=list(MODEL_RESPONSES), cycle=False)
+    hooks: list[Any] = []
+    if sink is not None:
+        llm = sink.wrap_llm(llm)
+        hooks.append(sink.trajectory_hook())
+    if eval_hook is not None:
+        hooks.append(eval_hook)
+    steps = list(
+        composable_loop(
+            llm=llm,
+            tools=build_registry(suite),
+            hooks=hooks,
+            task=live_task(),
+            config=_loop_config(),
+            state=DefaultState(max_steps=MAX_STEPS),
+        )
+    )
+    if sink is not None:
+        sink.flush()
+    return tuple(step.tool_call.tool for step in steps)
+
+
+def replay_with_fixed_tools(
+    suite: ToolSuite,
+    trace_dir: Path,
+    eval_hook: EvalHook,
+) -> tuple[str, ...]:
+    """Re-execute the recorded decisions against the fixed implementation."""
+    steps = list(
+        replay_loop(
+            trace_dir,
+            tools=build_registry(suite),
+            state=DefaultState(max_steps=MAX_STEPS),
+            hooks=[eval_hook],
+            config=_loop_config(),
+            task=live_task(),
+        )
+    )
+    return tuple(step.tool_call.tool for step in steps)
+
+
+def run_migration(output_dir: str | Path | None = None) -> MigrationResult:
+    """Run the four cartridge-free stages and return their persisted evidence."""
+    root = Path(output_dir or (Path(tempfile.gettempdir()) / "looplet-private-loop-migration"))
+    _reset_output(root)
+    workspaces = root / "workspaces"
+    runs = root / "runs"
+
+    # Stage 1: replace the loop, keep the tools.
+    raw_suite = build_tool_suite(seed_case_workspace(CASE, workspaces / "raw_loop"))
+    raw_decisions = run_raw_loop(raw_suite)
+    owned_suite = build_tool_suite(seed_case_workspace(CASE, workspaces / "composable_loop"))
+    owned_decisions = run_owned_loop(owned_suite)
+
+    # Stages 2 and 3: capture the failing run, then grade what the host sees.
+    failure_workspace = seed_case_workspace(CASE, workspaces / "captured_failure")
+    failure_run = runs / "captured_failure"
+    failure_sink = ProvenanceSink(dir=failure_run)
+    failure_hook = build_eval_hook(failure_workspace)
+    graded_decisions = run_owned_loop(
+        build_tool_suite(failure_workspace),
+        sink=failure_sink,
+        eval_hook=failure_hook,
+    )
+    save_eval_run(
+        failure_run,
+        recorder=failure_sink.trajectory_hook(),
+        eval_hook=failure_hook,
+        case=CASE,
+    )
+
+    # Stage 4: fix one implementation, replay the recorded decisions.
+    fixed_workspace = seed_case_workspace(CASE, workspaces / "replayed_fix")
+    fixed_run = runs / "replayed_fix"
+    fixed_hook = build_eval_hook(fixed_workspace)
+    replayed_decisions = replay_with_fixed_tools(
+        build_tool_suite(fixed_workspace, select_open=select_open_incidents),
+        failure_run,
+        fixed_hook,
+    )
+    save_eval_run(fixed_run, eval_hook=fixed_hook, case=CASE)
+
+    return MigrationResult(
+        output_dir=root,
+        raw_decisions=raw_decisions,
+        owned_decisions=owned_decisions,
+        graded_decisions=graded_decisions,
+        replayed_decisions=replayed_decisions,
+        raw_invocations=tuple(raw_suite.invocations),
+        owned_invocations=tuple(owned_suite.invocations),
+        raw_handoff=_read_json(raw_suite.workspace / HANDOFF_FILE),
+        owned_handoff=_read_json(owned_suite.workspace / HANDOFF_FILE),
+        before_fix_artifacts=failure_hook.artifacts,
+        after_fix_artifacts=fixed_hook.artifacts,
+        before_fix_score=required_score(failure_hook.results),
+        after_fix_score=required_score(fixed_hook.results),
+        recorded_calls=_recorded_call_count(failure_run),
+        failure_run=failure_run,
+        fixed_run=fixed_run,
+        changed_lines=changed_implementation_lines(),
+    )
+
+
+def render(result: MigrationResult) -> str:
+    """Render a stable summary of the four stages."""
+    expected_open = CASE.expected["open_count"]
+    before_line, after_line = result.changed_lines
+    return "\n".join(
+        [
+            "Looplet: one private tool loop -> one outcome-grounded regression contract",
+            "",
+            "1. REPLACE the loop, keep the private tools",
+            f"   raw loop:        {_route(result.raw_decisions)}",
+            f"   composable_loop: {_route(result.owned_decisions)}",
+            f"   private callables that ran: {_route(result.owned_invocations)}",
+            f"   same tools reused:      {_flag(result.reuses_private_tools)}",
+            f"   same handoff written:   {_flag(result.loop_swap_kept_the_outcome)}",
+            "",
+            "2. CAPTURE the failing run as ordinary files",
+            f"   model calls recorded: {result.recorded_calls}",
+            f"   evidence: {result.failure_run}",
+            "",
+            "3. GRADE the outcome the host observed, not the route",
+            f"   collected open_count: {result.before_fix_artifacts.get('observed_open_count')}"
+            f" (expected {expected_open})",
+            f"   required eval: {_verdict(result.before_fix_score)}",
+            "",
+            "4. FIX one tool implementation and replay the recorded decisions",
+            f"   - {before_line}",
+            f"   + {after_line}",
+            f"   replayed:                {_route(result.replayed_decisions)}",
+            f"   same recorded decisions: {_flag(result.same_recorded_decisions)}",
+            f"   collected open_count: {result.after_fix_artifacts.get('observed_open_count')}"
+            f" (expected {expected_open})",
+            f"   required eval: {_verdict(result.after_fix_score)}",
+            "",
+            f"Evidence: {result.output_dir}",
+            "No stage above loads a cartridge. Replay holds the model responses fixed;",
+            "the tools execute again in a fresh workspace.",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="Evidence directory (default: system temp)")
+    args = parser.parse_args(argv)
+    print(render(run_migration(args.out)))
+    return 0
+
+
+def _loop_config() -> LoopConfig:
+    return LoopConfig(
+        max_steps=MAX_STEPS,
+        use_native_tools=False,
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+
+def _raw_prompt(task: dict[str, Any], observations: list[str]) -> str:
+    """Prompt assembly the private loop hand-rolled before the migration."""
+    lines = [
+        f"goal: {task['goal']}",
+        "",
+        "tools: list_incidents(), publish_handoff(owner), done(summary)",
+    ]
+    if observations:
+        lines += ["", "observations:", *observations]
+    lines += ["", 'Reply with {"tool": ..., "args": {...}}.']
+    return "\n".join(lines)
+
+
+def _reset_output(root: Path) -> None:
+    """Reset a prior evidence directory without deleting unrelated data."""
+    if root.exists():
+        entries = list(root.iterdir())
+        if entries and not (root / MARKER).is_file():
+            raise ValueError(
+                f"refusing to replace non-recipe directory {root}; choose an empty --out path"
+            )
+        shutil.rmtree(root)
+    root.mkdir(parents=True)
+    (root / MARKER).write_text(
+        "generated by examples/private_loop_migration/run_recipe.py\n",
+        encoding="utf-8",
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _recorded_call_count(run_dir: Path) -> int:
+    manifest = (run_dir / "manifest.jsonl").read_text(encoding="utf-8")
+    return len([line for line in manifest.splitlines() if line.strip()])
+
+
+def _route(names: tuple[str, ...]) -> str:
+    return " -> ".join(names)
+
+
+def _flag(value: bool) -> str:
+    return str(value).lower()
+
+
+def _verdict(score: float) -> str:
+    return f"{'PASS' if score >= 0.5 else 'FAIL'} ({score:.2f})"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/private_loop_migration/run_recipe.py
+++ b/examples/private_loop_migration/run_recipe.py
@@ -1,23 +1,8 @@
 """Migrate a private tool loop to one outcome-grounded regression contract.
 
-Four stages, no cartridge and no provider:
-
-1. the private while-loop is replaced by ``composable_loop()`` while the
-   same tool callables run through one ``tools_from(...)`` registry;
-2. the failing run is captured as readable files with ``ProvenanceSink``;
-3. an ``EvalHook`` collector reads the resulting workspace and a required
-   grader turns that observation into a contract;
-4. one tool implementation is fixed and ``replay_loop()`` re-executes the
-   recorded model decisions against it.
-
-Replay is the right tool only in stage four, because the model responses
-are the variable being held fixed. Tool code executes again, so the
-workspace, the collected artifacts, and the verdict are all fresh.
-
-Two notes on how the stages are wired. The scripted ``MockLLMBackend``
-stands in for the team's provider client so every stage runs offline;
-nothing else about the private harness is a test double. Stages two and
-three share one run, because the contract grades the failure it captured.
+The four offline stages replace the control loop, capture a failed run,
+grade observed world state, and replay fixed tool code while holding the
+recorded model decisions constant. No stage loads a cartridge or provider.
 """
 
 from __future__ import annotations
@@ -30,21 +15,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from looplet import (
-    BaseToolRegistry,
-    DefaultState,
-    EvalHook,
-    LoopConfig,
-    ProvenanceSink,
-    composable_loop,
-    replay_loop,
-    save_eval_run,
-    seed_case_workspace,
-    tools_from,
-)
-from looplet.testing import MockLLMBackend
+from looplet import BaseToolRegistry, EvalHook, ProvenanceSink, save_eval_run, seed_case_workspace
 
-from .handoff_contract import CASE, build_eval_hook, live_task, required_score
+from .execution import (
+    build_registry,
+    replay_with_fixed_tools,
+    run_owned_loop,
+    run_raw_loop,
+)
+from .handoff_contract import CASE, build_eval_hook, required_score
 from .handoff_tools import (
     HANDOFF_FILE,
     ToolSuite,
@@ -52,216 +31,127 @@ from .handoff_tools import (
     changed_implementation_lines,
     select_open_incidents,
 )
+from .result import MigrationResult
 
-DONE_TOOL = "done"
-MAX_STEPS = 4
 MARKER = ".looplet-private-loop-migration"
-SYSTEM_PROMPT = "You hand an on-call shift over. Record the work the next owner still carries."
-
-MODEL_RESPONSES = [
-    json.dumps(
-        {
-            "tool": "list_incidents",
-            "args": {},
-            "reasoning": "read the shift log before writing anything",
-        }
-    ),
-    json.dumps(
-        {
-            "tool": "publish_handoff",
-            "args": {"owner": "day-shift"},
-            "reasoning": "write the handoff file",
-        }
-    ),
-    json.dumps(
-        {
-            "tool": DONE_TOOL,
-            "args": {"summary": "handoff file written for day-shift"},
-            "reasoning": "the requested file exists",
-        }
-    ),
-]
 
 
 @dataclass(frozen=True)
-class MigrationResult:
-    """Evidence produced by :func:`run_migration`."""
-
-    output_dir: Path
+class _Baseline:
+    suite: ToolSuite
+    registry: BaseToolRegistry
     raw_decisions: tuple[str, ...]
     owned_decisions: tuple[str, ...]
-    graded_decisions: tuple[str, ...]
-    replayed_decisions: tuple[str, ...]
     raw_invocations: tuple[str, ...]
     owned_invocations: tuple[str, ...]
     raw_handoff: dict[str, Any]
     owned_handoff: dict[str, Any]
-    before_fix_artifacts: dict[str, Any]
-    after_fix_artifacts: dict[str, Any]
-    before_fix_score: float
-    after_fix_score: float
-    recorded_calls: int
-    failure_run: Path
-    fixed_run: Path
-    changed_lines: tuple[str, str]
-
-    @property
-    def reuses_private_tools(self) -> bool:
-        """True when both loops dispatched the same private callables."""
-        return bool(self.raw_invocations) and self.raw_invocations == self.owned_invocations
-
-    @property
-    def loop_swap_kept_the_outcome(self) -> bool:
-        """True when replacing the loop changed neither decisions nor world state."""
-        return self.raw_decisions == self.owned_decisions and self.raw_handoff == self.owned_handoff
-
-    @property
-    def same_recorded_decisions(self) -> bool:
-        """True when replay consumed the decisions the failing run recorded."""
-        return self.replayed_decisions == self.graded_decisions
 
 
-def build_registry(suite: ToolSuite) -> BaseToolRegistry:
-    """The one ``tools_from(...)`` registry every Looplet stage reuses."""
-    return tools_from(list(suite.callables.values()), include_done=True)
+@dataclass(frozen=True)
+class _Captured:
+    decisions: tuple[str, ...]
+    run_dir: Path
+    hook: EvalHook
 
 
-def run_raw_loop(suite: ToolSuite) -> tuple[str, ...]:
-    """The private while-loop this recipe migrates away from.
-
-    It owns prompt assembly, response parsing, dispatch, and the stop
-    condition, and it has no interception point for capture, permissions,
-    or parse recovery. Those are the responsibilities stage one hands to
-    ``composable_loop()``.
-    """
-    llm = MockLLMBackend(responses=list(MODEL_RESPONSES), cycle=False)
-    task = live_task()
-    decisions: list[str] = []
-    observations: list[str] = []
-    for _ in range(MAX_STEPS):
-        response = llm.generate(_raw_prompt(task, observations), system_prompt=SYSTEM_PROMPT)
-        call = json.loads(response)
-        name = str(call["tool"])
-        decisions.append(name)
-        if name == DONE_TOOL:
-            break
-        result = suite.callables[name](**call.get("args", {}))
-        observations.append(f"{name} -> {json.dumps(result)}")
-    return tuple(decisions)
-
-
-def run_owned_loop(
-    suite: ToolSuite,
-    *,
-    sink: ProvenanceSink | None = None,
-    eval_hook: EvalHook | None = None,
-) -> tuple[str, ...]:
-    """Run the same tools through ``composable_loop()``.
-
-    Passing neither ``sink`` nor ``eval_hook`` is stage one: the loop is
-    the only thing that changed. Stages two and three add each argument
-    without touching the tools.
-    """
-    llm: Any = MockLLMBackend(responses=list(MODEL_RESPONSES), cycle=False)
-    hooks: list[Any] = []
-    if sink is not None:
-        llm = sink.wrap_llm(llm)
-        hooks.append(sink.trajectory_hook())
-    if eval_hook is not None:
-        hooks.append(eval_hook)
-    steps = list(
-        composable_loop(
-            llm=llm,
-            tools=build_registry(suite),
-            hooks=hooks,
-            task=live_task(),
-            config=_loop_config(),
-            state=DefaultState(max_steps=MAX_STEPS),
-        )
-    )
-    if sink is not None:
-        sink.flush()
-    return tuple(step.tool_call.tool for step in steps)
-
-
-def replay_with_fixed_tools(
-    suite: ToolSuite,
-    trace_dir: Path,
-    eval_hook: EvalHook,
-) -> tuple[str, ...]:
-    """Re-execute the recorded decisions against the fixed implementation."""
-    steps = list(
-        replay_loop(
-            trace_dir,
-            tools=build_registry(suite),
-            state=DefaultState(max_steps=MAX_STEPS),
-            hooks=[eval_hook],
-            config=_loop_config(),
-            task=live_task(),
-        )
-    )
-    return tuple(step.tool_call.tool for step in steps)
+@dataclass(frozen=True)
+class _Fixed:
+    decisions: tuple[str, ...]
+    run_dir: Path
+    hook: EvalHook
 
 
 def run_migration(output_dir: str | Path | None = None) -> MigrationResult:
-    """Run the four cartridge-free stages and return their persisted evidence."""
-    root = Path(output_dir or (Path(tempfile.gettempdir()) / "looplet-private-loop-migration"))
-    _reset_output(root)
-    workspaces = root / "workspaces"
-    runs = root / "runs"
+    """Run the four cartridge-free stages and return their evidence."""
+    root = _prepare_output(output_dir)
+    workspaces, runs = root / "workspaces", root / "runs"
+    baseline = _run_baseline(workspaces)
+    captured = _capture_failure(workspaces, runs, baseline)
+    fixed = _replay_fix(workspaces, runs, captured)
+    return _assemble_result(root, baseline, captured, fixed)
 
-    # Stage 1: replace the loop, keep the tools.
-    raw_suite = build_tool_suite(seed_case_workspace(CASE, workspaces / "raw_loop"))
-    raw_decisions = run_raw_loop(raw_suite)
-    owned_suite = build_tool_suite(seed_case_workspace(CASE, workspaces / "composable_loop"))
-    owned_decisions = run_owned_loop(owned_suite)
 
-    # Stages 2 and 3: capture the failing run, then grade what the host sees.
-    failure_workspace = seed_case_workspace(CASE, workspaces / "captured_failure")
-    failure_run = runs / "captured_failure"
-    failure_sink = ProvenanceSink(dir=failure_run)
-    failure_hook = build_eval_hook(failure_workspace)
-    graded_decisions = run_owned_loop(
-        build_tool_suite(failure_workspace),
-        sink=failure_sink,
-        eval_hook=failure_hook,
-    )
-    save_eval_run(
-        failure_run,
-        recorder=failure_sink.trajectory_hook(),
-        eval_hook=failure_hook,
-        case=CASE,
-    )
-
-    # Stage 4: fix one implementation, replay the recorded decisions.
-    fixed_workspace = seed_case_workspace(CASE, workspaces / "replayed_fix")
-    fixed_run = runs / "replayed_fix"
-    fixed_hook = build_eval_hook(fixed_workspace)
-    replayed_decisions = replay_with_fixed_tools(
-        build_tool_suite(fixed_workspace, select_open=select_open_incidents),
-        failure_run,
-        fixed_hook,
-    )
-    save_eval_run(fixed_run, eval_hook=fixed_hook, case=CASE)
-
-    return MigrationResult(
-        output_dir=root,
+def _run_baseline(workspaces: Path) -> _Baseline:
+    raw_workspace = seed_case_workspace(CASE, workspaces / "raw_loop")
+    owned_workspace = seed_case_workspace(CASE, workspaces / "composable_loop")
+    suite = build_tool_suite(raw_workspace)
+    registry = build_registry(suite)
+    raw_decisions = run_raw_loop(suite, registry=registry, workspace=raw_workspace)
+    raw_invocations = tuple(suite.invocations)
+    raw_handoff = _read_json(raw_workspace / HANDOFF_FILE)
+    owned_decisions = run_owned_loop(suite, registry=registry, workspace=owned_workspace)
+    return _Baseline(
+        suite=suite,
+        registry=registry,
         raw_decisions=raw_decisions,
         owned_decisions=owned_decisions,
-        graded_decisions=graded_decisions,
-        replayed_decisions=replayed_decisions,
-        raw_invocations=tuple(raw_suite.invocations),
-        owned_invocations=tuple(owned_suite.invocations),
-        raw_handoff=_read_json(raw_suite.workspace / HANDOFF_FILE),
-        owned_handoff=_read_json(owned_suite.workspace / HANDOFF_FILE),
-        before_fix_artifacts=failure_hook.artifacts,
-        after_fix_artifacts=fixed_hook.artifacts,
-        before_fix_score=required_score(failure_hook.results),
-        after_fix_score=required_score(fixed_hook.results),
-        recorded_calls=_recorded_call_count(failure_run),
-        failure_run=failure_run,
-        fixed_run=fixed_run,
+        raw_invocations=raw_invocations,
+        owned_invocations=tuple(suite.invocations[len(raw_invocations) :]),
+        raw_handoff=raw_handoff,
+        owned_handoff=_read_json(owned_workspace / HANDOFF_FILE),
+    )
+
+
+def _capture_failure(workspaces: Path, runs: Path, baseline: _Baseline) -> _Captured:
+    workspace = seed_case_workspace(CASE, workspaces / "captured_failure")
+    run_dir = runs / "captured_failure"
+    sink = ProvenanceSink(dir=run_dir)
+    hook = build_eval_hook(workspace)
+    decisions = run_owned_loop(
+        baseline.suite,
+        registry=baseline.registry,
+        workspace=workspace,
+        sink=sink,
+        eval_hook=hook,
+    )
+    save_eval_run(run_dir, recorder=sink.trajectory_hook(), eval_hook=hook, case=CASE)
+    return _Captured(decisions=decisions, run_dir=run_dir, hook=hook)
+
+
+def _replay_fix(workspaces: Path, runs: Path, captured: _Captured) -> _Fixed:
+    workspace = seed_case_workspace(CASE, workspaces / "replayed_fix")
+    run_dir = runs / "replayed_fix"
+    hook = build_eval_hook(workspace)
+    suite = build_tool_suite(workspace, select_open=select_open_incidents)
+    decisions = replay_with_fixed_tools(
+        suite,
+        captured.run_dir,
+        hook,
+        registry=build_registry(suite),
+        workspace=workspace,
+    )
+    save_eval_run(run_dir, eval_hook=hook, case=CASE)
+    return _Fixed(decisions=decisions, run_dir=run_dir, hook=hook)
+
+
+def _assemble_result(
+    root: Path,
+    baseline: _Baseline,
+    captured: _Captured,
+    fixed: _Fixed,
+) -> MigrationResult:
+    return MigrationResult(
+        output_dir=root,
+        raw_decisions=baseline.raw_decisions,
+        owned_decisions=baseline.owned_decisions,
+        graded_decisions=captured.decisions,
+        replayed_decisions=fixed.decisions,
+        raw_invocations=baseline.raw_invocations,
+        owned_invocations=baseline.owned_invocations,
+        raw_handoff=baseline.raw_handoff,
+        owned_handoff=baseline.owned_handoff,
+        before_fix_artifacts=captured.hook.artifacts,
+        after_fix_artifacts=fixed.hook.artifacts,
+        before_fix_score=required_score(captured.hook.results),
+        after_fix_score=required_score(fixed.hook.results),
+        recorded_calls=_recorded_call_count(captured.run_dir),
+        failure_run=captured.run_dir,
+        fixed_run=fixed.run_dir,
         changed_lines=changed_implementation_lines(),
+        raw_registry=baseline.registry,
+        owned_registry=baseline.registry,
+        private_callables=baseline.suite.callables,
     )
 
 
@@ -307,35 +197,18 @@ def render(result: MigrationResult) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--out", type=Path, help="Evidence directory (default: system temp)")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Evidence directory (default: a unique directory under system temp)",
+    )
     args = parser.parse_args(argv)
     print(render(run_migration(args.out)))
     return 0
 
 
-def _loop_config() -> LoopConfig:
-    return LoopConfig(
-        max_steps=MAX_STEPS,
-        use_native_tools=False,
-        system_prompt=SYSTEM_PROMPT,
-    )
-
-
-def _raw_prompt(task: dict[str, Any], observations: list[str]) -> str:
-    """Prompt assembly the private loop hand-rolled before the migration."""
-    lines = [
-        f"goal: {task['goal']}",
-        "",
-        "tools: list_incidents(), publish_handoff(owner), done(summary)",
-    ]
-    if observations:
-        lines += ["", "observations:", *observations]
-    lines += ["", 'Reply with {"tool": ..., "args": {...}}.']
-    return "\n".join(lines)
-
-
 def _reset_output(root: Path) -> None:
-    """Reset a prior evidence directory without deleting unrelated data."""
+    """Reset only a caller-supplied prior recipe directory."""
     if root.exists():
         entries = list(root.iterdir())
         if entries and not (root / MARKER).is_file():
@@ -344,6 +217,20 @@ def _reset_output(root: Path) -> None:
             )
         shutil.rmtree(root)
     root.mkdir(parents=True)
+    _write_marker(root)
+
+
+def _prepare_output(output_dir: str | Path | None) -> Path:
+    if output_dir is not None:
+        root = Path(output_dir)
+        _reset_output(root)
+        return root
+    root = Path(tempfile.mkdtemp(prefix="looplet-private-loop-migration-"))
+    _write_marker(root)
+    return root
+
+
+def _write_marker(root: Path) -> None:
     (root / MARKER).write_text(
         "generated by examples/private_loop_migration/run_recipe.py\n",
         encoding="utf-8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ include = [
     "examples/agent_factory.cartridge",
     "examples/coder.cartridge",
     "examples/coder_portable.cartridge",
+    "examples/private_loop_migration",
     "examples/regression_demo",
     "tests/fixtures/coder_skill_bundle/SKILL.md",
     "tests/fixtures/coder_skill_bundle/looplet.py",

--- a/tests/test_private_loop_migration.py
+++ b/tests/test_private_loop_migration.py
@@ -1,0 +1,89 @@
+"""The private-loop migration recipe must stay executable and cartridge-free."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from examples import private_loop_migration as recipe
+
+pytestmark = pytest.mark.smoke
+
+RECIPE_DIR = Path(recipe.__file__ or "").parent
+
+# The four stages must reach the same seam without a cartridge loader.
+CARTRIDGE_SYMBOLS = (
+    "cartridge_to_preset",
+    "load_cartridge_evals",
+    "run_cartridge_evals",
+    "looplet.cartridge",
+    "AgentPreset",
+    ".cartridge",
+)
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_recipe_migrates_a_private_loop_to_a_green_outcome_contract(tmp_path: Path) -> None:
+    result = recipe.run_migration(tmp_path / "evidence")
+
+    for module in sorted(RECIPE_DIR.glob("*.py")):
+        source = module.read_text(encoding="utf-8")
+        for symbol in CARTRIDGE_SYMBOLS:
+            assert symbol not in source, f"{module.name} reaches for {symbol}"
+
+    # 1. The original tool implementation is reused through the migration.
+    assert result.raw_decisions == ("list_incidents", "publish_handoff", "done")
+    assert result.owned_decisions == result.raw_decisions
+    assert result.raw_invocations == ("list_incidents", "publish_handoff")
+    assert result.reuses_private_tools
+    assert result.loop_swap_kept_the_outcome
+    assert result.raw_handoff["open_count"] == 4
+
+    before_fix = recipe.build_tool_suite(tmp_path / "suite_before")
+    after_loop_swap = recipe.build_tool_suite(tmp_path / "suite_after")
+    assert before_fix.select_open is recipe.select_open_incidents_with_bug
+    assert (
+        before_fix.callables["publish_handoff"].__code__
+        is after_loop_swap.callables["publish_handoff"].__code__
+    )
+    registry = recipe.build_registry(after_loop_swap)
+    assert registry.tool_names == ["list_incidents", "publish_handoff", "done"]
+
+    # 2. The collector reads world state rather than a preferred tool sequence.
+    assert result.before_fix_artifacts["observed_open_count"] == 4
+    assert result.after_fix_artifacts["observed_open_count"] == 2
+    assert result.after_fix_artifacts["observed_open_ids"] == recipe.CASE.expected["open_ids"]
+    collector = recipe.make_handoff_collector(result.output_dir / "workspaces" / "replayed_fix")
+    assert collector(None) == result.after_fix_artifacts
+
+    # 3. The required grader fails before the intentional fix and passes after it.
+    assert result.before_fix_score == 0.0
+    assert result.after_fix_score == 1.0
+    assert result.changed_lines == (
+        "return list(incidents)",
+        'return [incident for incident in incidents if incident["status"] != "resolved"]',
+    )
+
+    # 4. Replay consumed the recorded decisions while the observed outcome changed.
+    assert result.recorded_calls == 3
+    assert result.replayed_decisions == result.graded_decisions
+    assert result.same_recorded_decisions
+    assert result.before_fix_artifacts != result.after_fix_artifacts
+
+    # The verdict came from collected artifacts, not from trajectory shape.
+    failure_run = result.failure_run
+    fixed_run = result.fixed_run
+    assert _read_json(failure_run / "artifacts.json") == result.before_fix_artifacts
+    assert _read_json(fixed_run / "artifacts.json") == result.after_fix_artifacts
+    assert (failure_run / "manifest.jsonl").is_file()
+    assert (failure_run / "call_00_response.txt").is_file()
+
+    # Grader-only expected data stayed out of the run the model saw.
+    assert _read_json(failure_run / "expected.json") == recipe.CASE.expected
+    assert "expected" not in _read_json(failure_run / "trajectory.json")["task"]
+    assert '"expected"' not in (failure_run / "call_00_prompt.txt").read_text(encoding="utf-8")

--- a/tests/test_private_loop_migration.py
+++ b/tests/test_private_loop_migration.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -31,12 +33,20 @@ def _read_json(path: Path) -> dict:
 def test_recipe_migrates_a_private_loop_to_a_green_outcome_contract(tmp_path: Path) -> None:
     result = recipe.run_migration(tmp_path / "evidence")
 
+    _assert_cartridge_free()
+    _assert_initial_migration(result, tmp_path)
+    _assert_outcome_contract(result)
+    _assert_capture_and_replay(result)
+
+
+def _assert_cartridge_free() -> None:
     for module in sorted(RECIPE_DIR.glob("*.py")):
         source = module.read_text(encoding="utf-8")
         for symbol in CARTRIDGE_SYMBOLS:
             assert symbol not in source, f"{module.name} reaches for {symbol}"
 
-    # 1. The original tool implementation is reused through the migration.
+
+def _assert_initial_migration(result, tmp_path: Path) -> None:
     assert result.raw_decisions == ("list_incidents", "publish_handoff", "done")
     assert result.owned_decisions == result.raw_decisions
     assert result.raw_invocations == ("list_incidents", "publish_handoff")
@@ -54,7 +64,8 @@ def test_recipe_migrates_a_private_loop_to_a_green_outcome_contract(tmp_path: Pa
     registry = recipe.build_registry(after_loop_swap)
     assert registry.tool_names == ["list_incidents", "publish_handoff", "done"]
 
-    # 2. The collector reads world state rather than a preferred tool sequence.
+
+def _assert_outcome_contract(result) -> None:
     assert result.before_fix_artifacts["observed_open_count"] == 4
     assert result.after_fix_artifacts["observed_open_count"] == 2
     assert result.after_fix_artifacts["observed_open_ids"] == recipe.CASE.expected["open_ids"]
@@ -69,13 +80,13 @@ def test_recipe_migrates_a_private_loop_to_a_green_outcome_contract(tmp_path: Pa
         'return [incident for incident in incidents if incident["status"] != "resolved"]',
     )
 
-    # 4. Replay consumed the recorded decisions while the observed outcome changed.
+
+def _assert_capture_and_replay(result) -> None:
     assert result.recorded_calls == 3
     assert result.replayed_decisions == result.graded_decisions
     assert result.same_recorded_decisions
     assert result.before_fix_artifacts != result.after_fix_artifacts
 
-    # The verdict came from collected artifacts, not from trajectory shape.
     failure_run = result.failure_run
     fixed_run = result.fixed_run
     assert _read_json(failure_run / "artifacts.json") == result.before_fix_artifacts
@@ -83,7 +94,70 @@ def test_recipe_migrates_a_private_loop_to_a_green_outcome_contract(tmp_path: Pa
     assert (failure_run / "manifest.jsonl").is_file()
     assert (failure_run / "call_00_response.txt").is_file()
 
-    # Grader-only expected data stayed out of the run the model saw.
     assert _read_json(failure_run / "expected.json") == recipe.CASE.expected
     assert "expected" not in _read_json(failure_run / "trajectory.json")["task"]
     assert '"expected"' not in (failure_run / "call_00_prompt.txt").read_text(encoding="utf-8")
+
+
+def test_raw_and_migrated_stages_share_exact_registry_and_tools(tmp_path: Path) -> None:
+    """Replacing the loop must not rebuild the approved tool boundary."""
+    result = recipe.run_migration(tmp_path / "identity-evidence")
+
+    assert result.raw_registry is result.owned_registry
+    for name in ("list_incidents", "publish_handoff"):
+        raw_spec = result.raw_registry._tools[name]
+        owned_spec = result.owned_registry._tools[name]
+        assert raw_spec is owned_spec
+        assert raw_spec.execute is result.private_callables[name]
+
+
+def _run_with_default_output(_index: int):
+    return recipe.run_migration()
+
+
+def test_overlapping_default_runs_receive_distinct_evidence_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Concurrent library calls must not share or reset an evidence tree."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_run_with_default_output, range(4)))
+
+    roots = {result.output_dir for result in results}
+    assert len(roots) == len(results)
+    assert len({id(result.raw_registry) for result in results}) == len(results)
+    for result in results:
+        assert result.raw_handoff == result.owned_handoff
+        assert result.before_fix_artifacts["observed_open_count"] == 4
+        assert result.after_fix_artifacts["observed_open_count"] == 2
+        assert (result.failure_run / "manifest.jsonl").is_file()
+        assert (result.fixed_run / "artifacts.json").is_file()
+
+
+def test_sequential_default_runs_preserve_previous_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A later implicit run must leave the prior packet untouched."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    first = recipe.run_migration()
+    note = first.output_dir / "consumer-note.txt"
+    note.write_text("retain this packet\n", encoding="utf-8")
+
+    second = recipe.run_migration()
+
+    assert second.output_dir != first.output_dir
+    assert second.raw_registry is not first.raw_registry
+    assert note.read_text(encoding="utf-8") == "retain this packet\n"
+
+
+def test_explicit_output_path_is_the_only_resettable_target(tmp_path: Path) -> None:
+    """A caller-supplied path deliberately replaces its prior recipe packet."""
+    output = tmp_path / "chosen-evidence"
+    first = recipe.run_migration(output)
+    note = output / "consumer-note.txt"
+    note.write_text("replace me\n", encoding="utf-8")
+
+    second = recipe.run_migration(output)
+
+    assert first.output_dir == second.output_dir == output
+    assert not note.exists()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -98,6 +98,15 @@ def test_regression_proof_is_in_both_distribution_formats() -> None:
     assert "cartridge.schema.json" in sdist_files
 
 
+def test_private_loop_migration_recipe_is_available_to_sdist_tests() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    sdist_files = project["tool"]["hatch"]["build"]["targets"]["sdist"]["include"]
+    migrate = (ROOT / "docs" / "migrate.md").read_text()
+
+    assert "examples/private_loop_migration" in sdist_files
+    assert "source checkout" in migrate
+
+
 def test_manifest_schema_matches_supported_cartridge_version() -> None:
     from looplet.cartridge._layout import SCHEMA_VERSION
 


### PR DESCRIPTION
Closes #105.

Late: you approved this on 2026-07-17 and it should have landed then.

## The scope you approved

> Keep the four main stages cartridge-free and reuse the same tool callables and `tools_from(...)` registry through the raw-loop-to-`composable_loop()` migration.

> 1. Extend the existing `docs/migrate.md` rather than creating a second migration guide. Add the executable example under `examples/private_loop_migration/` plus one focused end-to-end test. Link it from the quickstart and selection guide as the issue requests; no homepage expansion is needed.
> 2. For the final regression step, it is fine to replace one intentionally buggy tool implementation with its fixed version, or change one narrow hook, while holding the captured model responses fixed. Before that intentional fix, the raw loop and Looplet migration should reuse the unchanged implementation.

Where to check each one:

| Constraint | Where it lands |
| --- | --- |
| Four stages cartridge-free | No stage imports a cartridge loader. The test asserts that against every module in the example package. |
| Same tool callables | `build_tool_suite()` binds the callables once; the raw loop dispatches `suite.callables[name]`, and `composable_loop()` dispatches the same objects. |
| Same `tools_from(...)` registry | `build_registry(suite)` is the only registry construction path, used by the migrated loop and by replay. |
| Extend `docs/migrate.md` | One new section, `Run the whole recipe`. No new page, `mkdocs.yml` nav unchanged. |
| Example under `examples/private_loop_migration/` | Yes, plus `tests/test_private_loop_migration.py`. |
| Link from quickstart and selection guide | `docs/quickstart.md` (Next list) and `docs/why-looplet.md` (See the claim run). `docs/index.md` untouched. |
| One buggy implementation replaced, responses fixed | Stage 4 swaps `select_open_incidents_with_bug` for `select_open_incidents` and replays the captured responses. |
| Unchanged implementation before the fix | The buggy selector is the default in `build_tool_suite()`, so stages 1 to 3 all run it. The test asserts the identity. |
| Raw loop guidance preserved | New subsection, `When the raw loop is still the better choice`. The existing guidance in the selection guide is untouched and linked from it. |

## The recipe

A tiny on-call handoff agent hands resolved incidents to the next owner as if
they were still open work.

```
uv run python -m examples.private_loop_migration
```

```text
1. REPLACE the loop, keep the private tools
   raw loop:        list_incidents -> publish_handoff -> done
   composable_loop: list_incidents -> publish_handoff -> done
   private callables that ran: list_incidents -> publish_handoff
   same tools reused:      true
   same handoff written:   true

2. CAPTURE the failing run as ordinary files
   model calls recorded: 3

3. GRADE the outcome the host observed, not the route
   collected open_count: 4 (expected 2)
   required eval: FAIL (0.00)

4. FIX one tool implementation and replay the recorded decisions
   - return list(incidents)
   + return [incident for incident in incidents if incident["status"] != "resolved"]
   replayed:                list_incidents -> publish_handoff -> done
   same recorded decisions: true
   collected open_count: 2 (expected 2)
   required eval: PASS (1.00)
```

`ProvenanceSink` captures the failing run, an `EvalHook` collector reads
`handoff.json` from a fresh seeded workspace, and one `@eval_mark("required")`
grader compares it with grader-only expected data.

## The four proofs from your comment

Each is an assertion in the one focused test:

1. **The original tool implementation is reused through the initial migration.**
   Both loops produce the same decisions and the same wrong `handoff.json`, both
   suites record the same private callables running, and
   `publish_handoff.__code__` is the identical code object before and after the
   loop swap.
2. **The collector reads world state rather than a preferred tool sequence.**
   The collector is called with `state=None` and still returns the same
   artifacts the graded run collected.
3. **The required grader fails before the fix and passes after it.** `0.0` then
   `1.0`, from `save_eval_run` output on disk.
4. **Replay consumes the same recorded decisions while the observed outcome
   changes.** The replayed and captured decision sequences are equal while the
   collected artifacts differ.

On your point about the verdict: the equal-decisions assertion is labelled an
experiment control in both the code and the guide, and the verdict itself is
read from `artifacts.json`. The guide says why grading trajectory shape would
have failed the first time a better model reordered two safe reads.

## Verification

Run on Linux, Python 3.12, at the tip of this branch:

```text
$ make check
Text style check passed: no em dashes in tracked UTF-8 files.
All checks passed!                      # ruff check
461 files already formatted             # ruff format --check
0 errors, 0 warnings, 0 informations    # pyright src/looplet/
================= 2348 passed, 2 skipped in 160.06s (0:02:40) ==================
✓ All CI checks passed locally.

$ mkdocs build --strict
INFO    -  Documentation built in 0.81 seconds
```

Both exited 0. The new test runs in about 0.2s and is marked `smoke`.

## Notes and limits

- The issue body asked for `docs/private-loop-migration.md`. Your note 1
  supersedes that, so nothing was added under `docs/` beyond the new section in
  `migrate.md`.
- Two files go slightly past the three you named, and I am happy to drop either:
  `examples/private_loop_migration/README.md`, which mirrors
  `examples/regression_demo/README.md`, and the `## Unreleased` changelog entry
  the contributing checklist asks for. That entry is duplicated into
  `docs/changelog.md` because
  `tests/test_release_metadata.py::test_site_changelog_matches_canonical_history`
  enforces the two copies matching.
- One registry object cannot span four stages, because each stage seeds its own
  fresh workspace. So `build_registry(suite)` is reused as the single
  construction path and is rebuilt per stage from the same callables.
- Stages 2 and 3 share one run: the contract grades the failure it captured.
  The module docstring says so.
- The driver module is `run_recipe.py`, not `run_migration.py`. With a
  `run_migration.py` module and an exported `run_migration` function, the
  package attribute is ambiguous, and `tests/test_bundles_smoke.py` rebinds it
  to the module while it exercises `examples.*` in `sys.modules`. The
  end-to-end test then failed with `TypeError: 'module' object is not callable`
  under full-suite ordering but passed in isolation. Renaming the module removed
  the ambiguity. `examples/regression_demo` has the same module and function
  name pair today, so it is exposed to the same ordering hazard; I left it alone
  as out of scope here.
- The example list in `README.md` still ends at `regression_demo`. You named the
  quickstart and the selection guide as the link sites, so I left the front page
  alone. Say the word and I will add the one bullet.
- No new core API, no new dependency, and no change under `src/`. Replay keeps
  its stated boundary: model responses are fixed, tool code executes again, and
  the recipe says nothing about whether a prompt change would produce better
  decisions.
