### PR TITLE
test: pin file-native evidence workflow

### DIFF
--- a/tests/test_file_native_workflow.py
+++ b/tests/test_file_native_workflow.py
@@ -1,0 +1,102 @@
+"""Compatibility contract for Looplet's file-native evidence workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from looplet import BaseToolRegistry, DefaultState, LoopConfig, ProvenanceSink, composable_loop
+from looplet.__main__ import main as cli_main
+from looplet.evals import EvalContext, eval_run
+from looplet.testing import MockLLMBackend
+from looplet.tools import ToolSpec
+
+pytestmark = pytest.mark.smoke
+
+
+def _capture_publish_run(
+    *,
+    trace_dir: Path,
+    workspace: Path,
+    value: str,
+    metadata: dict[str, str] | None = None,
+) -> Path:
+    workspace.mkdir(parents=True)
+    output_path = workspace / "result.json"
+
+    def publish(*, value: str) -> dict[str, str]:
+        output_path.write_text(json.dumps({"value": value}))
+        return {"path": str(output_path)}
+
+    tools = BaseToolRegistry()
+    tools.register(
+        ToolSpec(
+            name="publish",
+            description="Publish one value to the result artifact.",
+            parameters={"value": "str"},
+            execute=publish,
+        )
+    )
+    tools.register(
+        ToolSpec(
+            name="done",
+            description="Finish the run.",
+            parameters={"summary": "str"},
+            execute=lambda *, summary: {"summary": summary},
+        )
+    )
+
+    responses = [
+        json.dumps({"tool": "publish", "args": {"value": value}, "reasoning": "publish"}),
+        json.dumps({"tool": "done", "args": {"summary": "published"}, "reasoning": "done"}),
+    ]
+    sink = ProvenanceSink(dir=trace_dir, metadata=metadata)
+    llm = sink.wrap_llm(MockLLMBackend(responses=responses, cycle=False))
+    list(
+        composable_loop(
+            llm=llm,
+            tools=tools,
+            state=DefaultState(max_steps=3),
+            hooks=[sink.trajectory_hook()],
+            config=LoopConfig(max_steps=3),
+            task={"goal": f"Publish {value}"},
+        )
+    )
+    sink.flush()
+    return output_path
+
+
+def test_capture_inspect_link_and_grade_outcome(tmp_path: Path, capsys) -> None:
+    parent_trace = tmp_path / "traces" / "parent"
+    _capture_publish_run(
+        trace_dir=parent_trace,
+        workspace=tmp_path / "workspaces" / "parent",
+        value="draft",
+    )
+
+    assert cli_main(["show", str(parent_trace), "--json"]) == 0
+    parent_view = json.loads(capsys.readouterr().out)
+    parent_run_id = parent_view["trajectory"]["run_id"]
+
+    child_trace = tmp_path / "traces" / "child"
+    child_output = _capture_publish_run(
+        trace_dir=child_trace,
+        workspace=tmp_path / "workspaces" / "child",
+        value="verified",
+        metadata={"parent_run_id": parent_run_id},
+    )
+
+    observed = json.loads(child_output.read_text())
+    (child_trace / "artifacts.json").write_text(json.dumps({"published_value": observed["value"]}))
+    context = EvalContext.from_trajectory_dir(child_trace)
+
+    def eval_published_value(ctx: EvalContext) -> bool:
+        return ctx.artifacts.get("published_value") == "verified"
+
+    results = eval_run([eval_published_value], context)
+
+    assert context.completed is True
+    assert context.metadata["parent_run_id"] == parent_run_id
+    assert results[0].passed is True


### PR DESCRIPTION
## Summary

Add one network-free compatibility test for Looplet’s complete file-native evidence workflow.

## Motivation

Capture, JSON inspection, parent lineage, persisted artifacts, and offline grading were each covered independently. This pins their composition so future artifact or CLI changes cannot silently break the public workflow.

## Changes

- Capture a parent run with a real file-producing tool.
- Inspect its trace through `looplet show --json`.
- Capture a linked child run using the parent run ID.
- Persist a host-observed artifact from the child workspace.
- Load the child via `EvalContext.from_trajectory_dir` and grade the observed outcome with `eval_run`.

## Behavioral contract

A captured run can be inspected, linked to a follow-up run, loaded through the supported persisted-evidence reader, and graded from independently observed world state. The child remains completed and preserves its parent run ID.

## Core-boundary check

Not applicable. This adds no production code or format; it protects existing composition.

## Sync ↔ async parity

- [x] Not applicable; this contract covers the currently shipped synchronous CLI/library workflow.

## Checklist

- [x] New contract passes network-free in 0.2s.
- [x] 112 neighboring provenance, inspection, and eval tests pass.
- [x] Ruff, formatting, text style, editor diagnostics, and CI-equivalent all-extras Pyright pass.
- [x] No changelog entry needed for a test-only change.
- [x] Read `CONTRIBUTING.md`.