### PR TITLE
fix(cli): report cartridge completion status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   records for shell pipelines and external tooling.
 - `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
   trajectory metadata without adding orchestration semantics.
-- `looplet run-cartridge --json` emits one machine-readable completion object
-  while suppressing human progress output.
+- `looplet run-cartridge --json` emits one machine-readable completion object,
+  including explicit `completed` and `termination_reason` fields, while
+  suppressing human progress output.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,8 +17,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   records for shell pipelines and external tooling.
 - `looplet run-cartridge --parent-trace <dir>` records the parent run ID in
   trajectory metadata without adding orchestration semantics.
-- `looplet run-cartridge --json` emits one machine-readable completion object
-  while suppressing human progress output.
+- `looplet run-cartridge --json` emits one machine-readable completion object,
+  including explicit `completed` and `termination_reason` fields, while
+  suppressing human progress output.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,7 +99,7 @@ Emit one completion object for a shell pipeline:
 
 ```bash
 looplet run-cartridge ./agent.cartridge "Inspect the change" --json \
-  | jq '.result'
+  | jq -e '.completed'
 ```
 
 `--project-root` controls the directory available to project-aware tools. It
@@ -110,10 +110,12 @@ to choose an explicit location or `--no-trace` to disable capture. Traces may
 contain full prompts, responses, and tool results; inspect them before sharing.
 `--parent-trace` reads the parent's `run_id` and records it as
 `metadata.parent_run_id`; it does not resume, replay, or orchestrate that run.
-`--json` suppresses human progress output and emits `steps`, `duration_ms`, the
-terminal `result`, and `trace_dir` (`null` with `--no-trace`). Errors remain on
-standard error; consumers should tolerate added fields. It cannot be combined
-with `--pretty`.
+`--json` suppresses human progress output and emits `completed`,
+`termination_reason`, `steps`, `duration_ms`, the terminal `result`, and
+`trace_dir` (`null` with `--no-trace`). `completed` is true only when the agent
+reaches `done`; budget and hook stops remain successful CLI executions but are
+reported as incomplete. Errors remain on standard error; consumers should
+tolerate added fields. It cannot be combined with `--pretty`.
 `run-workspace` remains a compatibility alias.
 
 ### Review commands

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -432,9 +432,14 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
 
     elapsed = time.time() - t0
     if json_output:
+        termination_reason = getattr(state, "_stop_reason", None)
+        if termination_reason is None:
+            termination_reason = getattr(state, "stop_reason", None)
         print(
             json.dumps(
                 {
+                    "completed": termination_reason == "done",
+                    "termination_reason": termination_reason or "unknown",
                     "steps": n_steps,
                     "duration_ms": round(elapsed * 1000, 2),
                     "result": final_data,

--- a/tests/test_run_cartridge_nondict_smoke.py
+++ b/tests/test_run_cartridge_nondict_smoke.py
@@ -30,6 +30,7 @@ _MCP_DEMO = Path(__file__).resolve().parents[1] / "examples" / "mcp_demo.cartrid
 def _args(
     *,
     task: str = "What is 12345 + 67890?",
+    max_steps: int = 5,
     project_root: Path | None = None,
     trace_dir: Path | None = None,
     parent_trace: Path | None = None,
@@ -39,7 +40,7 @@ def _args(
     return argparse.Namespace(
         workspace=_MCP_DEMO,
         task=task,
-        max_steps=5,
+        max_steps=max_steps,
         project_root=project_root,
         trace_dir=trace_dir,
         parent_trace=parent_trace,
@@ -202,6 +203,8 @@ def test_run_cartridge_json_emits_one_completion_object(monkeypatch, tmp_path, c
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["completed"] is True
+    assert payload["termination_reason"] == "done"
     assert payload["steps"] == 2
     assert payload["duration_ms"] >= 0
     assert payload["result"] == {"status": "completed", "total": 80235}
@@ -232,3 +235,26 @@ def test_run_cartridge_json_without_trace_reports_null(monkeypatch, capsys):
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["trace_dir"] is None
+
+
+@pytest.mark.skipif(not _MCP_DEMO.is_dir(), reason="mcp_demo cartridge not present")
+def test_run_cartridge_json_reports_budget_exhaustion(monkeypatch, capsys):
+    monkeypatch.setenv("OPENAI_MODEL", "mock-model")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:1/v1")
+    monkeypatch.setattr(factory_commands, "_check_env", lambda: 0)
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: MockLLMBackend(
+            responses=['{"tool":"add","args":{"a":1,"b":2},"reasoning":"add"}'],
+            cycle=False,
+        ),
+    )
+
+    rc = factory_commands.cmd_run_workspace(_args(max_steps=1, no_trace=True, json_output=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["completed"] is False
+    assert payload["termination_reason"] == "budget_exhausted"
+    assert payload["result"] is None


### PR DESCRIPTION
## Summary

Make `run-cartridge --json` report whether the agent actually reached `done` and why the loop stopped.

## Motivation

The completion envelope could return exit code 0 with `result: null` after budget or hook termination, leaving automation unable to distinguish a completed agent run from a successfully executed but incomplete loop.

## Changes

- Add `completed` to the JSON envelope; true only for the authoritative `done` stop reason.
- Add the authoritative `termination_reason`.
- Preserve existing CLI exit codes and terminal result payloads.
- Document fail-closed shell usage with `jq -e .completed`.

## Behavioral contract

A run that reaches `done` reports `completed: true` and `termination_reason: done`. A max-step run reports `completed: false`, `termination_reason: budget_exhausted`, and a null terminal result while retaining exit code 0.

## Core-boundary check

Not applicable. The fields are a presentation of the existing loop stop signal; no new completion state machine or public state API is added.

## Sync ↔ async parity

- [x] Not applicable; this hardens the existing synchronous `run-cartridge` CLI path.

## Checklist

- [x] 64 focused CLI, provenance, and release-metadata tests pass.
- [x] Ruff, formatting, Pyright, text style, and editor diagnostics pass.
- [x] Regression evidence covers completed and budget-exhausted runs.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.