### PR TITLE
fix(hooks): expire check-done signature cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   project's `.looplet/traces/` directory by default. Use `--trace-dir` to
   choose a location or `--no-trace` to opt out.
 
+### Fixed
+
+- Legacy `check_done` hooks no longer intermittently receive an unsupported
+  `tool_call` keyword after short-lived hook classes are collected.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   project's `.looplet/traces/` directory by default. Use `--trace-dir` to
   choose a location or `--no-trace` to opt out.
 
+### Fixed
+
+- Legacy `check_done` hooks no longer intermittently receive an unsupported
+  `tool_call` keyword after short-lived hook classes are collected.
+
 ## [0.3.0] - 2026-07-16
 
 ### Added

--- a/src/looplet/loop.py
+++ b/src/looplet/loop.py
@@ -11,6 +11,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from dataclasses import replace as _dc_replace
 from typing import TYPE_CHECKING, Any, Callable, Generator, Protocol, runtime_checkable
+from weakref import WeakKeyDictionary
 
 from looplet.checkpoint import (
     Checkpoint as _Checkpoint,
@@ -1046,29 +1047,31 @@ _init_event_method_equiv()
 
 # ── check_done dispatch (backward-compatible tool_call kwarg) ───
 
-_CHECK_DONE_ACCEPTS_TOOL_CALL: dict[int, bool] = {}
-"""Cache mapping ``id(method.__func__)`` (i.e. the unbound function on the
-class) to whether ``check_done`` accepts a ``tool_call`` keyword argument.
+_CHECK_DONE_ACCEPTS_TOOL_CALL: WeakKeyDictionary[Any, bool] = WeakKeyDictionary()
+"""Weak cache mapping the unbound ``check_done`` function to whether it
+accepts a ``tool_call`` keyword argument.
 
 Bound methods are ephemeral in CPython - ``obj.check_done`` creates a
 fresh bound-method object on each access, so caching by
 ``id(bound_method)`` is unsound: bound methods get garbage-collected
 and their ids get reused for unrelated methods on other classes,
-poisoning the cache. ``method.__func__`` (the underlying class
-attribute) has stable identity and is safe to key on. For plain
-callables that lack ``__func__`` (rare - e.g. lambdas attached as
-attributes), we fall back to ``id`` of the callable itself.
+poisoning the cache. Integer ids of unbound functions have the same
+problem when local hook classes are collected. Weak keys preserve the
+callable's identity without retaining short-lived hook classes.
 """
 
 
-def _cache_key(method: Any) -> int:
-    """Stable cache key for a (possibly bound) callable."""
-    return id(getattr(method, "__func__", method))
+def _cache_key(method: Any) -> Any:
+    """Return the underlying callable for a possibly bound method."""
+    return getattr(method, "__func__", method)
 
 
 def _accepts_tool_call_kwarg(method: Any) -> bool:
     key = _cache_key(method)
-    cached = _CHECK_DONE_ACCEPTS_TOOL_CALL.get(key)
+    try:
+        cached = _CHECK_DONE_ACCEPTS_TOOL_CALL.get(key)
+    except TypeError:
+        cached = None
     if cached is not None:
         return cached
     import inspect  # noqa: PLC0415
@@ -1082,7 +1085,10 @@ def _accepts_tool_call_kwarg(method: Any) -> bool:
         accepts = "tool_call" in params or any(
             p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
         )
-    _CHECK_DONE_ACCEPTS_TOOL_CALL[key] = accepts
+    try:
+        _CHECK_DONE_ACCEPTS_TOOL_CALL[key] = accepts
+    except TypeError:
+        pass
     return accepts
 
 

--- a/tests/test_check_done_payload.py
+++ b/tests/test_check_done_payload.py
@@ -9,6 +9,8 @@ working unchanged while new quality gates can inspect the candidate
 
 from __future__ import annotations
 
+import gc
+import weakref
 from typing import Any
 
 from looplet import (
@@ -188,5 +190,25 @@ def test_signature_cache_keys_on_func_not_bound_method_id() -> None:
 
     # Two distinct cache entries (one per class), not one per
     # short-lived bound-method object.
-    func_keys = {id(WithKwarg.check_done), id(WithoutKwarg.check_done)}
+    func_keys = {WithKwarg.check_done, WithoutKwarg.check_done}
     assert func_keys.issubset(_CHECK_DONE_ACCEPTS_TOOL_CALL.keys())
+
+
+def test_signature_cache_does_not_retain_local_hook_functions() -> None:
+    from looplet.loop import _CHECK_DONE_ACCEPTS_TOOL_CALL, _accepts_tool_call_kwarg
+
+    class LocalHook:
+        def check_done(self, state, session_log, context, step_num, tool_call=None):
+            return None
+
+    hook = LocalHook()
+    function = LocalHook.check_done
+    function_ref = weakref.ref(function)
+
+    assert _accepts_tool_call_kwarg(hook.check_done) is True
+    assert function in _CHECK_DONE_ACCEPTS_TOOL_CALL
+
+    del hook, function, LocalHook
+    gc.collect()
+
+    assert function_ref() is None


### PR DESCRIPTION
## Summary

Replace the integer-ID cache for `check_done` signatures with weak callable keys so short-lived hook classes cannot poison later dispatch.

## Motivation

PR #111 exposed a deterministic Python 3.12 full-suite failure: a collected local hook function left its integer ID in the signature cache, and a later legacy hook reused that ID and incorrectly received `tool_call=`.

## Changes

- Cache signature results in `WeakKeyDictionary` keyed by the underlying callable.
- Preserve uncached signature inspection for unusual non-weak-referenceable callables.
- Add a regression proving local hook functions are collectable.
- Document the compatibility fix under Unreleased.

## Behavioral contract

Legacy `check_done(self, state, session_log, context, step_num)` hooks continue to run without the additive `tool_call` keyword, even after short-lived hook classes are collected.

## Core-boundary check

Not applicable. This repairs an existing compatibility cache and adds no core concept.

## Sync ↔ async parity

- [x] Behavior uses the shared check-done dispatcher exercised by the loop tests.

## Checklist

- [x] Focused hook and event tests pass on Python 3.12.
- [x] Full Python 3.12 order passed the previously failing lifecycle test; 2,336 passed and 15 skipped, with the sole missing-extra failure passing separately under `--all-extras`.
- [x] Ruff, formatting, Pyright, and text-style checks pass.
- [x] Behavioral regression evidence added.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.