### PR TITLE
feat(cli): read cartridge tasks from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - `looplet run-cartridge` now captures a provenance trace under the target
   project's `.looplet/traces/` directory by default. Use `--trace-dir` to
   choose a location or `--no-trace` to opt out.
+- `looplet run-cartridge <cartridge> -` reads the task from standard input for
+  shell pipelines and rejects empty input before starting a run.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - `looplet run-cartridge` now captures a provenance trace under the target
   project's `.looplet/traces/` directory by default. Use `--trace-dir` to
   choose a location or `--no-trace` to opt out.
+- `looplet run-cartridge <cartridge> -` reads the task from standard input for
+  shell pipelines and rejects empty input before starting a run.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,6 +79,12 @@ looplet run-cartridge ./agent.cartridge \
   --max-steps 20
 ```
 
+Use `-` as the task to read it from standard input:
+
+```bash
+git diff | looplet run-cartridge ./review.cartridge - --project-root .
+```
+
 `--project-root` controls the directory available to project-aware tools. It
 defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
 directory. Each run also writes a provenance trace under

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -286,10 +286,12 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         print(_red(f"error: cartridge not found at {workspace_path}"), file=sys.stderr)
         return 1
 
-    task: str = sys.stdin.read() if args.task == "-" else args.task
-    if not task.strip():
-        print(_red("error: task read from stdin is empty"), file=sys.stderr)
-        return 1
+    task: str = args.task
+    if task == "-":
+        task = sys.stdin.read()
+        if not task.strip():
+            print(_red("error: task read from stdin is empty"), file=sys.stderr)
+            return 1
 
     try:
         from looplet import (  # noqa: PLC0415

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -281,10 +281,14 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 1
 
     workspace_path: Path = args.workspace.resolve()
-    task: str = args.task
 
     if not workspace_path.is_dir():
         print(_red(f"error: cartridge not found at {workspace_path}"), file=sys.stderr)
+        return 1
+
+    task: str = sys.stdin.read() if args.task == "-" else args.task
+    if not task.strip():
+        print(_red("error: task read from stdin is empty"), file=sys.stderr)
         return 1
 
     try:
@@ -514,7 +518,7 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         type=Path,
         help="Path to a cartridge directory",
     )
-    run_p.add_argument("task", help="Task to give the agent")
+    run_p.add_argument("task", help="Task to give the agent, or '-' to read it from stdin")
     run_p.add_argument(
         "--max-steps",
         type=int,

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -403,3 +403,4 @@ def test_run_cartridge_help_advertises_runtime_options() -> None:
     assert "--pretty" in out
     assert "--trace-dir" in out
     assert "--no-trace" in out
+    assert "read it from stdin" in out

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -11,7 +11,9 @@ Before the fix, the per-step printer in ``cmd_run_workspace`` did
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -27,13 +29,14 @@ _MCP_DEMO = Path(__file__).resolve().parents[1] / "examples" / "mcp_demo.cartrid
 
 def _args(
     *,
+    task: str = "What is 12345 + 67890?",
     project_root: Path | None = None,
     trace_dir: Path | None = None,
     no_trace: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         workspace=_MCP_DEMO,
-        task="What is 12345 + 67890?",
+        task=task,
         max_steps=5,
         project_root=project_root,
         trace_dir=trace_dir,
@@ -100,3 +103,33 @@ def test_run_cartridge_defaults_trace_to_project_root(monkeypatch, tmp_path):
     traces = list((tmp_path / ".looplet" / "traces").glob("mcp_demo-*"))
     assert len(traces) == 1
     assert (traces[0] / "trajectory.json").is_file()
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_reads_task_from_stdin(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch)
+    task = "Review this exact piped input.\nSecond line stays intact.\n"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(task))
+    trace_dir = tmp_path / "trace"
+
+    rc = factory_commands.cmd_run_workspace(_args(task="-", trace_dir=trace_dir))
+
+    assert rc == 0
+    trajectory = json.loads((trace_dir / "trajectory.json").read_text())
+    assert trajectory["task"]["goal"] == task
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_rejects_empty_stdin(monkeypatch, capsys):
+    _patch_runtime(monkeypatch)
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: pytest.fail("empty stdin must fail before backend construction"),
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(" \n"))
+
+    rc = factory_commands.cmd_run_workspace(_args(task="-", no_trace=True))
+
+    assert rc == 1
+    assert "task read from stdin is empty" in capsys.readouterr().err

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -133,3 +133,15 @@ def test_run_cartridge_rejects_empty_stdin(monkeypatch, capsys):
 
     assert rc == 1
     assert "task read from stdin is empty" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_preserves_explicit_empty_task(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch)
+    trace_dir = tmp_path / "trace"
+
+    rc = factory_commands.cmd_run_workspace(_args(task="", trace_dir=trace_dir))
+
+    assert rc == 0
+    trajectory = json.loads((trace_dir / "trajectory.json").read_text())
+    assert trajectory["task"]["goal"] == ""


### PR DESCRIPTION
## Summary

Allow `looplet run-cartridge <cartridge> -` to read its task from standard input.

## Motivation

An explicit stdin sentinel makes cartridge runs compose with ordinary shell pipelines without changing existing positional-task behavior or adding a new configuration surface.

## Changes

- Resolve task `-` from `sys.stdin` after validating the cartridge path.
- Reject empty stdin before cartridge loading or backend construction.
- Advertise the convention in CLI help and add a `git diff | looplet run-cartridge ... -` example.
- Keep canonical and site changelogs synchronized.

## Behavioral contract

`tests/test_run_cartridge_nondict_smoke.py` runs a scripted cartridge with multiline stdin and proves the persisted trajectory contains the exact input as `task.goal`. A second test proves whitespace-only stdin exits nonzero before backend construction. `tests/test_cli_new_smoke.py` proves the convention is discoverable through `--help`.

## Core-boundary check

Not applicable. This is one CLI input convention and does not modify the loop, cartridge schema, provenance format, or public Python API.

## Sync ↔ async parity

- [x] Not applicable (no loop change).
- [ ] Behavior mirrored in both `composable_loop` and `async_composable_loop`.
- [ ] Tests cover both paths.

## Checklist

- [ ] `uv run pytest` passes. Focused set: 54 passed; full matrix delegated to CI.
- [x] `uv run ruff check .` reports no new issues. Focused Ruff, format, and Pyright checks pass.
- [x] New public API has docstrings and tests. No new Python API; CLI help and behavior are tested.
- [x] Behavioral changes have outcome-grounded regression evidence.
- [x] Any candidate-editable eval is not treated as a protected release oracle.
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]` (or change is docs-only).
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
