### PR TITLE
feat(cli): capture cartridge runs by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ scratch/
 # Example runtime artifacts
 /checkpoints/
 /.benchmarks/
+/.looplet/
 /traces/
 site/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### CLI
+
+- `looplet run-cartridge` now captures a provenance trace under the target
+  project's `.looplet/traces/` directory by default. Use `--trace-dir` to
+  choose a location or `--no-trace` to opt out.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### CLI
+
+- `looplet run-cartridge` now captures a provenance trace under the target
+  project's `.looplet/traces/` directory by default. Use `--trace-dir` to
+  choose a location or `--no-trace` to opt out.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,7 +81,11 @@ looplet run-cartridge ./agent.cartridge \
 
 `--project-root` controls the directory available to project-aware tools. It
 defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
-directory. `run-workspace` remains a compatibility alias.
+directory. Each run also writes a provenance trace under
+`.looplet/traces/<cartridge>-<id>/` in that project root. Pass `--trace-dir`
+to choose an explicit location or `--no-trace` to disable capture. Traces may
+contain full prompts, responses, and tool results; inspect them before sharing.
+`run-workspace` remains a compatibility alias.
 
 ### Review commands
 

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -40,6 +40,7 @@ import json
 import os
 import sys
 import time
+import uuid
 from pathlib import Path
 
 from looplet.bundled import bundled_cartridge_path
@@ -287,7 +288,12 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        from looplet import cartridge_to_preset, composable_loop  # noqa: PLC0415
+        from looplet import (  # noqa: PLC0415
+            ProvenanceSink,
+            cartridge_to_preset,
+            composable_loop,
+        )
+        from looplet.cartridge.runtime_helpers import resolve_project_root  # noqa: PLC0415
         from looplet.types import DefaultState  # noqa: PLC0415
     except Exception as exc:
         print(_red(f"error: {exc}"), file=sys.stderr)
@@ -314,6 +320,24 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     if args.max_steps:
         preset.config.max_steps = args.max_steps
     state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
+    sink = None
+    effective_trace_dir = None
+    if not getattr(args, "no_trace", False):
+        effective_trace_dir = getattr(args, "trace_dir", None)
+        if effective_trace_dir is None:
+            cartridge_name = workspace_path.name.removesuffix(".cartridge")
+            effective_trace_dir = (
+                Path(resolve_project_root(runtime))
+                / ".looplet"
+                / "traces"
+                / f"{cartridge_name}-{uuid.uuid4().hex[:12]}"
+            )
+        sink = ProvenanceSink(dir=effective_trace_dir)
+        backend = sink.wrap_llm(backend)
+
+    hooks = list(preset.hooks)
+    if sink is not None:
+        hooks.append(sink.trajectory_hook())
     pretty = None
     if getattr(args, "pretty", False) and not args.quiet:
         from looplet.cli._pretty import PrettyPrinter  # noqa: PLC0415
@@ -332,13 +356,15 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     n_steps = 0
     final_summary: str | None = None
     final_data: dict | None = None
+    interrupted = False
+    saved_trace_dir = None
     try:
         for step in composable_loop(
             llm=backend,
             config=preset.config,
             tools=preset.tools,
             state=state,
-            hooks=preset.hooks,
+            hooks=hooks,
             task={"goal": task},
         ):
             n_steps += 1
@@ -363,6 +389,14 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
                 final_summary = str(tool_result.data.get("summary", ""))
     except KeyboardInterrupt:
         print(_red("\ninterrupted"), file=sys.stderr)
+        interrupted = True
+    finally:
+        if sink is not None:
+            saved_trace_dir = sink.flush()
+
+    if interrupted:
+        if saved_trace_dir is not None:
+            print(f"  Trace: {saved_trace_dir}")
         return 130
 
     elapsed = time.time() - t0
@@ -375,6 +409,8 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     elif final_data:
         print(_bold("result:"))
         print(json.dumps(final_data, indent=2, default=str)[:2000])
+    if saved_trace_dir is not None:
+        print(f"\n  Trace: {saved_trace_dir}")
     return 0
 
 
@@ -493,6 +529,16 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
             "Defaults to $LOOPLET_PROJECT_ROOT, then the current git repo, "
             "then the current working directory."
         ),
+    )
+    run_p.add_argument(
+        "--trace-dir",
+        type=Path,
+        help="Write provenance trace output here",
+    )
+    run_p.add_argument(
+        "--no-trace",
+        action="store_true",
+        help="Disable default provenance capture",
     )
     run_p.add_argument("--quiet", action="store_true", help="Suppress per-step output")
     run_p.add_argument(

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -393,10 +393,13 @@ def test_new_help_advertises_pretty() -> None:
     assert "--pretty" in captured.getvalue()
 
 
-def test_run_cartridge_help_advertises_pretty() -> None:
-    """``looplet run-cartridge --help`` should mention the --pretty flag."""
+def test_run_cartridge_help_advertises_runtime_options() -> None:
+    """``looplet run-cartridge --help`` should name its runtime controls."""
     captured = io.StringIO()
     with pytest.raises(SystemExit) as exc, patch.object(sys, "stdout", captured):
         main(["run-cartridge", "--help"])
     assert exc.value.code == 0
-    assert "--pretty" in captured.getvalue()
+    out = captured.getvalue()
+    assert "--pretty" in out
+    assert "--trace-dir" in out
+    assert "--no-trace" in out

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -11,10 +11,12 @@ Before the fix, the per-step printer in ``cmd_run_workspace`` did
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import pytest
 
+from looplet.__main__ import main
 from looplet.cli import factory_commands
 from looplet.testing import MockLLMBackend
 
@@ -23,19 +25,25 @@ pytestmark = pytest.mark.smoke
 _MCP_DEMO = Path(__file__).resolve().parents[1] / "examples" / "mcp_demo.cartridge"
 
 
-def _args() -> argparse.Namespace:
+def _args(
+    *,
+    project_root: Path | None = None,
+    trace_dir: Path | None = None,
+    no_trace: bool = False,
+) -> argparse.Namespace:
     return argparse.Namespace(
         workspace=_MCP_DEMO,
         task="What is 12345 + 67890?",
         max_steps=5,
+        project_root=project_root,
+        trace_dir=trace_dir,
+        no_trace=no_trace,
         quiet=False,
         pretty=False,
     )
 
 
-@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
-def test_run_cartridge_survives_int_tool_result(monkeypatch, capsys):
-    """The non-quiet printer tolerates an int ToolResult.data without crashing."""
+def _patch_runtime(monkeypatch) -> None:
     responses = [
         '{"tool":"add","args":{"a":12345,"b":67890},"reasoning":"sum"}',
         '{"tool":"done","args":{"total":80235},"reasoning":"report"}',
@@ -49,10 +57,46 @@ def test_run_cartridge_survives_int_tool_result(monkeypatch, capsys):
         lambda: MockLLMBackend(responses=responses, cycle=False),
     )
 
-    rc = factory_commands.cmd_run_workspace(_args())
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_survives_int_tool_result(monkeypatch, capsys, tmp_path):
+    """The non-quiet printer tolerates an int ToolResult.data without crashing."""
+    _patch_runtime(monkeypatch)
+
+    trace_dir = tmp_path / "trace"
+    rc = factory_commands.cmd_run_workspace(_args(trace_dir=trace_dir))
 
     assert rc == 0
     out = capsys.readouterr().out
     # The add step printed without raising, and the run reached `done`.
     assert "add(" in out
     assert "80235" in out
+    assert f"Trace: {trace_dir}" in out
+    assert (trace_dir / "trajectory.json").is_file()
+    assert (trace_dir / "manifest.jsonl").is_file()
+    trajectory = json.loads((trace_dir / "trajectory.json").read_text())
+    assert len(trajectory["steps"]) == 2
+    assert main(["show", str(trace_dir)]) == 0
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_can_disable_trace(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch)
+    trace_dir = tmp_path / "trace"
+
+    rc = factory_commands.cmd_run_workspace(_args(trace_dir=trace_dir, no_trace=True))
+
+    assert rc == 0
+    assert not trace_dir.exists()
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_defaults_trace_to_project_root(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch)
+
+    rc = factory_commands.cmd_run_workspace(_args(project_root=tmp_path))
+
+    assert rc == 0
+    traces = list((tmp_path / ".looplet" / "traces").glob("mcp_demo-*"))
+    assert len(traces) == 1
+    assert (traces[0] / "trajectory.json").is_file()


### PR DESCRIPTION
## Summary

Make `looplet run-cartridge` save the existing provenance artifact by default, with explicit destination and opt-out controls.

## Motivation

A core Looplet CLI path ran agents without preserving the evidence that Looplet already knows how to record. Default capture makes the product's inspectable-run claim true on the simplest cartridge workflow without adding a new run schema or subsystem.

## Changes

- Write default traces under the target project's `.looplet/traces/<cartridge>-<id>/` directory.
- Add `--trace-dir` and `--no-trace` controls.
- Reuse `ProvenanceSink` and the existing project-root resolver.
- Document sensitive trace contents, update release notes, and ignore Looplet's local `.looplet/` artifacts.
- Cover explicit, disabled, and default paths, including reading the result through `looplet show`.

## Behavioral contract

`tests/test_run_cartridge_nondict_smoke.py` proves that a scripted cartridge run writes `trajectory.json` and `manifest.jsonl`, records both steps, and is readable by the public `looplet show` command. Separate tests prove `--no-trace` writes nothing and the default location is under the selected project root.

## Core-boundary check

Not applicable. This composes the existing `ProvenanceSink` at the CLI boundary; it adds no core concept, schema, or loop behavior.

## Sync ↔ async parity

- [x] Not applicable (no loop change).
- [ ] Behavior mirrored in both `composable_loop` and `async_composable_loop`.
- [ ] Tests cover both paths.

## Checklist

- [ ] `uv run pytest` passes. Full local suite: 2,358 passed, 2 skipped; two load-sensitive failures passed together in isolation.
- [x] `uv run ruff check .` reports no new issues. Focused Ruff, format, and Pyright checks pass.
- [x] New public API has docstrings and tests. No new Python API; CLI options are documented and tested.
- [x] Behavioral changes have outcome-grounded regression evidence.
- [x] Any candidate-editable eval is not treated as a protected release oracle.
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]` (or change is docs-only).
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
