### PR TITLE
feat(cli): expose trace artifacts as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   choose a location or `--no-trace` to opt out.
 - `looplet run-cartridge <cartridge> -` reads the task from standard input for
   shell pipelines and rejects empty input before starting a run.
+- `looplet show <trace-dir> --json` emits parsed trajectory and manifest
+  records for shell pipelines and external tooling.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   choose a location or `--no-trace` to opt out.
 - `looplet run-cartridge <cartridge> -` reads the task from standard input for
   shell pipelines and rejects empty input before starting a run.
+- `looplet show <trace-dir> --json` emits parsed trajectory and manifest
+  records for shell pipelines and external tooling.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,10 +44,13 @@ steps, failures, LLM-call counts, and timing when recorded.
 
 ```bash
 looplet show traces/incident-42
+looplet show traces/incident-42 --json | jq '.trajectory.termination_reason'
 ```
 
 The command returns non-zero for a missing, malformed, or empty trace
-directory. Read [saved artifacts](artifacts.md) for the complete layout.
+directory. JSON output contains the parsed `trajectory.json` object and
+`manifest.jsonl` records; consumers should tolerate added fields. Read
+[saved artifacts](artifacts.md) for the complete layout.
 
 ## Build and run cartridges
 

--- a/src/looplet/__main__.py
+++ b/src/looplet/__main__.py
@@ -33,7 +33,7 @@ def _fmt_ms(ms: float | int | None) -> str:
     return f"{int(ms):>5}ms"
 
 
-def _render_show(trace_dir: Path) -> int:
+def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
     if not trace_dir.exists():
         print(f"error: {trace_dir} does not exist", file=sys.stderr)
         return 1
@@ -68,6 +68,10 @@ def _render_show(trace_dir: Path) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if json_output:
+        print(json.dumps({"trajectory": traj or None, "manifest": calls}, indent=2))
+        return 0
 
     # ── Header ──────────────────────────────────────────────────
     run_id = traj.get("run_id") or trace_dir.name
@@ -653,6 +657,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Show a one-page summary of a captured trace directory",
     )
     show.add_argument("trace_dir", type=Path, help="Path to a trace directory")
+    show.add_argument("--json", action="store_true", help="Emit the parsed trace artifacts as JSON")
 
     doctor = sub.add_parser(
         "doctor",
@@ -783,7 +788,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "show":
-        return _render_show(args.trace_dir)
+        return _render_show(args.trace_dir, json_output=args.json)
     if args.command == "doctor":
         return _render_doctor(
             probe_backend=not args.no_backend,

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -40,6 +40,14 @@ def test_run_workspace_alias_help() -> None:
     assert exc.value.code == 0
 
 
+def test_show_help_advertises_json() -> None:
+    captured = io.StringIO()
+    with pytest.raises(SystemExit) as exc, patch.object(sys, "stdout", captured):
+        main(["show", "--help"])
+    assert exc.value.code == 0
+    assert "--json" in captured.getvalue()
+
+
 @pytest.mark.parametrize(
     "argv",
     [

--- a/tests/test_replay_and_cli_smoke.py
+++ b/tests/test_replay_and_cli_smoke.py
@@ -122,6 +122,20 @@ class TestShowCLISmoke:
         assert "LLM:" in out
         assert "add" in out
 
+    def test_show_json_preserves_trace_artifacts(self, tmp_path: Path, capsys):
+        trace_dir = _captured_dir(tmp_path)
+
+        rc = cli_main(["show", str(trace_dir), "--json"])
+
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["trajectory"] == json.loads((trace_dir / "trajectory.json").read_text())
+        assert payload["manifest"] == [
+            json.loads(line)
+            for line in (trace_dir / "manifest.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+
     def test_show_missing_dir(self, tmp_path: Path, capsys):
         rc = cli_main(["show", str(tmp_path / "no-such-dir")])
         assert rc == 1
@@ -144,6 +158,17 @@ class TestShowCLISmoke:
         assert rc == 0
         out = capsys.readouterr().out
         assert "LLM:" in out
+
+    def test_show_json_tolerates_missing_trajectory(self, tmp_path: Path, capsys):
+        trace_dir = _captured_dir(tmp_path)
+        (trace_dir / "trajectory.json").unlink()
+
+        rc = cli_main(["show", str(trace_dir), "--json"])
+
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["trajectory"] is None
+        assert len(payload["manifest"]) == 3
 
 
 class TestDoctorCLISmoke:


### PR DESCRIPTION
## Summary

Add `looplet show <trace-dir> --json` as a machine-readable view over the existing trace artifacts.

## Motivation

Looplet traces are ordinary files, but automation currently has to parse the human summary or reconstruct the artifact layout itself. This adds a Unix-friendly JSON presentation mode without introducing a new run schema.

## Changes

- Add `--json` to `looplet show`.
- Emit the parsed `trajectory.json` object and valid `manifest.jsonl` records in one envelope.
- Preserve manifest-only trace support.
- Document a `jq` pipeline and compatibility guidance.

## Behavioral contract

JSON output is fidelity-preserving: `trajectory` equals the parsed `trajectory.json` object and `manifest` equals the parsed non-empty manifest records. Existing human output and error behavior remain unchanged.

## Core-boundary check

Not applicable. This is a presentation option over existing trace files and adds no runtime concept or artifact format.

## Sync ↔ async parity

- [x] Not applicable; trace inspection is runtime-independent.

## Checklist

- [x] 42 focused CLI, replay, and release-metadata tests pass.
- [x] Ruff, formatting, Pyright, text style, and editor diagnostics pass.
- [x] Behavioral regression evidence added for full and manifest-only traces.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.