### PR TITLE
Reject stale and malformed trace evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Legacy `check_done` hooks no longer intermittently receive an unsupported
   `tool_call` keyword after short-lived hook classes are collected.
+- Trace inspection and replay now reject malformed structures, invalid replay
+  indices or methods, missing responses, and corrupt native content blocks
+  before rendering or execution.
+- Reusing a trace directory removes stale Looplet-owned call and step files
+  while preserving unrelated files.
 - `looplet run-cartridge` now rejects missing project roots before execution,
   preserves results from custom terminal tools, reports incomplete human runs
   honestly, and closes cartridge-owned subprocesses before returning.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Legacy `check_done` hooks no longer intermittently receive an unsupported
   `tool_call` keyword after short-lived hook classes are collected.
+- Trace inspection and replay now reject malformed structures, invalid replay
+  indices or methods, missing responses, and corrupt native content blocks
+  before rendering or execution.
+- Reusing a trace directory removes stale Looplet-owned call and step files
+  while preserving unrelated files.
 - `looplet run-cartridge` now rejects missing project roots before execution,
   preserves results from custom terminal tools, reports incomplete human runs
   honestly, and closes cartridge-owned subprocesses before returning.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -85,6 +85,16 @@ Every file is human-readable. `trajectory.json` and `manifest.jsonl` are
 machine-parseable. You can diff, grep, version-control, attach to bug
 reports, or feed to a separate analysis pipeline.
 
+Saving to an existing trace directory replaces Looplet-owned call and step
+files from the prior run. Files that do not match those exact artifact names
+are preserved. Do not use one explicit trace directory for concurrent writers.
+
+`looplet show` and `replay_loop()` fail before rendering or execution when the
+evidence structures they consume are malformed. Replay also requires
+contiguous manifest indices and the corresponding response file for every
+manifest record. These checks protect one run from mixed or corrupt evidence;
+they do not make the pre-1.0 artifact format a frozen schema.
+
 ### Link related traces
 
 Seed trajectory metadata when a host wants to record evidence lineage:

--- a/src/looplet/__main__.py
+++ b/src/looplet/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import platform
 import sys
@@ -33,6 +34,56 @@ def _fmt_ms(ms: float | int | None) -> str:
     return f"{int(ms):>5}ms"
 
 
+def _is_finite_number(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _trace_shape_error(
+    trajectory: dict[str, Any],
+    calls: list[dict[str, Any]],
+) -> str | None:
+    for field in ("run_id", "termination_reason"):
+        value = trajectory.get(field)
+        if value is not None and not isinstance(value, str):
+            return f"trajectory.{field} must be a string"
+    for field in ("step_count", "llm_call_count"):
+        value = trajectory.get(field)
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+        ):
+            return f"trajectory.{field} must be a non-negative integer"
+    steps = trajectory.get("steps", [])
+    if not isinstance(steps, list):
+        return "trajectory.steps must be an array"
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            return f"trajectory.steps[{index}] must be an object"
+        for field in ("tool_call", "tool_result"):
+            value = step.get(field)
+            if value is not None and not isinstance(value, dict):
+                return f"trajectory.steps[{index}].{field} must be an object"
+        linked = step.get("llm_call_indices")
+        if linked is not None and not isinstance(linked, list):
+            return f"trajectory.steps[{index}].llm_call_indices must be an array"
+        duration = step.get("duration_ms")
+        if duration is not None and not _is_finite_number(duration):
+            return f"trajectory.steps[{index}].duration_ms must be a finite number"
+    failure_modes = trajectory.get("failure_modes")
+    if failure_modes is not None and not isinstance(failure_modes, list):
+        return "trajectory.failure_modes must be an array"
+    for index, call in enumerate(calls):
+        for field in ("duration_ms", "prompt_chars", "response_chars"):
+            value = call.get(field)
+            if value is not None and not _is_finite_number(value):
+                return f"manifest[{index}].{field} must be a finite number"
+    return None
+
+
 def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
     if not trace_dir.exists():
         print(f"error: {trace_dir} does not exist", file=sys.stderr)
@@ -44,22 +95,39 @@ def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
     traj: dict[str, Any] = {}
     if traj_path.exists():
         try:
-            traj = json.loads(traj_path.read_text(encoding="utf-8"))
+            parsed_traj = json.loads(traj_path.read_text(encoding="utf-8"))
         except Exception as exc:
             print(f"error: could not parse {traj_path}: {exc}", file=sys.stderr)
             return 1
+        if not isinstance(parsed_traj, dict):
+            print(f"error: expected a JSON object in {traj_path}", file=sys.stderr)
+            return 1
+        traj = parsed_traj
 
     # ── manifest.jsonl (optional) ────────────────────────────────
     calls: list[dict[str, Any]] = []
     if manifest_path.exists():
-        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+        for line_number, line in enumerate(
+            manifest_path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
             line = line.strip()
             if not line:
                 continue
             try:
-                calls.append(json.loads(line))
-            except Exception:
-                continue
+                call = json.loads(line)
+            except Exception as exc:
+                print(
+                    f"error: could not parse {manifest_path} line {line_number}: {exc}",
+                    file=sys.stderr,
+                )
+                return 1
+            if not isinstance(call, dict):
+                print(
+                    f"error: expected a JSON object in {manifest_path} line {line_number}",
+                    file=sys.stderr,
+                )
+                return 1
+            calls.append(call)
 
     if not traj and not calls:
         print(
@@ -67,6 +135,11 @@ def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
             "manifest.jsonl - not a trace directory",
             file=sys.stderr,
         )
+        return 1
+
+    shape_error = _trace_shape_error(traj, calls)
+    if shape_error is not None:
+        print(f"error: invalid trace shape: {shape_error}", file=sys.stderr)
         return 1
 
     if json_output:

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -55,6 +56,17 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+_CALL_ARTIFACT = re.compile(r"call_\d+_(?:prompt|response)\.txt")
+_STEP_ARTIFACT = re.compile(r"step_\d+\.json")
+
+
+def _clear_call_artifacts(root: Path) -> None:
+    for path in root.iterdir():
+        if path.is_file() and _CALL_ARTIFACT.fullmatch(path.name):
+            path.unlink()
+    (root / "manifest.jsonl").unlink(missing_ok=True)
+
 
 __all__ = [
     "LLMCall",
@@ -211,6 +223,7 @@ class _RecordingBase:
         """
         root = Path(directory)
         root.mkdir(parents=True, exist_ok=True)
+        _clear_call_artifacts(root)
         manifest = root / "manifest.jsonl"
         with manifest.open("w", encoding="utf-8") as mf:
             for c in self.calls:
@@ -791,12 +804,16 @@ class TrajectoryRecorder:
         """
         root = Path(directory)
         root.mkdir(parents=True, exist_ok=True)
+        _clear_call_artifacts(root)
         traj_text = json.dumps(self.trajectory.to_dict(), indent=2, default=str)
         if self._redact is not None:
             traj_text = self._redact(traj_text)
         (root / "trajectory.json").write_text(traj_text, encoding="utf-8")
         steps_dir = root / "steps"
         steps_dir.mkdir(exist_ok=True)
+        for path in steps_dir.iterdir():
+            if path.is_file() and _STEP_ARTIFACT.fullmatch(path.name):
+                path.unlink()
         for s in self.trajectory.steps:
             step_text = json.dumps(s.to_dict(), indent=2, default=str)
             if self._redact is not None:
@@ -985,23 +1002,51 @@ def _load_trace_calls(trace_dir: Path) -> list[dict[str, Any]]:
     manifest = trace_dir / "manifest.jsonl"
     calls: list[dict[str, Any]] = []
     if manifest.exists():
-        for line in manifest.read_text(encoding="utf-8").splitlines():
+        for line_number, line in enumerate(
+            manifest.read_text(encoding="utf-8").splitlines(), start=1
+        ):
             line = line.strip()
             if not line:
                 continue
-            entry = json.loads(line)
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid {manifest} line {line_number}: {exc}") from exc
+            if not isinstance(entry, dict):
+                raise ValueError(f"invalid {manifest} line {line_number}: expected an object")
             idx = entry.get("index")
+            expected_index = len(calls)
+            if isinstance(idx, bool) or not isinstance(idx, int) or idx != expected_index:
+                raise ValueError(
+                    f"invalid {manifest} line {line_number}: "
+                    f"expected index {expected_index}, got {idx!r}"
+                )
+            method = entry.get("method", "generate")
+            if method not in {"generate", "generate_with_tools"}:
+                raise ValueError(
+                    f"invalid {manifest} line {line_number}: unsupported method {method!r}"
+                )
             response_txt = _read_call_body(trace_dir, idx)
-            if entry.get("method") == "generate_with_tools":
+            if response_txt is None:
+                raise FileNotFoundError(
+                    f"missing recorded response for {manifest} line {line_number}: "
+                    f"call_{idx:02d}_response.txt"
+                )
+            if method == "generate_with_tools":
                 # The on-disk .txt file contains a JSON content-block
                 # dump after the "## RESPONSE (content blocks)" header.
-                response: Any = _extract_content_blocks(response_txt)
+                try:
+                    response: Any = _extract_content_blocks(response_txt)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"invalid recorded response for {manifest} line {line_number}: {exc}"
+                    ) from exc
             else:
                 response = _extract_response_text(response_txt)
             calls.append(
                 {
                     "index": idx,
-                    "method": entry.get("method", "generate"),
+                    "method": method,
                     "response": response,
                 }
             )
@@ -1053,16 +1098,18 @@ def _extract_response_text(body: str | None) -> str:
 
 def _extract_content_blocks(body: str | None) -> list[dict[str, Any]]:
     if not body:
-        return []
+        raise ValueError("content-block response is empty")
     marker = "## RESPONSE (content blocks)\n"
-    if marker in body:
-        payload = body.split(marker, 1)[1].strip()
-        try:
-            decoded = json.loads(payload)
-            return decoded if isinstance(decoded, list) else []
-        except Exception:
-            return []
-    return []
+    if marker not in body:
+        raise ValueError("content-block response header is missing")
+    payload = body.split(marker, 1)[1].strip()
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"content blocks are not valid JSON: {exc}") from exc
+    if not isinstance(decoded, list) or any(not isinstance(block, dict) for block in decoded):
+        raise ValueError("content blocks must be an array of objects")
+    return decoded
 
 
 def replay_loop(

--- a/tests/test_provenance_smoke.py
+++ b/tests/test_provenance_smoke.py
@@ -95,11 +95,21 @@ class TestRecordingLLMBackendSmoke:
         rec = RecordingLLMBackend(MockLLMBackend(responses=["r1", "r2"]))
         rec.generate("p1", system_prompt="sys")
         rec.generate("p2")
-        out = rec.save(tmp_path / "traces")
+        trace_dir = tmp_path / "traces"
+        trace_dir.mkdir()
+        stale = trace_dir / "call_99_prompt.txt"
+        unrelated = trace_dir / "call_notes_prompt.txt"
+        stale.write_text("old")
+        unrelated.write_text("keep")
+
+        out = rec.save(trace_dir)
+
         assert (out / "call_00_prompt.txt").exists()
         assert (out / "call_00_response.txt").exists()
         assert (out / "call_01_prompt.txt").exists()
         assert (out / "manifest.jsonl").exists()
+        assert not stale.exists()
+        assert unrelated.read_text() == "keep"
         text = (out / "call_00_prompt.txt").read_text()
         assert "p1" in text and "sys" in text
         # manifest has one line per call
@@ -207,9 +217,26 @@ class TestTrajectoryRecorderSmoke:
         hook.post_dispatch(state, None, step.tool_call, step.tool_result, step_num=1)
         hook.on_loop_end(state, None, None, None)
 
-        out = hook.save(tmp_path / "traj")
+        trace_dir = tmp_path / "traj"
+        steps_dir = trace_dir / "steps"
+        steps_dir.mkdir(parents=True)
+        stale = steps_dir / "step_99.json"
+        unrelated = steps_dir / "step_notes.json"
+        stale_call = trace_dir / "call_99_prompt.txt"
+        stale_manifest = trace_dir / "manifest.jsonl"
+        stale.write_text("old")
+        unrelated.write_text("keep")
+        stale_call.write_text("old")
+        stale_manifest.write_text('{"index":99}\n')
+
+        out = hook.save(trace_dir)
+
         assert (out / "trajectory.json").exists()
         assert (out / "steps" / "step_01.json").exists()
+        assert not stale.exists()
+        assert not stale_call.exists()
+        assert not stale_manifest.exists()
+        assert unrelated.read_text() == "keep"
         doc = json.loads((out / "trajectory.json").read_text())
         assert doc["step_count"] == 1
         assert doc["termination_reason"] == "done"

--- a/tests/test_replay_and_cli_smoke.py
+++ b/tests/test_replay_and_cli_smoke.py
@@ -110,6 +110,89 @@ class TestReplayLoopSmoke:
         steps = list(replay_loop(trace_dir, tools=_make_tools()))
         assert len(steps) == 3
 
+    @pytest.mark.parametrize(
+        "manifest, expected",
+        [
+            ("not-json\n", "invalid"),
+            ("42\n", "expected an object"),
+            ('{"method":"generate"}\n', "expected index 0"),
+            (
+                '{"index":0,"method":"generate"}\n{"index":0,"method":"generate"}\n',
+                "expected index 1",
+            ),
+            ('{"index":0,"method":"unknown"}\n', "unsupported method"),
+        ],
+    )
+    def test_replay_rejects_invalid_manifest(
+        self,
+        tmp_path: Path,
+        manifest: str,
+        expected: str,
+    ):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text(manifest)
+        (trace_dir / "call_00_response.txt").write_text("response")
+
+        with pytest.raises(ValueError, match=expected):
+            list(replay_loop(trace_dir, tools=_make_tools()))
+
+    def test_replay_rejects_missing_manifest_response(self, tmp_path: Path):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text('{"index":0,"method":"generate"}\n')
+
+        with pytest.raises(FileNotFoundError, match="call_00_response.txt"):
+            list(replay_loop(trace_dir, tools=_make_tools()))
+
+    @pytest.mark.parametrize("payload", ["not-json", "[42]"])
+    def test_replay_rejects_malformed_native_response(self, tmp_path: Path, payload: str):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text('{"index":0,"method":"generate_with_tools"}\n')
+        (trace_dir / "call_00_response.txt").write_text(
+            f"# call 00 - method=generate_with_tools\n\n## RESPONSE (content blocks)\n{payload}\n"
+        )
+
+        with pytest.raises(ValueError, match="invalid recorded response"):
+            list(replay_loop(trace_dir, tools=_make_tools()))
+
+    def test_replays_valid_native_responses(self, tmp_path: Path):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text(
+            '{"index":0,"method":"generate_with_tools"}\n'
+            '{"index":1,"method":"generate_with_tools"}\n'
+        )
+        responses = [
+            [{"type": "tool_use", "id": "t1", "name": "add", "input": {"a": 1, "b": 2}}],
+            [
+                {
+                    "type": "tool_use",
+                    "id": "t2",
+                    "name": "done",
+                    "input": {"answer": "3"},
+                }
+            ],
+        ]
+        for index, response in enumerate(responses):
+            (trace_dir / f"call_{index:02d}_response.txt").write_text(
+                f"# call {index:02d} - method=generate_with_tools\n\n"
+                "## RESPONSE (content blocks)\n"
+                f"{json.dumps(response)}\n"
+            )
+
+        steps = list(
+            replay_loop(
+                trace_dir,
+                tools=_make_tools(),
+                state=DefaultState(max_steps=3),
+                config=LoopConfig(max_steps=3, use_native_tools=True),
+            )
+        )
+
+        assert [step.tool_call.tool for step in steps] == ["add", "done"]
+
 
 class TestShowCLISmoke:
     def test_show_renders_summary(self, tmp_path: Path, capsys):
@@ -169,6 +252,116 @@ class TestShowCLISmoke:
         payload = json.loads(capsys.readouterr().out)
         assert payload["trajectory"] is None
         assert len(payload["manifest"]) == 3
+
+    def test_show_rejects_nonobject_trajectory(self, tmp_path: Path, capsys):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "trajectory.json").write_text("[1]\n")
+
+        rc = cli_main(["show", str(trace_dir)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "expected a JSON object" in captured.err
+
+    def test_show_rejects_malformed_manifest_line(self, tmp_path: Path, capsys):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text('{"index": 0}\nnot-json\n')
+
+        rc = cli_main(["show", str(trace_dir), "--json"])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "manifest.jsonl line 2" in captured.err
+        assert captured.out == ""
+
+    def test_show_rejects_nonobject_manifest_record(self, tmp_path: Path, capsys):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text("42\n")
+
+        rc = cli_main(["show", str(trace_dir), "--json"])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "expected a JSON object" in captured.err
+        assert captured.out == ""
+
+    @pytest.mark.parametrize(
+        "trajectory, expected",
+        [
+            ({"run_id": "r", "steps": 1}, "trajectory.steps must be an array"),
+            ({"run_id": "r", "steps": [42]}, "trajectory.steps[0] must be an object"),
+            (
+                {"run_id": "r", "steps": [{"tool_call": 42}]},
+                "trajectory.steps[0].tool_call must be an object",
+            ),
+            (
+                {"run_id": "r", "steps": [{"tool_result": 42}]},
+                "trajectory.steps[0].tool_result must be an object",
+            ),
+            (
+                {"run_id": "r", "steps": [{"llm_call_indices": 1}]},
+                "trajectory.steps[0].llm_call_indices must be an array",
+            ),
+            (
+                {"run_id": "r", "steps": [{"duration_ms": "slow"}]},
+                "trajectory.steps[0].duration_ms must be a finite number",
+            ),
+            (
+                {"run_id": "r", "termination_reason": {}, "steps": []},
+                "trajectory.termination_reason must be a string",
+            ),
+            (
+                {"run_id": "r", "step_count": [], "steps": []},
+                "trajectory.step_count must be a non-negative integer",
+            ),
+            (
+                {"run_id": "r", "failure_modes": 1, "steps": []},
+                "trajectory.failure_modes must be an array",
+            ),
+            (
+                {"run_id": "r", "steps": [{"duration_ms": 10**1000}]},
+                "trajectory.steps[0].duration_ms must be a finite number",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("json_mode", [False, True])
+    def test_show_rejects_malformed_nested_trajectory(
+        self,
+        tmp_path: Path,
+        capsys,
+        trajectory,
+        expected: str,
+        json_mode: bool,
+    ):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "trajectory.json").write_text(json.dumps(trajectory))
+        args = ["show", str(trace_dir)]
+        if json_mode:
+            args.append("--json")
+
+        rc = cli_main(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert expected in captured.err
+        assert "traceback" not in captured.err.lower()
+        assert captured.out == ""
+
+    def test_show_rejects_malformed_manifest_summary(self, tmp_path: Path, capsys):
+        trace_dir = tmp_path / "trace"
+        trace_dir.mkdir()
+        (trace_dir / "manifest.jsonl").write_text('{"duration_ms":"slow"}\n')
+
+        rc = cli_main(["show", str(trace_dir)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "manifest[0].duration_ms must be a finite number" in captured.err
+        assert "traceback" not in captured.err.lower()
 
 
 class TestDoctorCLISmoke:


### PR DESCRIPTION
## Summary

- reject malformed trajectory and manifest structures before `looplet show` renders human or JSON output
- replace only exact Looplet-owned trace artifacts when a trace directory is reused
- fail replay before execution when its manifest, response files, or native content blocks are inconsistent
- preserve manifest-free replay compatibility and unrelated files in reused trace directories

## Why

Adversarial installed-wheel dogfooding found that malformed traces could be partly rendered or blessed as JSON, reused directories could mix evidence from multiple runs, and corrupt replay inputs could silently become empty model responses. These cases now fail at the evidence boundary.

## Validation

- 73 focused provenance, replay, workflow, regression, and release tests
- Ruff check and format check
- Pyright: 0 errors
- text-style and `git diff --check`
- installed-wheel adversarial matrix: 16/16 pass
- malformed nested trace probe: 12/12 clean rejections
- additional shape/reuse probe: 8/8 clean rejections, no stale calls
- replay corruption probe: 6/6 fail before execution
- valid native captured-response replay positive control
