### PR TITLE
feat(artifacts): version saved evidence

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -15,6 +15,7 @@ capture:
 
 ```text
 traces/run-42/
+├── artifact.json
 ├── trajectory.json
 ├── steps/
 │   ├── step_00.json
@@ -28,6 +29,7 @@ traces/run-42/
 
 | Path | Contents | Primary reader |
 | --- | --- | --- |
+| `artifact.json` | Format version, artifact kind, producing Looplet version, and declared components. | All supported directory readers |
 | `trajectory.json` | Run metadata, task view, steps, stop reason, timing, and captured context. | `EvalContext.from_trajectory_dir()` or JSON tooling |
 | `steps/step_NN.json` | One review-friendly copy of each step record. | Humans, diffs, JSON tooling |
 | `manifest.jsonl` | One structured summary per model call. | `looplet show`, replay loader, line-oriented tooling |
@@ -68,6 +70,7 @@ grader results, and case identity to the trajectory:
 
 ```text
 eval-runs/regression-42/
+├── artifact.json
 ├── trajectory.json
 ├── steps/
 ├── manifest.jsonl              # when a recording backend was attached
@@ -81,6 +84,7 @@ eval-runs/regression-42/
 
 | Path | Contents | Trust role |
 | --- | --- | --- |
+| `artifact.json` | Declares a versioned `eval_run` and its required components. | Compatibility boundary |
 | `artifacts.json` | Collector-observed world state used by graders. | Host observation |
 | `evals.json` | Normalized grader scores, labels, metrics, and errors. | Decision evidence |
 | `expected.json` | Grader-only expected data restored into `ctx.task["expected"]` after the run. | Promotion oracle input |
@@ -100,6 +104,23 @@ print(record.case.id if record.case else "no case metadata")
 
 A missing `trajectory.json` or malformed JSON fails loudly. Collector errors
 remain explicit eval results rather than disappearing as absent data.
+
+### Writer inventory
+
+| Writer | Files it owns |
+| --- | --- |
+| `RecordingLLMBackend.save()` and its async twin | `artifact.json`, `manifest.jsonl`, and indexed `call_NN_{prompt,response}.txt` pairs |
+| `TrajectoryRecorder.save()` | `artifact.json`, `trajectory.json`, `steps/step_NN.json`, and the model-call files when a recording backend is attached |
+| `ProvenanceSink.flush()` | The union selected by its attached recorder/backend; an unused sink may create only its directory |
+| `EvalHook.save()` | One legacy standalone JSON report with `task`, `results`, `summary`, and optional `expected` / `artifacts` |
+| `save_eval_run()` | A versioned eval-run directory: required trajectory, artifacts, and eval results; optional case, expectations, and recorded calls |
+| `promote_to_offline()` | The same layout as `save_eval_run()` |
+| `run_cartridge_evals(..., output_dir=...)` | One `save_eval_run()` directory per case plus a `workspace/` owned by the evaluated application |
+
+`EvalHook.save()` remains an unversioned compatibility report. It has no
+supported round-trip reader and should not be used as a long-lived CI wire
+format. Use `save_eval_run()` for durable evidence; use the documented
+`looplet eval run --json` schema for transient CI decisions.
 
 ### Agent-visible and grader-only data
 
@@ -142,24 +163,81 @@ write collector output to `artifacts.json` and top-level case expectations to
 
 ## Compatibility policy
 
-The cartridge format has its own schema version. Saved provenance and eval
-run directories in `0.3` do not yet declare a separate stable artifact schema
-version.
+The cartridge schema and saved-artifact schema are independent. New provenance
+and eval-run directories carry this descriptor:
 
-For automation:
+```json
+{
+  "schema": "looplet.saved-artifact",
+  "version": 1,
+  "kind": "provenance",
+  "producer": {"name": "looplet", "version": "0.4.0"},
+  "components": ["model_calls", "trajectory"]
+}
+```
 
-1. pin the Looplet minor line;
-2. prefer `load_eval_run()` and `EvalContext.from_trajectory_dir()` over
-   reconstructing dataclasses from JSON fields;
-3. tolerate additional object fields when consuming JSON;
-4. fail on missing required evidence rather than substituting success;
-5. preserve the producing Looplet version and cartridge hash beside exported
-   artifacts;
-6. review the changelog before upgrading the reader or producer.
+`version` governs the artifact layout; `producer.version` identifies the
+package that wrote it for diagnostics. They do not advance together. `kind` is
+`provenance` or `eval_run`. Version 1 components use the closed vocabulary
+`trajectory`, `model_calls`, `artifacts`, and `eval_results`.
 
-The roadmap includes explicit schema-version and compatibility guarantees for
-saved evidence. Until those land, readable files aid review and portability
-but are not a frozen cross-version wire contract.
+An absent `artifact.json` means the supported unversioned legacy shape (called
+v0), not “the latest version.” Looplet keeps concrete legacy fixtures for that
+shape, including the older `metrics.json` input. An unknown schema, unsupported
+explicit version, unknown kind/component, malformed descriptor, or missing
+declared component fails before rendering, replay, or grading.
+
+### Stable and optional fields
+
+Required means a current writer emits the field and a v1 reader may rely on its
+meaning. Optional means consumers must accept its absence and producers may add
+it without advancing the format. Unknown object fields are ignored; this makes
+additive metadata forward-compatible. Unknown component names are refused
+because components declare completeness.
+
+| File | Required stable | Optional stable | Internal or application-owned |
+| --- | --- | --- | --- |
+| `artifact.json` | `schema`, `version`, `kind`, `producer.name`, `producer.version`, `components` | Additional object fields | None |
+| `trajectory.json` | `run_id`, `termination_reason`, `steps`; each step's `tool_call` and `tool_result` | `task`, timestamps, counts, session text, metadata, context, call linkage, call summaries | In-memory span objects |
+| `manifest.jsonl` | Contiguous `index`, supported `method`; matching indexed prompt/response files and replay response section | Timing, sizes, tool count, step link, error, scope, metadata | None |
+| `artifacts.json` | A JSON object | Application-defined keys and values | The meaning of application keys |
+| `evals.json` | An array; each result's `name` | Present `score`, `label`, `metrics`, `details`, `explanation`, `duration_ms` | None |
+| `expected.json` | A JSON object when present | The whole file is optional | Application-defined keys and values |
+| `case.json` | `id` and `task` when present | `expected`, `marks`, `notes`; the whole file is optional | None |
+| `steps/step_NN.json` | None | None | Redundant review copy; `trajectory.json` is authoritative |
+| `workspace/` | None | None | Evaluated application state, outside the artifact schema |
+
+Current writers also emit `task`, `results`, and `summary` in the standalone
+`EvalHook.save()` report; `expected` and `artifacts` are optional there. Those
+v0 fields retain their current meaning, but new automation should use the
+versioned directory or CI summary instead.
+
+Malformed decision-bearing JSON fails closed. Missing optional fields use the
+defaults documented by the supported readers. Conflicting expected data is an
+error. Consumers should call `load_eval_run()` and
+`EvalContext.from_trajectory_dir()` rather than reconstructing internal
+dataclasses from JSON.
+
+### Publication and incomplete directories
+
+Saved directories are not transactional databases, and concurrent reads while
+a writer is active are unsupported. Before clearing an old descriptor, writers
+atomically publish `.artifact.json.pending`. Readers refuse any directory with
+that marker, so a crash cannot turn a partial v1 replacement into an
+ordinary-looking legacy v0 artifact. Writers then replace the payload, publish
+`artifact.json` with an atomic file replacement, and remove the pending marker.
+Once a v1 descriptor is present, every declared component file must be present
+or the directory is rejected as incomplete.
+
+Legacy v0 has no completion marker, so its historical best-effort behavior is
+retained. Required malformed files still fail loudly. Reusing a directory
+removes only exact Looplet-owned names; use one directory per logical run and
+inspect it only after the writer returns.
+
+For automation, preserve the artifact directory intact, tolerate additional
+object fields, fail on missing required evidence, and review the changelog
+before advancing the producing or reading Looplet version. There is no promise
+to read every historical or future shape.
 
 ## Redaction and retention
 

--- a/src/looplet/__main__.py
+++ b/src/looplet/__main__.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from looplet import __version__
+from looplet.artifact_compat import read_artifact_descriptor
 
 
 def _fmt_ms(ms: float | int | None) -> str:
@@ -88,12 +89,21 @@ def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
     if not trace_dir.exists():
         print(f"error: {trace_dir} does not exist", file=sys.stderr)
         return 1
+    try:
+        descriptor = read_artifact_descriptor(
+            trace_dir,
+            expected_kinds=("eval_run", "provenance"),
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
     # ── trajectory.json (optional; short-circuit if missing) ─────
     traj_path = trace_dir / "trajectory.json"
     manifest_path = trace_dir / "manifest.jsonl"
+    declared = set(descriptor["components"]) if descriptor is not None else None
     traj: dict[str, Any] = {}
-    if traj_path.exists():
+    if (declared is None or "trajectory" in declared) and traj_path.exists():
         try:
             parsed_traj = json.loads(traj_path.read_text(encoding="utf-8"))
         except Exception as exc:
@@ -106,7 +116,7 @@ def _render_show(trace_dir: Path, *, json_output: bool = False) -> int:
 
     # ── manifest.jsonl (optional) ────────────────────────────────
     calls: list[dict[str, Any]] = []
-    if manifest_path.exists():
+    if (declared is None or "model_calls" in declared) and manifest_path.exists():
         for line_number, line in enumerate(
             manifest_path.read_text(encoding="utf-8").splitlines(), start=1
         ):

--- a/src/looplet/artifact_compat.py
+++ b/src/looplet/artifact_compat.py
@@ -1,0 +1,218 @@
+"""Compatibility descriptor for saved provenance and eval-run directories."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+ARTIFACT_DESCRIPTOR = "artifact.json"
+ARTIFACT_PENDING = ".artifact.json.pending"
+ARTIFACT_SCHEMA = "looplet.saved-artifact"
+ARTIFACT_VERSION = 1
+
+_KINDS = {"eval_run", "provenance"}
+_COMPONENT_FILES = {
+    "artifacts": "artifacts.json",
+    "eval_results": "evals.json",
+    "model_calls": "manifest.jsonl",
+    "trajectory": "trajectory.json",
+}
+_REQUIRED_COMPONENTS = {
+    "eval_run": {"artifacts", "eval_results", "trajectory"},
+    "provenance": set(),
+}
+
+
+def begin_artifact_write(directory: str | Path) -> None:
+    """Mark an artifact incomplete before removing its previous descriptor."""
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    _atomic_write(root / ARTIFACT_PENDING, "incomplete\n")
+    (root / ARTIFACT_DESCRIPTOR).unlink(missing_ok=True)
+
+
+def write_artifact_descriptor(
+    directory: str | Path,
+    *,
+    kind: str,
+    components: Iterable[str],
+) -> Path:
+    """Atomically publish the descriptor after an artifact payload is complete."""
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    normalized = _validate_kind_and_components(kind, components)
+    _validate_component_files(root, normalized)
+
+    # Import lazily so package initialization cannot cycle through this module.
+    from looplet import __version__  # noqa: PLC0415
+
+    payload = {
+        "schema": ARTIFACT_SCHEMA,
+        "version": ARTIFACT_VERSION,
+        "kind": kind,
+        "producer": {"name": "looplet", "version": __version__},
+        "components": normalized,
+    }
+    descriptor = root / ARTIFACT_DESCRIPTOR
+    _atomic_write(descriptor, json.dumps(payload, indent=2) + "\n")
+    (root / ARTIFACT_PENDING).unlink(missing_ok=True)
+    return descriptor
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def read_artifact_descriptor(
+    directory: str | Path,
+    *,
+    expected_kinds: Iterable[str] | None = None,
+) -> dict[str, Any] | None:
+    """Read and validate a v1 descriptor; return ``None`` for legacy v0."""
+    root = Path(directory)
+    if (root / ARTIFACT_PENDING).exists():
+        raise ValueError(f"Incomplete saved artifact in {root}: write is still pending")
+    descriptor = root / ARTIFACT_DESCRIPTOR
+    if not descriptor.exists():
+        return None
+    try:
+        payload = json.loads(descriptor.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: expected an object")
+
+    schema = payload.get("schema")
+    if schema != ARTIFACT_SCHEMA:
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: unsupported schema {schema!r}")
+    version = payload.get("version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: version must be an integer")
+    if version != ARTIFACT_VERSION:
+        raise ValueError(
+            f"Unsupported {ARTIFACT_SCHEMA} version {version} in {root}; "
+            f"this Looplet supports version {ARTIFACT_VERSION}"
+        )
+
+    kind = payload.get("kind")
+    raw_components = payload.get("components")
+    if not isinstance(kind, str):
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: kind must be a string")
+    if not isinstance(raw_components, list) or any(
+        not isinstance(component, str) for component in raw_components
+    ):
+        raise ValueError(
+            f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: components must be an array of strings"
+        )
+    components = _validate_kind_and_components(kind, raw_components, root=root)
+
+    producer = payload.get("producer")
+    if not isinstance(producer, dict):
+        raise ValueError(f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: producer must be an object")
+    if producer.get("name") != "looplet" or not isinstance(producer.get("version"), str):
+        raise ValueError(
+            f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: producer requires looplet name and version"
+        )
+
+    if expected_kinds is not None:
+        allowed = set(expected_kinds)
+        if kind not in allowed:
+            expected = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"Invalid {ARTIFACT_DESCRIPTOR} in {root}: kind {kind!r} is not {expected}"
+            )
+    _validate_component_files(root, components)
+    return payload
+
+
+def _validate_kind_and_components(
+    kind: str,
+    components: Iterable[str],
+    *,
+    root: Path | None = None,
+) -> list[str]:
+    where = f" in {root}" if root is not None else ""
+    if kind not in _KINDS:
+        raise ValueError(f"Invalid artifact kind {kind!r}{where}")
+    normalized = list(components)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"Invalid artifact components{where}: duplicates are not allowed")
+    unknown = sorted(set(normalized) - set(_COMPONENT_FILES))
+    if unknown:
+        raise ValueError(f"Invalid artifact components{where}: unknown {', '.join(unknown)}")
+    required = _REQUIRED_COMPONENTS[kind]
+    missing = sorted(required - set(normalized))
+    if missing:
+        raise ValueError(f"Invalid {kind} artifact components{where}: missing {', '.join(missing)}")
+    if kind == "provenance" and not normalized:
+        raise ValueError(f"Invalid provenance artifact components{where}: at least one is required")
+    return sorted(normalized)
+
+
+def _validate_component_files(root: Path, components: Iterable[str]) -> None:
+    for component in components:
+        path = root / _COMPONENT_FILES[component]
+        if not path.is_file():
+            raise ValueError(
+                f"Incomplete saved artifact in {root}: component {component!r} "
+                f"requires {_COMPONENT_FILES[component]}"
+            )
+        if component == "model_calls":
+            _validate_model_call_files(root, path)
+
+
+def _validate_model_call_files(root: Path, manifest: Path) -> None:
+    try:
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ValueError(f"Invalid model_calls component in {root}: {exc}") from exc
+    expected_index = 0
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Invalid model_calls component in {root}: manifest.jsonl line {line_number}: {exc}"
+            ) from exc
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Invalid model_calls component in {root}: "
+                f"manifest.jsonl line {line_number} must be an object"
+            )
+        index = entry.get("index")
+        if isinstance(index, bool) or not isinstance(index, int) or index != expected_index:
+            raise ValueError(
+                f"Invalid model_calls component in {root}: manifest.jsonl line "
+                f"{line_number} expected index {expected_index}, got {index!r}"
+            )
+        if entry.get("method", "generate") not in {"generate", "generate_with_tools"}:
+            raise ValueError(
+                f"Invalid model_calls component in {root}: manifest.jsonl line "
+                f"{line_number} has unsupported method {entry.get('method')!r}"
+            )
+        for suffix in ("prompt", "response"):
+            call_path = root / f"call_{index:02d}_{suffix}.txt"
+            if not call_path.is_file():
+                raise ValueError(
+                    f"Incomplete saved artifact in {root}: model_calls index {index} "
+                    f"requires {call_path.name}"
+                )
+        expected_index += 1

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -74,6 +74,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast
 
+from looplet.artifact_compat import (
+    begin_artifact_write,
+    read_artifact_descriptor,
+    write_artifact_descriptor,
+)
+
 if TYPE_CHECKING:
     from looplet.session import SessionLog
     from looplet.types import AgentState, LLMBackend
@@ -274,6 +280,10 @@ class EvalContext:
         Expects ``trajectory.json`` (from :class:`TrajectoryRecorder`).
         """
         root = Path(path)
+        read_artifact_descriptor(
+            root,
+            expected_kinds=("eval_run", "provenance"),
+        )
         traj_path = root / "trajectory.json"
         if not traj_path.exists():
             raise FileNotFoundError(f"No trajectory.json in {root}")
@@ -1091,6 +1101,7 @@ def save_eval_run(
     """
     root = Path(directory)
     root.mkdir(parents=True, exist_ok=True)
+    begin_artifact_write(root)
 
     # Resolve the trajectory source.
     src_context = context
@@ -1106,6 +1117,7 @@ def save_eval_run(
     recorder_redact = (
         cast(Callable[[str], str], raw_recorder_redact) if callable(raw_recorder_redact) else None
     )
+    has_model_calls = False
 
     if recorder is not None:
         # Full-fidelity record (trajectory.json + steps/ + LLM calls).
@@ -1114,7 +1126,12 @@ def save_eval_run(
             src_context,
             expected=grader_expected,
         )
-        recorder.save(root)
+        save_parameters = inspect.signature(recorder.save).parameters
+        if "publish_descriptor" in save_parameters:
+            recorder.save(root, publish_descriptor=False)
+        else:
+            recorder.save(root)
+        has_model_calls = (root / "manifest.jsonl").is_file()
         if src_context is not None and not merged_before_save:
             _merge_context_into_saved_trajectory(
                 root,
@@ -1168,6 +1185,10 @@ def save_eval_run(
     else:
         (root / "case.json").unlink(missing_ok=True)
 
+    components = ["artifacts", "eval_results", "trajectory"]
+    if has_model_calls:
+        components.append("model_calls")
+    write_artifact_descriptor(root, kind="eval_run", components=components)
     return root
 
 
@@ -1263,6 +1284,7 @@ def load_eval_run(directory: str | Path) -> "EvalRunRecord":
     ``trajectory.json`` raises :class:`FileNotFoundError` (loud).
     """
     root = Path(directory)
+    read_artifact_descriptor(root, expected_kinds=("eval_run",))
     context = EvalContext.from_trajectory_dir(root)
 
     results: list[EvalResult] = []

--- a/src/looplet/provenance.py
+++ b/src/looplet/provenance.py
@@ -50,6 +50,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 from uuid import uuid4
 
+from looplet.artifact_compat import (
+    begin_artifact_write,
+    read_artifact_descriptor,
+    write_artifact_descriptor,
+)
 from looplet.telemetry import Span, Tracer
 
 if TYPE_CHECKING:
@@ -215,7 +220,7 @@ class _RecordingBase:
 
     # ── disk IO ─────────────────────────────────────────────────
 
-    def save(self, directory: str | Path) -> Path:
+    def save(self, directory: str | Path, *, publish_descriptor: bool = True) -> Path:
         """Write captured calls as ``call_NN_prompt.txt`` / ``_response.txt``.
 
         Also writes ``manifest.jsonl`` with one :class:`LLMCall` summary
@@ -223,6 +228,8 @@ class _RecordingBase:
         """
         root = Path(directory)
         root.mkdir(parents=True, exist_ok=True)
+        if publish_descriptor:
+            begin_artifact_write(root)
         _clear_call_artifacts(root)
         manifest = root / "manifest.jsonl"
         with manifest.open("w", encoding="utf-8") as mf:
@@ -235,6 +242,8 @@ class _RecordingBase:
                     _format_response_block(c), encoding="utf-8"
                 )
                 mf.write(json.dumps(c.to_dict()) + "\n")
+        if publish_descriptor:
+            write_artifact_descriptor(root, kind="provenance", components=("model_calls",))
         return root
 
     def reset(self) -> None:
@@ -788,7 +797,7 @@ class TrajectoryRecorder:
 
     # ── disk IO ─────────────────────────────────────────────────
 
-    def save(self, directory: str | Path) -> Path:
+    def save(self, directory: str | Path, *, publish_descriptor: bool = True) -> Path:
         """Write ``trajectory.json`` + per-step files + (optional) LLM calls.
 
         Layout::
@@ -804,6 +813,8 @@ class TrajectoryRecorder:
         """
         root = Path(directory)
         root.mkdir(parents=True, exist_ok=True)
+        if publish_descriptor:
+            begin_artifact_write(root)
         _clear_call_artifacts(root)
         traj_text = json.dumps(self.trajectory.to_dict(), indent=2, default=str)
         if self._redact is not None:
@@ -823,7 +834,12 @@ class TrajectoryRecorder:
                 encoding="utf-8",
             )
         if self._recording_llm is not None:
-            self._recording_llm.save(root)
+            self._recording_llm.save(root, publish_descriptor=False)
+        components = ["trajectory"]
+        if self._recording_llm is not None:
+            components.append("model_calls")
+        if publish_descriptor:
+            write_artifact_descriptor(root, kind="provenance", components=components)
         return root
 
 
@@ -999,6 +1015,12 @@ def _load_trace_calls(trace_dir: Path) -> list[dict[str, Any]]:
     the manifest is missing, falls back to the response files alone
     (every call treated as ``generate`` returning the file contents).
     """
+    descriptor = read_artifact_descriptor(
+        trace_dir,
+        expected_kinds=("eval_run", "provenance"),
+    )
+    if descriptor is not None and "model_calls" not in descriptor["components"]:
+        raise ValueError(f"Saved artifact in {trace_dir} does not declare a model_calls component")
     manifest = trace_dir / "manifest.jsonl"
     calls: list[dict[str, Any]] = []
     if manifest.exists():

--- a/tests/fixtures/artifact_compat/legacy_v0_eval_run/metrics.json
+++ b/tests/fixtures/artifact_compat/legacy_v0_eval_run/metrics.json
@@ -1,0 +1,6 @@
+{
+  "expected_answer": 42,
+  "output": {
+    "answer": "legacy"
+  }
+}

--- a/tests/fixtures/artifact_compat/legacy_v0_eval_run/trajectory.json
+++ b/tests/fixtures/artifact_compat/legacy_v0_eval_run/trajectory.json
@@ -1,0 +1,13 @@
+{
+  "run_id": "fixture-legacy-v0",
+  "task": "legacy task",
+  "steps": [
+    {
+      "tool": "done",
+      "args": {
+        "answer": "legacy"
+      },
+      "error": null
+    }
+  ]
+}

--- a/tests/fixtures/artifact_compat/v1_eval_run/artifact.json
+++ b/tests/fixtures/artifact_compat/v1_eval_run/artifact.json
@@ -1,0 +1,16 @@
+{
+  "schema": "looplet.saved-artifact",
+  "version": 1,
+  "kind": "eval_run",
+  "producer": {
+    "name": "looplet",
+    "version": "0.3.0",
+    "future_producer_field": "ignored"
+  },
+  "components": [
+    "artifacts",
+    "eval_results",
+    "trajectory"
+  ],
+  "future_descriptor_field": "ignored"
+}

--- a/tests/fixtures/artifact_compat/v1_eval_run/artifacts.json
+++ b/tests/fixtures/artifact_compat/v1_eval_run/artifacts.json
@@ -1,0 +1,3 @@
+{
+  "tests_passing": true
+}

--- a/tests/fixtures/artifact_compat/v1_eval_run/case.json
+++ b/tests/fixtures/artifact_compat/v1_eval_run/case.json
@@ -1,0 +1,10 @@
+{
+  "id": "fixture-v1",
+  "task": {
+    "goal": "Prove the saved eval fixture loads"
+  },
+  "marks": [
+    "regression"
+  ],
+  "future_case_field": "ignored"
+}

--- a/tests/fixtures/artifact_compat/v1_eval_run/evals.json
+++ b/tests/fixtures/artifact_compat/v1_eval_run/evals.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "eval_tests_pass",
+    "score": 1.0,
+    "label": "pass",
+    "future_result_field": "ignored"
+  }
+]

--- a/tests/fixtures/artifact_compat/v1_eval_run/trajectory.json
+++ b/tests/fixtures/artifact_compat/v1_eval_run/trajectory.json
@@ -1,0 +1,27 @@
+{
+  "run_id": "fixture-v1",
+  "task": {
+    "goal": "Prove the saved eval fixture loads"
+  },
+  "termination_reason": "done",
+  "steps": [
+    {
+      "step_num": 1,
+      "tool_call": {
+        "tool": "done",
+        "args": {
+          "summary": "fixture complete"
+        }
+      },
+      "tool_result": {
+        "data": {
+          "status": "completed"
+        },
+        "error": null
+      }
+    }
+  ],
+  "future_trajectory_field": {
+    "ignored": true
+  }
+}

--- a/tests/test_artifact_compatibility.py
+++ b/tests/test_artifact_compatibility.py
@@ -1,0 +1,176 @@
+"""Compatibility contract for versioned saved provenance and eval artifacts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from looplet import EvalContext, __version__, load_eval_run, save_eval_run
+from looplet.artifact_compat import (
+    ARTIFACT_DESCRIPTOR,
+    ARTIFACT_PENDING,
+    ARTIFACT_SCHEMA,
+    ARTIFACT_VERSION,
+    begin_artifact_write,
+    read_artifact_descriptor,
+)
+from looplet.provenance import ProvenanceSink, replay_loop
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "artifact_compat"
+
+
+def test_v1_eval_run_fixture_loads_and_ignores_unknown_fields() -> None:
+    record = load_eval_run(_FIXTURES / "v1_eval_run")
+
+    assert record.case is not None
+    assert record.case.id == "fixture-v1"
+    assert record.case.marks == ["regression"]
+    assert record.context.completed is True
+    assert record.context.final_output == {"summary": "fixture complete"}
+    assert record.context.artifacts == {"tests_passing": True}
+    assert [(result.name, result.score, result.label) for result in record.results] == [
+        ("eval_tests_pass", 1.0, "pass")
+    ]
+
+
+def test_legacy_v0_eval_run_fixture_remains_readable() -> None:
+    fixture = _FIXTURES / "legacy_v0_eval_run"
+
+    assert read_artifact_descriptor(fixture) is None
+    record = load_eval_run(fixture)
+
+    assert record.case is None
+    assert record.context.task == {
+        "description": "legacy task",
+        "expected_answer": 42,
+    }
+    assert record.context.final_output == {"answer": "legacy"}
+    assert record.context.tool_sequence == ["done"]
+
+
+def test_eval_run_writer_publishes_v1_descriptor_last(tmp_path: Path) -> None:
+    output = save_eval_run(
+        tmp_path / "run",
+        context=EvalContext(
+            steps=[],
+            task={"goal": "write a descriptor"},
+            artifacts={"observed": True},
+            stop_reason="done",
+        ),
+    )
+
+    descriptor = read_artifact_descriptor(output, expected_kinds=("eval_run",))
+    assert descriptor == {
+        "schema": ARTIFACT_SCHEMA,
+        "version": ARTIFACT_VERSION,
+        "kind": "eval_run",
+        "producer": {"name": "looplet", "version": __version__},
+        "components": ["artifacts", "eval_results", "trajectory"],
+    }
+    assert not list(output.glob(f".{ARTIFACT_DESCRIPTOR}.*.tmp"))
+    assert not (output / ARTIFACT_PENDING).exists()
+
+
+def test_eval_run_declares_model_calls_from_a_legacy_recorder(tmp_path: Path) -> None:
+    class LegacyRecorder:
+        def save(self, directory: str | Path) -> Path:
+            root = Path(directory)
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "trajectory.json").write_text('{"steps": []}')
+            (root / "manifest.jsonl").write_text('{"index": 0, "method": "generate"}\n')
+            (root / "call_00_prompt.txt").write_text("prompt")
+            (root / "call_00_response.txt").write_text("response")
+            return root
+
+    output = save_eval_run(tmp_path / "run", recorder=LegacyRecorder())
+
+    descriptor = read_artifact_descriptor(output, expected_kinds=("eval_run",))
+    assert descriptor is not None
+    assert "model_calls" in descriptor["components"]
+
+
+def test_pending_write_cannot_be_misread_as_legacy_v0(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    shutil.copytree(_FIXTURES / "v1_eval_run", run)
+
+    begin_artifact_write(run)
+
+    assert not (run / ARTIFACT_DESCRIPTOR).exists()
+    with pytest.raises(ValueError, match="write is still pending"):
+        load_eval_run(run)
+
+
+def test_provenance_sink_declares_the_components_it_wrote(tmp_path: Path) -> None:
+    sink = ProvenanceSink(tmp_path / "trace")
+    llm = sink.wrap_llm(type("Backend", (), {"generate": lambda self, prompt, **kw: "ok"})())
+    llm.generate("hello")
+    sink.trajectory_hook()
+
+    output = sink.flush()
+
+    descriptor = read_artifact_descriptor(output, expected_kinds=("provenance",))
+    assert descriptor is not None
+    assert descriptor["components"] == ["model_calls", "trajectory"]
+
+
+def test_v1_model_calls_refuse_a_missing_indexed_file(tmp_path: Path) -> None:
+    sink = ProvenanceSink(tmp_path / "trace")
+    llm = sink.wrap_llm(type("Backend", (), {"generate": lambda self, prompt, **kw: "ok"})())
+    llm.generate("hello")
+    sink.trajectory_hook()
+    output = sink.flush()
+    (output / "call_00_prompt.txt").unlink()
+
+    with pytest.raises(ValueError, match="model_calls index 0 requires call_00_prompt.txt"):
+        read_artifact_descriptor(output)
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        ({"version": 999}, "Unsupported looplet.saved-artifact version 999"),
+        ({"schema": "other.schema"}, "unsupported schema"),
+        ({"kind": "provenance"}, "kind 'provenance' is not eval_run"),
+        ({"components": ["artifacts", "eval_results", "future", "trajectory"]}, "unknown future"),
+    ],
+)
+def test_explicit_incompatible_descriptors_fail_closed(
+    tmp_path: Path,
+    replacement: dict[str, object],
+    message: str,
+) -> None:
+    run = tmp_path / "run"
+    shutil.copytree(_FIXTURES / "v1_eval_run", run)
+    descriptor_path = run / ARTIFACT_DESCRIPTOR
+    descriptor = json.loads(descriptor_path.read_text())
+    descriptor.update(replacement)
+    descriptor_path.write_text(json.dumps(descriptor))
+
+    with pytest.raises(ValueError, match=message):
+        load_eval_run(run)
+
+
+def test_v1_missing_required_component_fails_closed(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    shutil.copytree(_FIXTURES / "v1_eval_run", run)
+    (run / "evals.json").unlink()
+
+    with pytest.raises(ValueError, match="component 'eval_results' requires evals.json"):
+        load_eval_run(run)
+
+
+def test_malformed_descriptor_fails_before_payload_is_used(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    shutil.copytree(_FIXTURES / "v1_eval_run", run)
+    (run / ARTIFACT_DESCRIPTOR).write_text("not-json")
+
+    with pytest.raises(ValueError, match="Invalid artifact.json"):
+        load_eval_run(run)
+
+
+def test_replay_refuses_v1_artifact_without_model_calls() -> None:
+    with pytest.raises(ValueError, match="does not declare a model_calls component"):
+        list(replay_loop(_FIXTURES / "v1_eval_run", tools=object()))

--- a/tests/test_replay_and_cli_smoke.py
+++ b/tests/test_replay_and_cli_smoke.py
@@ -16,6 +16,7 @@ from looplet import (
     composable_loop,
 )
 from looplet.__main__ import main as cli_main
+from looplet.artifact_compat import ARTIFACT_DESCRIPTOR
 from looplet.provenance import ProvenanceSink, replay_loop
 from looplet.testing import MockLLMBackend
 from looplet.tools import ToolSpec
@@ -107,6 +108,7 @@ class TestReplayLoopSmoke:
         """Replay should work from call_NN_response.txt even without manifest."""
         trace_dir = _captured_dir(tmp_path)
         (trace_dir / "manifest.jsonl").unlink()
+        (trace_dir / ARTIFACT_DESCRIPTOR).unlink()
         steps = list(replay_loop(trace_dir, tools=_make_tools()))
         assert len(steps) == 3
 
@@ -237,6 +239,7 @@ class TestShowCLISmoke:
         """With only manifest.jsonl present, `show` still prints LLM summary."""
         trace_dir = _captured_dir(tmp_path)
         (trace_dir / "trajectory.json").unlink()
+        (trace_dir / ARTIFACT_DESCRIPTOR).unlink()
         rc = cli_main(["show", str(trace_dir)])
         assert rc == 0
         out = capsys.readouterr().out
@@ -245,6 +248,7 @@ class TestShowCLISmoke:
     def test_show_json_tolerates_missing_trajectory(self, tmp_path: Path, capsys):
         trace_dir = _captured_dir(tmp_path)
         (trace_dir / "trajectory.json").unlink()
+        (trace_dir / ARTIFACT_DESCRIPTOR).unlink()
 
         rc = cli_main(["show", str(trace_dir), "--json"])
 


### PR DESCRIPTION
Closes #103.

## Summary
- inventory and classify every persisted provenance/eval artifact
- publish a small versioned `artifact.json` descriptor after completed writes
- preserve explicit legacy-v0 fixtures and reject unsupported/incomplete v1 artifacts
- distinguish crash-interrupted writes with a fail-closed pending marker

## Validation
- `make check` (2,420 passed, 2 skipped)
- `mkdocs build --strict`
- independent blocker review and follow-up re-review
