### PR TITLE
fix(cli): harden cartridge runner lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Legacy `check_done` hooks no longer intermittently receive an unsupported
   `tool_call` keyword after short-lived hook classes are collected.
+- `looplet run-cartridge` now rejects missing project roots before execution,
+  preserves results from custom terminal tools, reports incomplete human runs
+  honestly, and closes cartridge-owned subprocesses before returning.
 
 ## [0.3.0] - 2026-07-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Legacy `check_done` hooks no longer intermittently receive an unsupported
   `tool_call` keyword after short-lived hook classes are collected.
+- `looplet run-cartridge` now rejects missing project roots before execution,
+  preserves results from custom terminal tools, reports incomplete human runs
+  honestly, and closes cartridge-owned subprocesses before returning.
 
 ## [0.3.0] - 2026-07-16
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,7 +104,7 @@ looplet run-cartridge ./agent.cartridge "Inspect the change" --json \
 
 `--project-root` controls the directory available to project-aware tools. It
 defaults to `LOOPLET_PROJECT_ROOT`, the current Git repository, or the current
-directory. Each run also writes a provenance trace under
+directory, and must already exist. Each run also writes a provenance trace under
 `.looplet/traces/<cartridge>-<id>/` in that project root. Pass `--trace-dir`
 to choose an explicit location or `--no-trace` to disable capture. Traces may
 contain full prompts, responses, and tool results; inspect them before sharing.
@@ -114,7 +114,8 @@ contain full prompts, responses, and tool results; inspect them before sharing.
 `termination_reason`, `steps`, `duration_ms`, the terminal `result`, and
 `trace_dir` (`null` with `--no-trace`). `completed` is true only when the agent
 reaches `done`; budget and hook stops remain successful CLI executions but are
-reported as incomplete. Errors remain on standard error; consumers should
+reported as incomplete. Human output likewise prints `stopped (<reason>)`
+instead of `done` for incomplete runs. Errors remain on standard error; consumers should
 tolerate added fields. It cannot be combined with `--pretty`.
 `run-workspace` remains a compatibility alias.
 

--- a/src/looplet/cli/factory_commands.py
+++ b/src/looplet/cli/factory_commands.py
@@ -42,6 +42,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
+from typing import Any
 
 from looplet.bundled import bundled_cartridge_path
 
@@ -310,17 +311,24 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         print(_red(f"error: {exc}"), file=sys.stderr)
         return 1
 
+    project_root = getattr(args, "project_root", None)
+    runtime: dict | None = None
+    if project_root is not None:
+        runtime = {"project_root": str(project_root.expanduser().resolve())}
+    effective_project_root = Path(resolve_project_root(runtime))
+    if not effective_project_root.is_dir():
+        print(
+            _red(f"error: project root is not a directory: {effective_project_root}"),
+            file=sys.stderr,
+        )
+        return 1
+
     if not json_output:
         print(f"{_bold('looplet run')} {workspace_path}")
         if not getattr(args, "pretty", False):
             print(_dim(f"  task:  {task[:100]}{'…' if len(task) > 100 else ''}"))
             print(_dim(f"  model: {os.environ['OPENAI_MODEL']}"))
         print()
-
-    project_root = getattr(args, "project_root", None)
-    runtime: dict | None = None
-    if project_root is not None:
-        runtime = {"project_root": str(project_root.expanduser().resolve())}
 
     trajectory_metadata: dict[str, str] = {}
     parent_trace = getattr(args, "parent_trace", None)
@@ -351,6 +359,7 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     if args.max_steps:
         preset.config.max_steps = args.max_steps
     state = DefaultState(max_steps=args.max_steps or preset.config.max_steps)
+    terminal_tools = {preset.config.done_tool, *preset.config.done_tools}
     sink = None
     effective_trace_dir = None
     if not getattr(args, "no_trace", False):
@@ -358,7 +367,7 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         if effective_trace_dir is None:
             cartridge_name = workspace_path.name.removesuffix(".cartridge")
             effective_trace_dir = (
-                Path(resolve_project_root(runtime))
+                effective_project_root
                 / ".looplet"
                 / "traces"
                 / f"{cartridge_name}-{uuid.uuid4().hex[:12]}"
@@ -386,7 +395,7 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
     t0 = time.time()
     n_steps = 0
     final_summary: str | None = None
-    final_data: dict | None = None
+    final_data: Any = None
     interrupted = False
     saved_trace_dir = None
     try:
@@ -415,15 +424,19 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
                 tag = _red("✗") if err else _green("✓")
                 short = json.dumps(tool_call.args, default=str)[:80]
                 print(f"  {tag} step {n_steps:>2}: {tool_call.tool}({short})")
-            if tool_call.tool == "done" and tool_result and isinstance(tool_result.data, dict):
-                final_data = dict(tool_result.data)
-                final_summary = str(tool_result.data.get("summary", ""))
+            if tool_call.tool in terminal_tools and tool_result is not None:
+                final_data = tool_result.data
+                if isinstance(final_data, dict):
+                    final_summary = str(final_data.get("summary", ""))
     except KeyboardInterrupt:
         print(_red("\ninterrupted"), file=sys.stderr)
         interrupted = True
     finally:
-        if sink is not None:
-            saved_trace_dir = sink.flush()
+        try:
+            if sink is not None:
+                saved_trace_dir = sink.flush()
+        finally:
+            preset.close()
 
     if interrupted:
         if saved_trace_dir is not None and not json_output:
@@ -431,10 +444,10 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 130
 
     elapsed = time.time() - t0
+    termination_reason = getattr(state, "_stop_reason", None)
+    if termination_reason is None:
+        termination_reason = getattr(state, "stop_reason", None)
     if json_output:
-        termination_reason = getattr(state, "_stop_reason", None)
-        if termination_reason is None:
-            termination_reason = getattr(state, "stop_reason", None)
         print(
             json.dumps(
                 {
@@ -452,12 +465,16 @@ def cmd_run_workspace(args: argparse.Namespace) -> int:
         return 0
 
     print()
-    print(f"{_green('✓')} done in {elapsed:.1f}s - {n_steps} steps")
+    if termination_reason == "done":
+        status = _green("✓ done")
+    else:
+        status = _dim(f"· stopped ({termination_reason or 'unknown'})")
+    print(f"{status} in {elapsed:.1f}s - {n_steps} steps")
     print()
     if final_summary:
         print(_bold("result:"))
         print(final_summary)
-    elif final_data:
+    elif final_data is not None:
         print(_bold("result:"))
         print(json.dumps(final_data, indent=2, default=str)[:2000])
     if saved_trace_dir is not None:

--- a/tests/test_run_cartridge_cli_hardening.py
+++ b/tests/test_run_cartridge_cli_hardening.py
@@ -1,0 +1,175 @@
+"""Regressions for installed-wheel runner frictions found by dogfooding."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from looplet.cli import factory_commands
+from looplet.testing import MockLLMBackend
+
+
+def _args(
+    cartridge: Path,
+    *,
+    project_root: Path | None = None,
+    max_steps: int = 1,
+    json_output: bool = True,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        workspace=cartridge,
+        task="finish",
+        max_steps=max_steps,
+        project_root=project_root,
+        trace_dir=None,
+        parent_trace=None,
+        no_trace=True,
+        quiet=False,
+        pretty=False,
+        json=json_output,
+    )
+
+
+def _patch_backend(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    monkeypatch.setenv("OPENAI_MODEL", "mock-model")
+    monkeypatch.setattr(factory_commands, "_check_env", lambda: 0)
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: MockLLMBackend(responses=responses, cycle=False),
+    )
+
+
+def _custom_terminal_cartridge(root: Path, *, name: str, return_expression: str) -> Path:
+    cartridge = root / f"{name}.cartridge"
+    (cartridge / "prompts").mkdir(parents=True)
+    (cartridge / "tools" / name).mkdir(parents=True)
+    (cartridge / "cartridge.json").write_text(json.dumps({"name": name, "schema_version": 2}))
+    (cartridge / "config.yaml").write_text(f"max_steps: 1\ndone_tool: {name}\n")
+    (cartridge / "runtime.yaml").write_text("use_native_tools: false\n")
+    (cartridge / "prompts" / "system.md").write_text(f"Call {name}.\n")
+    (cartridge / "tools" / name / "tool.yaml").write_text(
+        f"name: {name}\n"
+        "description: Finish with an answer.\n"
+        "parameters:\n"
+        "  answer:\n"
+        "    type: string\n"
+        "    description: Final answer.\n"
+    )
+    (cartridge / "tools" / name / "execute.py").write_text(
+        f"def execute(*, answer: str):\n    return {return_expression}\n"
+    )
+    return cartridge
+
+
+def test_missing_project_root_fails_before_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    cartridge = _custom_terminal_cartridge(tmp_path, name="done", return_expression="{}")
+    missing = tmp_path / "missing"
+    _patch_backend(monkeypatch, [json.dumps({"tool": "done", "args": {"answer": "ok"}})])
+    monkeypatch.setattr(
+        factory_commands,
+        "_build_backend",
+        lambda: pytest.fail("missing project root must fail before backend construction"),
+    )
+
+    rc = factory_commands.cmd_run_workspace(_args(cartridge, project_root=missing))
+
+    assert rc == 1
+    assert not missing.exists()
+    assert "project root is not a directory" in capsys.readouterr().err
+
+
+def test_incomplete_human_run_does_not_say_done(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    cartridge = _custom_terminal_cartridge(tmp_path, name="done", return_expression="{}")
+    work = cartridge / "tools" / "work"
+    work.mkdir()
+    (work / "tool.yaml").write_text("name: work\ndescription: Work.\nparameters: {}\n")
+    (work / "execute.py").write_text("def execute():\n    return {'ok': True}\n")
+    _patch_backend(
+        monkeypatch,
+        [json.dumps({"tool": "work", "args": {}, "reasoning": "work"})],
+    )
+
+    rc = factory_commands.cmd_run_workspace(
+        _args(cartridge, project_root=tmp_path, json_output=False)
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "stopped (budget_exhausted)" in out
+    assert "done in" not in out
+
+
+@pytest.mark.parametrize(
+    ("name", "return_expression", "expected"),
+    [
+        ("report", "{'answer': answer}", {"answer": "ok"}),
+        ("finish", "answer", "ok"),
+    ],
+)
+def test_custom_terminal_result_is_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+    name: str,
+    return_expression: str,
+    expected: object,
+) -> None:
+    cartridge = _custom_terminal_cartridge(
+        tmp_path,
+        name=name,
+        return_expression=return_expression,
+    )
+    _patch_backend(
+        monkeypatch,
+        [json.dumps({"tool": name, "args": {"answer": "ok"}, "reasoning": "finish"})],
+    )
+
+    rc = factory_commands.cmd_run_workspace(_args(cartridge, project_root=tmp_path))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["completed"] is True
+    assert payload["result"] == expected
+
+
+def test_runner_closes_real_mcp_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    import looplet
+
+    cartridge = Path(__file__).parents[1] / "examples" / "mcp_demo.cartridge"
+    captured: dict[str, object] = {}
+    original_loader = looplet.cartridge_to_preset
+
+    def capture_loader(*args, **kwargs):
+        preset = original_loader(*args, **kwargs)
+        captured["preset"] = preset
+        captured["adapter"] = preset.mcp_adapters[0]
+        return preset
+
+    monkeypatch.setattr(looplet, "cartridge_to_preset", capture_loader)
+    _patch_backend(
+        monkeypatch,
+        [
+            json.dumps({"tool": "add", "args": {"a": 1, "b": 2}, "reasoning": "add"}),
+            json.dumps({"tool": "done", "args": {"total": 3}, "reasoning": "done"}),
+        ],
+    )
+
+    rc = factory_commands.cmd_run_workspace(_args(cartridge, project_root=tmp_path, max_steps=2))
+
+    assert rc == 0
+    json.loads(capsys.readouterr().out)
+    preset = captured["preset"]
+    adapter = captured["adapter"]
+    assert preset.mcp_adapters == []
+    assert preset.model_gateway is None
+    assert adapter._proc is None


### PR DESCRIPTION
## Summary

Fix four `run-cartridge` lifecycle and reporting defects found by an adversarial installed-wheel dogfood matrix.

## Motivation

The hammer matrix showed that the CLI accepted missing project roots and still completed, labeled budget-exhausted human runs as done, dropped results from custom terminal tools, and retained real MCP resources when called in a long-lived Python process.

## Changes

- Validate the effective project root before backend/cartridge execution.
- Derive terminal tool names from `LoopConfig` and preserve arbitrary terminal result types.
- Render incomplete human runs as `stopped (<reason>)`.
- Close every cartridge-owned MCP/state/model-gateway resource in `finally`.
- Add focused regressions, including a real MCP adapter lifecycle check.

## Behavioral contract

Missing project roots fail before backend construction. Any declared terminal tool produces the JSON `result`, including string results. Only a true done stop is labeled done in human output. `cmd_run_workspace()` returns with cartridge-owned subprocesses closed.

## Core-boundary check

Not applicable. This repairs ownership and rendering in the existing CLI runner; no new runtime concept or option is added.

## Sync ↔ async parity

- [x] Not applicable; `run-cartridge` is the existing synchronous CLI path.

## Hammer evidence

- Before: 4/4 targeted runner scenarios failed.
- After overlay: missing-root, incomplete wording, custom dict/string terminals, and in-process real MCP cleanup all passed.
- Concurrent default trace allocation, paths with spaces, malformed model output, provider failure, and invalid-parent handling also passed.

## Checklist

- [x] 51 focused CLI/MCP/release tests pass.
- [x] Ruff, formatting, CI-equivalent Pyright, text style, and editor diagnostics pass.
- [x] `CHANGELOG.md` updated under Unreleased.
- [x] Read `CONTRIBUTING.md`.