### PR TITLE
feat(evals): emit machine-readable run reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - `looplet run-cartridge --json` emits one machine-readable completion object,
   including explicit `completed` and `termination_reason` fields, while
   suppressing human progress output.
+- `looplet eval run --json` emits the existing threshold and integrity verdict
+  with per-case completion and grader results.
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - `looplet run-cartridge --json` emits one machine-readable completion object,
   including explicit `completed` and `termination_reason` fields, while
   suppressing human progress output.
+- `looplet eval run --json` emits the existing threshold and integrity verdict
+  with per-case completion and grader results.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -141,7 +141,8 @@ Always run `migrate --dry-run` first and review the resulting files.
 ```bash
 looplet eval run ./agent.cartridge \
   --out ./eval-runs \
-  --threshold 1.0
+  --threshold 1.0 \
+  --json | jq -e '.passed'
 ```
 
 Notable options:
@@ -155,10 +156,15 @@ Notable options:
 | `--judge-model NAME` | Use a separate judge model and imply `--judge`. |
 | `--out DIR` | Persist each case under `DIR/<case-id>/`. |
 | `--threshold VALUE` | Fail when any scored grader falls below the value. |
+| `--json` | Emit one report with the overall verdict and per-case grader results. |
 
 Required graders, explicit failures, collector errors, malformed records,
 unknown cases, and empty required suites also fail the command. Persisted case
-runs use the [eval artifact layout](artifacts.md#persisted-eval-run).
+runs use the [eval artifact layout](artifacts.md#persisted-eval-run). JSON output
+contains the threshold verdict, case completion state, serialized grader
+results, integrity failures, and output directory. It deliberately omits
+artifacts and grader-only expected data; read those through the persisted run.
+Consumers should tolerate added fields.
 
 ### Grade saved trajectories
 

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -2330,6 +2330,11 @@ def _run_cartridge_cli(args: list[str]) -> int:
         default=0.0,
         help="Fail (exit 1) if any scored grader is below this on any case.",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one machine-readable eval report",
+    )
     parsed = parser.parse_args(args)
     if not math.isfinite(parsed.threshold) or not 0.0 <= parsed.threshold <= 1.0:
         print("error: --threshold must be finite and between 0 and 1", file=sys.stderr)
@@ -2384,11 +2389,12 @@ def _run_cartridge_cli(args: list[str]) -> int:
         else:
             judge_llm = llm
 
-    print(
-        f"running {cdir.name}: {len(overview.cases)} case(s), "
-        f"{len(overview.graders)} grader(s), {len(overview.collectors)} collector(s)"
-        f"{'  [judge on]' if judge_llm is not None else ''}\n"
-    )
+    if not parsed.json:
+        print(
+            f"running {cdir.name}: {len(overview.cases)} case(s), "
+            f"{len(overview.graders)} grader(s), {len(overview.collectors)} collector(s)"
+            f"{'  [judge on]' if judge_llm is not None else ''}\n"
+        )
     try:
         records = run_cartridge_evals(
             cdir,
@@ -2404,10 +2410,12 @@ def _run_cartridge_cli(args: list[str]) -> int:
 
     grader_names = sorted(g.__name__ for g in overview.graders)
     header = f"{'case':22}" + "".join(f"{n:22}" for n in grader_names)
-    print(header)
-    print("-" * len(header))
+    if not parsed.json:
+        print(header)
+        print("-" * len(header))
     below_threshold = False
     integrity_failures: list[str] = []
+    case_reports: list[dict[str, Any]] = []
     required_names = {
         grader.__name__ for grader in overview.graders if _REQUIRED_EVAL_MARK in _get_marks(grader)
     }
@@ -2428,7 +2436,8 @@ def _run_cartridge_cli(args: list[str]) -> int:
             else:
                 cells += f"{(r.label or '-'):22}"
         case_id = rec.case.id if rec.case is not None else "?"
-        print(f"{case_id:22}{cells}")
+        if not parsed.json:
+            print(f"{case_id:22}{cells}")
         for result in rec.results:
             if _result_is_integrity_failure(
                 result,
@@ -2437,17 +2446,37 @@ def _run_cartridge_cli(args: list[str]) -> int:
                 integrity_failures.append(
                     f"{case_id}/{result.name}: {result.label or 'invalid result'}"
                 )
+        case_reports.append(
+            {
+                "id": case_id,
+                "completed": rec.context.completed,
+                "results": [result.to_dict() for result in rec.results],
+            }
+        )
 
-    if parsed.out:
+    failed = below_threshold or bool(integrity_failures)
+    if parsed.json:
+        print(
+            json.dumps(
+                {
+                    "passed": not failed,
+                    "threshold": parsed.threshold,
+                    "cases": case_reports,
+                    "integrity_failures": integrity_failures,
+                    "output_dir": str(parsed.out) if parsed.out else None,
+                },
+                indent=2,
+            )
+        )
+    elif parsed.out:
         print(f"\npersisted {len(records)} run(s) under {parsed.out}/")
-    if integrity_failures:
+    if integrity_failures and not parsed.json:
         print("\nintegrity failures:")
         for failure in integrity_failures:
             print(f"  - {failure}")
-    if parsed.threshold > 0:
-        failed = below_threshold or bool(integrity_failures)
+    if parsed.threshold > 0 and not parsed.json:
         print(f"threshold {parsed.threshold:.2f} → {'FAIL' if failed else 'PASS'}")
-    return 1 if below_threshold or integrity_failures else 0
+    return 1 if failed else 0
 
 
 def _cases_cli(args: list[str]) -> int:

--- a/tests/test_eval_cartridge_cli.py
+++ b/tests/test_eval_cartridge_cli.py
@@ -314,6 +314,57 @@ def test_cli_run_without_judge_skips_judge_grader(tmp_path: Path, monkeypatch) -
     assert by["eval_judge_quality"].label == "skipped"
 
 
+def test_cli_run_json_emits_one_eval_report(tmp_path: Path, monkeypatch, capsys) -> None:
+    cart = _make_cartridge(tmp_path)
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://x")
+    import looplet.backends as _backends
+
+    monkeypatch.setattr(
+        _backends,
+        "OpenAIBackend",
+        lambda **kw: MockLLMBackend(responses=_scripted()),
+    )
+    out = tmp_path / "runs"
+
+    rc = eval_cli(["run", str(cart), "--out", str(out), "--threshold", "1.0", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is True
+    assert payload["threshold"] == 1.0
+    assert payload["output_dir"] == str(out)
+    assert payload["integrity_failures"] == []
+    assert payload["cases"][0]["id"] == "make_greeting"
+    assert payload["cases"][0]["completed"] is True
+    assert {result["name"] for result in payload["cases"][0]["results"]} >= {
+        "eval_completed",
+        "eval_wrote_file",
+    }
+
+
+def test_cli_run_json_preserves_threshold_failure_exit(tmp_path: Path, monkeypatch, capsys) -> None:
+    cart = _make_cartridge(tmp_path)
+    (cart / "evals" / "eval_zero.py").write_text("def eval_zero(ctx):\n    return 0.0\n")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://x")
+    import looplet.backends as _backends
+
+    monkeypatch.setattr(
+        _backends,
+        "OpenAIBackend",
+        lambda **kw: MockLLMBackend(responses=_scripted()),
+    )
+
+    rc = eval_cli(["run", str(cart), "--threshold", "1.0", "--json"])
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is False
+    zero = next(
+        result for result in payload["cases"][0]["results"] if result["name"] == "eval_zero"
+    )
+    assert zero["score"] == 0.0
+
+
 def test_cli_run_unknown_case_returns_failure(tmp_path: Path, monkeypatch) -> None:
     cart = _make_cartridge(tmp_path)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://x")
@@ -402,6 +453,13 @@ def test_cli_run_fails_on_collector_error(tmp_path: Path, monkeypatch) -> None:
 
 
 # ── CLI preflight / error paths (no live model needed) ───────────
+
+
+def test_cli_run_help_advertises_json(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        eval_cli(["run", "--help"])
+    assert exc.value.code == 0
+    assert "--json" in capsys.readouterr().out
 
 
 def test_cli_run_missing_cartridge() -> None:


### PR DESCRIPTION
## Summary

Add `looplet eval run --json` as a machine-readable view over the existing eval records and verdict.

## Motivation

End-to-end dogfooding of the installed wheel showed that run and trace inspection were pipe-friendly, but the final eval gate only printed a human table. Automation had to know the persisted directory layout and reopen `evals.json` to consume grader results.

## Changes

- Add `--json` to `looplet eval run`.
- Emit the existing threshold/integrity verdict, threshold, per-case completion and serialized grader results, integrity failures, and optional output directory.
- Suppress the human table in JSON mode while preserving stderr and exit semantics.
- Keep artifacts and grader-only expected data out of the report.

## Behavioral contract

A passing run emits one parseable JSON report and exits 0. A below-threshold run emits `passed: false`, preserves the failing score, and exits 1. Persisted artifacts and expected data remain separate.

## Core-boundary check

Not applicable. This is a presentation branch over existing `EvalRunRecord` and `EvalResult.to_dict()` data; no report model or artifact format is added.

## Sync ↔ async parity

- [x] Not applicable; this changes only the existing eval CLI renderer.

## Dogfood evidence

- Clean wheel installed into a fresh Python 3.12 venv.
- Public stdin/JSON run, trace inspection, parent-linked follow-up, MCP-backed run, and required eval all passed with empty stderr.
- MCP-backed CLI left no orphaned subprocess.
- Real good and buggy report cartridges produced matching JSON verdicts and exit codes (0/pass and 1/fail).

## Checklist

- [x] 39 focused eval, persistence, file-workflow, and release-metadata tests pass.
- [x] Ruff, formatting, CI-equivalent Pyright, text style, and editor diagnostics pass.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.