### PR TITLE
feat(cli): emit cartridge completion JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   records for shell pipelines and external tooling.
 - `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
   trajectory metadata without adding orchestration semantics.
+- `looplet run-cartridge --json` emits one machine-readable completion object
+  while suppressing human progress output.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   records for shell pipelines and external tooling.
 - `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
   trajectory metadata without adding orchestration semantics.
+- `looplet run-cartridge --json` emits one machine-readable completion object
+  while suppressing human progress output.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,6 +95,13 @@ looplet run-cartridge ./repair.cartridge "Repair the finding" \
   --parent-trace .looplet/traces/review-a1b2c3
 ```
 
+Emit one completion object for a shell pipeline:
+
+```bash
+looplet run-cartridge ./agent.cartridge "Inspect the change" --json \
+  | jq '.result'
+```
+
 `--project-root` controls the directory available to project-aware tools. It
 defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
 directory. Each run also writes a provenance trace under
@@ -103,6 +110,10 @@ to choose an explicit location or `--no-trace` to disable capture. Traces may
 contain full prompts, responses, and tool results; inspect them before sharing.
 `--parent-trace` reads the parent's `run_id` and records it as
 `metadata.parent_run_id`; it does not resume, replay, or orchestrate that run.
+`--json` suppresses human progress output and emits `steps`, `duration_ms`, the
+terminal `result`, and `trace_dir` (`null` with `--no-trace`). Errors remain on
+standard error; consumers should tolerate added fields. It cannot be combined
+with `--pretty`.
 `run-workspace` remains a compatibility alias.
 
 ### Review commands

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -280,6 +280,11 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     if _check_env() != 0:
         return 1
 
+    json_output = getattr(args, "json", False)
+    if json_output and getattr(args, "pretty", False):
+        print(_red("error: --json cannot be used with --pretty"), file=sys.stderr)
+        return 1
+
     workspace_path: Path = args.workspace.resolve()
 
     if not workspace_path.is_dir():
@@ -305,10 +310,11 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         print(_red(f"error: {exc}"), file=sys.stderr)
         return 1
 
-    print(f"{_bold('looplet run')} {workspace_path}")
-    if not getattr(args, "pretty", False):
-        print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
-        print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
+    if not json_output:
+        print(f"{_bold('looplet run')} {workspace_path}")
+        if not getattr(args, "pretty", False):
+            print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
+            print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
         print()
 
     project_root = getattr(args, "project_root", None)
@@ -401,7 +407,7 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
                 continue
             if pretty is not None:
                 pretty.step(step)
-            elif not args.quiet:
+            elif not args.quiet and not json_output:
                 _data = tool_result.data if tool_result else None
                 err = (tool_result and tool_result.error) or (
                     _data.get("error") if isinstance(_data, dict) else None
@@ -420,11 +426,26 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
             saved_trace_dir = sink.flush()
 
     if interrupted:
-        if saved_trace_dir is not None:
+        if saved_trace_dir is not None and not json_output:
             print(f"  Trace: {saved_trace_dir}")
         return 130
 
     elapsed = time.time() - t0
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "steps": n_steps,
+                    "duration_ms": round(elapsed * 1000, 2),
+                    "result": final_data,
+                    "trace_dir": str(saved_trace_dir) if saved_trace_dir is not None else None,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+        return 0
+
     print()
     print(f"{_green('✓')} done in {elapsed:.1f}s - {n_steps} steps")
     print()
@@ -575,6 +596,11 @@ def add_subparsers(sub: "argparse._SubParsersAction") -> None:
         "--pretty",
         action="store_true",
         help="Render the run as a live human-friendly trace (boxed header, per-step reasoning + result summary, colored).",
+    )
+    run_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one machine-readable completion object",
     )
     run_p.set_defaults(_handler=cmd_run_workspace)
 

--- a/tests/test_cli_new_smoke.py
+++ b/tests/test_cli_new_smoke.py
@@ -412,4 +412,5 @@ def test_run_cartridge_help_advertises_runtime_options() -> None:
     assert "--trace-dir" in out
     assert "--parent-trace" in out
     assert "--no-trace" in out
+    assert "--json" in out
     assert "read it from stdin" in out

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -34,6 +34,7 @@ def _args(
     trace_dir: Path | None = None,
     parent_trace: Path | None = None,
     no_trace: bool = False,
+    json_output: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         workspace=_MCP_DEMO,
@@ -45,6 +46,7 @@ def _args(
         no_trace=no_trace,
         quiet=False,
         pretty=False,
+        json=json_output,
     )
 
 
@@ -189,3 +191,44 @@ def test_run_cartridge_rejects_parent_without_trace(monkeypatch, tmp_path, capsy
 
     assert rc == 1
     assert "--parent-trace cannot be used with --no-trace" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_json_emits_one_completion_object(monkeypatch, tmp_path, capsys):
+    _patch_runtime(monkeypatch)
+    trace_dir = tmp_path / "trace"
+
+    rc = factory_commands.cmd_run_workspace(_args(trace_dir=trace_dir, json_output=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["steps"] == 2
+    assert payload["duration_ms"] >= 0
+    assert payload["result"] == {"status": "completed", "total": 80235}
+    assert payload["trace_dir"] == str(trace_dir)
+    trajectory = json.loads((trace_dir / "trajectory.json").read_text())
+    assert len(trajectory["steps"]) == 2
+
+
+def test_run_cartridge_rejects_json_with_pretty(monkeypatch, capsys):
+    _patch_runtime(monkeypatch)
+    args = _args(no_trace=True, json_output=True)
+    args.pretty = True
+
+    rc = factory_commands.cmd_run_workspace(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "--json cannot be used with --pretty" in captured.err
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_json_without_trace_reports_null(monkeypatch, capsys):
+    _patch_runtime(monkeypatch)
+
+    rc = factory_commands.cmd_run_workspace(_args(no_trace=True, json_output=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["trace_dir"] is None


### PR DESCRIPTION
## Summary

Add `looplet run-cartridge --json` as a machine-readable completion mode over the existing run path.

## Motivation

Run traces and inspection are now pipe-friendly, but executing a cartridge still emits human progress text. This adds one compact completion envelope without changing execution or defining another artifact format.

## Changes

- Add `--json` to `run-cartridge` and its compatibility alias.
- Suppress CLI human progress output in JSON mode.
- Emit `steps`, `duration_ms`, the real terminal `result`, and `trace_dir`.
- Keep errors on stderr and reject `--json` with `--pretty`.
- Report `trace_dir: null` when capture is disabled.

## Behavioral contract

A successful JSON-mode run emits one parseable JSON object on stdout. Its terminal result is the existing done-tool result, and its trace has the same executed steps as a human-mode run. Exit and error semantics are unchanged.

## Core-boundary check

Not applicable. This is a presentation option over the existing cartridge runner and provenance path.

## Sync ↔ async parity

- [x] Not applicable; `run-cartridge` currently drives the existing synchronous CLI path only.

## Checklist

- [x] 63 focused CLI, provenance, and release-metadata tests pass.
- [x] Ruff, formatting, Pyright, text style, and editor diagnostics pass.
- [x] Behavioral regression evidence covers traced, no-trace, and incompatible-output cases.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.