### PR TITLE
feat(provenance): link related traces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,8 +574,15 @@ tools = tools_from([deep_research])
 # Parent loop now sees `deep_research` as a regular tool.
 ```
 
-The parent's `ProvenanceSink` will record only the parent trajectory;
-wire a separate sink inside the sub-agent for parent-child linked traces.
+The parent's `ProvenanceSink` records only the parent trajectory. Wire a
+separate child sink and seed its existing metadata field when lineage matters:
+
+```python
+child_sink = ProvenanceSink(
+    dir="traces/child",
+    metadata={"parent_run_id": parent_sink.trajectory_hook().trajectory.run_id},
+)
+```
 
 ## Recipe 9 - Permissions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   shell pipelines and rejects empty input before starting a run.
 - `looplet show <trace-dir> --json` emits parsed trajectory and manifest
   records for shell pipelines and external tooling.
+- `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
+  trajectory metadata without adding orchestration semantics.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   shell pipelines and rejects empty input before starting a run.
 - `looplet show <trace-dir> --json` emits parsed trajectory and manifest
   records for shell pipelines and external tooling.
+- `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
+  trajectory metadata without adding orchestration semantics.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,12 +88,21 @@ Use `-` as the task to read it from standard input:
 git diff | looplet run-cartridge ./review.cartridge - --project-root .
 ```
 
+Link a follow-up run to an earlier trace without changing execution:
+
+```bash
+looplet run-cartridge ./repair.cartridge "Repair the finding" \
+  --parent-trace .looplet/traces/review-a1b2c3
+```
+
 `--project-root` controls the directory available to project-aware tools. It
 defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
 directory. Each run also writes a provenance trace under
 `.looplet/traces/<cartridge>-<id>/` in that project root. Pass `--trace-dir`
 to choose an explicit location or `--no-trace` to disable capture. Traces may
 contain full prompts, responses, and tool results; inspect them before sharing.
+`--parent-trace` reads the parent's `run_id` and records it as
+`metadata.parent_run_id`; it does not resume, replay, or orchestrate that run.
 `run-workspace` remains a compatibility alias.
 
 ### Review commands

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -85,6 +85,21 @@ Every file is human-readable. `trajectory.json` and `manifest.jsonl` are
 machine-parseable. You can diff, grep, version-control, attach to bug
 reports, or feed to a separate analysis pipeline.
 
+### Link related traces
+
+Seed trajectory metadata when a host wants to record evidence lineage:
+
+```python
+parent_hook = parent_sink.trajectory_hook()
+child_sink = ProvenanceSink(
+    dir="traces/child/",
+    metadata={"parent_run_id": parent_hook.trajectory.run_id},
+)
+```
+
+This is an annotation only. It does not add scheduling, traversal, replay, or
+state inheritance semantics to the loop.
+
 ---
 
 ## LLM-call provenance only

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -316,6 +316,25 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     if project_root is not None:
         runtime = {"project_root": str(project_root.expanduser().resolve())}
 
+    trajectory_metadata: dict[str, str] = {}
+    parent_trace = getattr(args, "parent_trace", None)
+    if parent_trace is not None:
+        if getattr(args, "no_trace", False):
+            print(_red("error: --parent-trace cannot be used with --no-trace"), file=sys.stderr)
+            return 1
+        parent_trajectory = parent_trace.expanduser().resolve() / "trajectory.json"
+        try:
+            parent_data = json.loads(parent_trajectory.read_text(encoding="utf-8"))
+            if not isinstance(parent_data, dict):
+                raise ValueError("trajectory.json must contain an object")
+            parent_run_id = parent_data.get("run_id")
+            if not isinstance(parent_run_id, str) or not parent_run_id.strip():
+                raise ValueError("trajectory.json has no run_id")
+        except (OSError, ValueError) as exc:
+            print(_red(f"error: invalid parent trace {parent_trace}: {exc}"), file=sys.stderr)
+            return 1
+        trajectory_metadata["parent_run_id"] = parent_run_id
+
     try:
         backend = _build_backend()
         preset = cartridge_to_preset(str(workspace_path), runtime=runtime)
@@ -338,7 +357,7 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
                 / "traces"
                 / f"{cartridge_name}-{uuid.uuid4().hex[:12]}"
             )
-        sink = ProvenanceSink(dir=effective_trace_dir)
+        sink = ProvenanceSink(dir=effective_trace_dir, metadata=trajectory_metadata)
         backend = sink.wrap_llm(backend)
 
     hooks = list(preset.hooks)
@@ -540,6 +559,11 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         "--trace-dir",
         type=Path,
         help="Write provenance trace output here",
+    )
+    run_p.add_argument(
+        "--parent-trace",
+        type=Path,
+        help="Link this run to a parent trace directory",
     )
     run_p.add_argument(
         "--no-trace",

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -826,6 +826,7 @@ class ProvenanceSink:
 
     The sink is safe to reuse across runs - call :meth:`reset` between
     them, or construct a fresh sink per run (cheaper and clearer).
+    ``metadata`` is copied into the trajectory when its hook is created.
     """
 
     def __init__(
@@ -836,12 +837,14 @@ class ProvenanceSink:
         redact: Callable[[str], str] | None = None,
         redact_upstream: bool = True,
         capture_context: bool = True,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         self._dir = Path(dir)
         self._max_chars = max_chars_per_call
         self._redact = redact
         self._redact_upstream = redact_upstream
         self._capture_context = capture_context
+        self._metadata = dict(metadata or {})
         self._recording_llm: _RecordingBase | None = None
         self._hook: TrajectoryRecorder | None = None
 
@@ -874,6 +877,7 @@ class ProvenanceSink:
                 capture_context=self._capture_context,
                 redact=self._redact,
             )
+            self._hook.trajectory.metadata.update(self._metadata)
         return self._hook
 
     def flush(self) -> Path:

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -410,5 +410,6 @@ def test_run_cartridge_help_advertises_runtime_options() -> None:
     out = captured.getvalue()
     assert "--pretty" in out
     assert "--trace-dir" in out
+    assert "--parent-trace" in out
     assert "--no-trace" in out
     assert "read it from stdin" in out

--- a/tests/test_provenance_smoke.py
+++ b/tests/test_provenance_smoke.py
@@ -270,6 +270,15 @@ class TestProvenanceSinkSmoke:
         assert (out / "trajectory.json").exists()
         assert (out / "call_00_prompt.txt").exists()
 
+    def test_seeds_trajectory_metadata(self, tmp_path: Path):
+        metadata = {"parent_run_id": "parent-123"}
+        sink = ProvenanceSink(dir=tmp_path / "run", metadata=metadata)
+        metadata["parent_run_id"] = "changed"
+
+        hook = sink.trajectory_hook()
+
+        assert hook.trajectory.metadata == {"parent_run_id": "parent-123"}
+
     def test_wrap_llm_detects_async(self):
         sink = ProvenanceSink(dir=Path("/tmp/does-not-matter"))
 

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -32,6 +32,7 @@ def _args(
     task: str = "What is 12345 + 67890?",
     project_root: Path | None = None,
     trace_dir: Path | None = None,
+    parent_trace: Path | None = None,
     no_trace: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
@@ -40,6 +41,7 @@ def _args(
         max_steps=5,
         project_root=project_root,
         trace_dir=trace_dir,
+        parent_trace=parent_trace,
         no_trace=no_trace,
         quiet=False,
         pretty=False,
@@ -145,3 +147,45 @@ def test_run_cartridge_preserves_explicit_empty_task(monkeypatch, tmp_path):
     assert rc == 0
     trajectory = json.loads((trace_dir / "trajectory.json").read_text())
     assert trajectory["task"]["goal"] == ""
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_records_parent_run_id(monkeypatch, tmp_path):
+    _patch_runtime(monkeypatch)
+    parent_trace = tmp_path / "parent"
+    parent_trace.mkdir()
+    (parent_trace / "trajectory.json").write_text('{"run_id":"parent-123"}')
+    trace_dir = tmp_path / "child"
+
+    rc = factory_commands.cmd_run_workspace(_args(trace_dir=trace_dir, parent_trace=parent_trace))
+
+    assert rc == 0
+    trajectory = json.loads((trace_dir / "trajectory.json").read_text())
+    assert trajectory["metadata"]["parent_run_id"] == "parent-123"
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_rejects_invalid_parent_before_backend(monkeypatch, tmp_path, capsys):
+    _patch_runtime(monkeypatch)
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: pytest.fail("invalid parent must fail before backend construction"),
+    )
+
+    rc = factory_commands.cmd_run_workspace(
+        _args(parent_trace=tmp_path / "missing", no_trace=False)
+    )
+
+    assert rc == 1
+    assert "invalid parent trace" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_rejects_parent_without_trace(monkeypatch, tmp_path, capsys):
+    _patch_runtime(monkeypatch)
+
+    rc = factory_commands.cmd_run_workspace(_args(parent_trace=tmp_path / "parent", no_trace=True))
+
+    assert rc == 1
+    assert "--parent-trace cannot be used with --no-trace" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Add optional parent-run lineage to existing provenance metadata, exposed through `ProvenanceSink(metadata=...)` and `run-cartridge --parent-trace`.

## Motivation

Related runs currently require separate traces but have no stable link. This records one parent run ID without introducing a run registry, graph, scheduler, traversal API, or inherited state.

## Changes

- Let `ProvenanceSink` seed copied trajectory metadata.
- Add `run-cartridge --parent-trace <dir>` and validate its `trajectory.json` before backend construction.
- Record the parent `run_id` as `metadata.parent_run_id`.
- Reject `--parent-trace` with `--no-trace`.
- Document CLI and library linkage as annotation-only.

## Behavioral contract

A child run linked to a valid parent trace persists exactly the parent stable run ID under `trajectory.metadata.parent_run_id`. Invalid parents fail before a model call. Lineage does not change execution, replay, scheduling, or state.

## Core-boundary check

No new core concept. The change uses the existing trajectory metadata field and the existing provenance sink.

## Sync ↔ async parity

- [x] ProvenanceSink metadata is shared by sync and async recording paths.

## Checklist

- [x] 74 focused provenance, CLI, replay, and release-metadata tests pass.
- [x] Ruff, formatting, Pyright, text style, and editor diagnostics pass.
- [x] Behavioral regression evidence covers valid, invalid, and no-trace cases.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.