### PR TITLE
feat(evals): version CI summary

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -398,3 +398,38 @@ looplet eval traces/ --evals eval_agent.py --threshold 0.7 -v
   overall: 0.81
   threshold: 0.70  → PASS
 ```
+
+For a cartridge's colocated cases, `--json` emits the stable transient CI
+schema `looplet.eval-summary` version 1:
+
+```bash
+looplet eval run ./agent.cartridge --threshold 0.7 --json > eval-summary.json
+jq -e '.schema == "looplet.eval-summary" and .version == 1 and .passed' \
+    eval-summary.json
+```
+
+The command itself exits non-zero exactly when `passed` is false. The report
+includes the trusted pre-run `grader_manifest`, case IDs and marks, and one
+result record per expected grader. Each result carries its grader marks,
+`required`, `required_status`, and one closed `state` value:
+
+| State | Meaning |
+| --- | --- |
+| `pass` | The result meets its required boundary and the CLI threshold. |
+| `explicit_fail` | The grader returned a failing label, an invalid empty result, or a required numeric score below $0.5$. |
+| `threshold_fail` | A numeric score is valid but below `--threshold`. |
+| `skipped` | The grader did not run, normally because no judge model was configured. Required skipped graders fail the report. |
+| `missing` | A grader discovered before execution has no run result. This is an integrity failure even when candidate-editable output omits it. |
+| `collector_error` | An outcome collector raised or returned the wrong shape. |
+| `grader_error` | A grader raised. |
+| `metric_only` | The grader emitted metrics but no pass/fail score or label. Required metric-only graders fail the report. |
+
+`required_status` is `not_required`, `satisfied`, or `failed`. A required score
+can satisfy the ordinary $0.5$ required boundary while still receiving
+`threshold_fail` under a stricter CLI threshold. Collector and grader errors
+include an `error` string and can never serialize as passing.
+
+This summary is a decision report, not a persisted run format. Use
+`save_eval_run()` / `--out` for durable evidence and preserve its sibling
+`artifact.json` descriptor. The JSON report intentionally omits task data,
+expected data, prompts, responses, and artifact values.

--- a/src/looplet/evals.py
+++ b/src/looplet/evals.py
@@ -137,6 +137,18 @@ CARTRIDGE_EVALS_SUBPATH = "evals"
 # an integrity failure; unmarked judge graders may still be intentionally
 # omitted when no judge backend is configured.
 _REQUIRED_EVAL_MARK = "required"
+_EVAL_SUMMARY_SCHEMA = "looplet.eval-summary"
+_EVAL_SUMMARY_VERSION = 1
+_EVAL_RESULT_STATES = {
+    "pass",
+    "explicit_fail",
+    "threshold_fail",
+    "skipped",
+    "missing",
+    "collector_error",
+    "grader_error",
+    "metric_only",
+}
 
 
 def _validate_case_id(case_id: str) -> str:
@@ -2044,6 +2056,184 @@ def _result_is_integrity_failure(
     return normalized not in {"pass", "correct", "yes"}
 
 
+def _eval_result_state(
+    result: EvalResult | None,
+    *,
+    required: bool,
+    threshold: float,
+    collector: bool = False,
+) -> str:
+    """Classify one result using the stable eval-summary v1 vocabulary."""
+    if result is None:
+        return "missing"
+    label = (result.label or "").lower()
+    if collector and label == "error":
+        return "collector_error"
+    if label == "error":
+        return "grader_error"
+    if label == "skipped":
+        return "skipped"
+    if label in {"fail", "wrong", "no"}:
+        return "explicit_fail"
+    if result.score is not None:
+        if required and result.score < 0.5:
+            return "explicit_fail"
+        if result.score < threshold:
+            return "threshold_fail"
+        return "pass"
+    if result.metrics and not label:
+        return "metric_only"
+    if label in {"pass", "correct", "yes"}:
+        return "pass"
+    return "explicit_fail"
+
+
+def _required_status(state: str, *, required: bool) -> str:
+    if not required:
+        return "not_required"
+    if state in {"pass", "threshold_fail"}:
+        return "satisfied"
+    return "failed"
+
+
+def _eval_state_fails(state: str, *, required: bool) -> bool:
+    if state in {"pass", "metric_only", "skipped"}:
+        return required and state != "pass"
+    return True
+
+
+def _eval_summary_result(
+    result: EvalResult | None,
+    *,
+    name: str,
+    marks: set[str],
+    threshold: float,
+    collector: bool = False,
+) -> dict[str, Any]:
+    required = _REQUIRED_EVAL_MARK in marks
+    state = _eval_result_state(
+        result,
+        required=required,
+        threshold=threshold,
+        collector=collector,
+    )
+    payload: dict[str, Any] = {
+        "name": name,
+        "marks": sorted(marks),
+        "required": required,
+        "required_status": _required_status(state, required=required),
+        "state": state,
+    }
+    if result is not None:
+        payload.update(result.to_dict())
+        if state in {"collector_error", "grader_error"}:
+            payload["error"] = result.explanation or result.label or "unknown error"
+    return payload
+
+
+def _eval_grader_manifest(graders: list[Callable]) -> list[dict[str, Any]]:
+    """Freeze grader identity and marks before candidate execution begins."""
+    return [
+        {
+            "name": grader.__name__,
+            "marks": sorted(_get_marks(grader)),
+            "required": _REQUIRED_EVAL_MARK in _get_marks(grader),
+        }
+        for grader in sorted(graders, key=lambda item: item.__name__)
+    ]
+
+
+def _build_eval_summary(
+    *,
+    records: list[EvalRunRecord],
+    grader_manifest: list[dict[str, Any]],
+    threshold: float,
+    output_dir: str | None,
+) -> dict[str, Any]:
+    """Build the stable v1 CI report from one trusted pre-run grader manifest."""
+    manifest = [dict(item) for item in grader_manifest]
+    manifest_names = {item["name"] for item in manifest}
+    integrity_failures: list[str] = []
+    case_reports: list[dict[str, Any]] = []
+    failed = False
+
+    for record in records:
+        case_id = record.case.id if record.case is not None else "?"
+        case_marks = sorted(record.case.marks) if record.case is not None else []
+        by_name = {result.name: result for result in record.results}
+        results: list[dict[str, Any]] = []
+        for expected in manifest:
+            result = by_name.get(expected["name"])
+            item = _eval_summary_result(
+                result,
+                name=expected["name"],
+                marks=set(expected["marks"]),
+                threshold=threshold,
+            )
+            results.append(item)
+            if _eval_state_fails(item["state"], required=item["required"]):
+                failed = True
+            if item["state"] == "missing":
+                integrity_failures.append(
+                    f"{case_id}/{item['name']}: grader missing from run result"
+                )
+            elif item["required_status"] == "failed":
+                integrity_failures.append(
+                    f"{case_id}/{item['name']}: required grader {item['state']}"
+                )
+            elif item["state"] == "grader_error":
+                integrity_failures.append(f"{case_id}/{item['name']}: grader error")
+
+        for result in record.results:
+            if result.name in manifest_names:
+                continue
+            collector = result.name.startswith("collector:")
+            item = _eval_summary_result(
+                result,
+                name=result.name,
+                marks=set(),
+                threshold=threshold,
+                collector=collector,
+            )
+            results.append(item)
+            if _eval_state_fails(item["state"], required=False):
+                failed = True
+            if item["state"] == "collector_error":
+                integrity_failures.append(f"{case_id}/{item['name']}: collector error")
+            elif item["state"] == "grader_error":
+                integrity_failures.append(f"{case_id}/{item['name']}: unexpected grader error")
+
+        case_reports.append(
+            {
+                "id": case_id,
+                "marks": case_marks,
+                "completed": record.context.completed,
+                "state": "fail"
+                if any(
+                    _eval_state_fails(item["state"], required=item["required"]) for item in results
+                )
+                else "pass",
+                "results": results,
+            }
+        )
+
+    report = {
+        "schema": _EVAL_SUMMARY_SCHEMA,
+        "version": _EVAL_SUMMARY_VERSION,
+        "state": "fail" if failed else "pass",
+        "passed": not failed,
+        "threshold": threshold,
+        "grader_manifest": manifest,
+        "cases": case_reports,
+        "integrity_failures": integrity_failures,
+        "output_dir": output_dir,
+    }
+    assert {item["state"] for case in case_reports for item in case["results"]} <= (
+        _EVAL_RESULT_STATES
+    )
+    return report
+
+
 # ── Batch runner ─────────────────────────────────────────────────
 
 
@@ -2378,6 +2568,7 @@ def _run_cartridge_cli(args: list[str]) -> int:
     if not overview.graders:
         print(f"error: no graders (evals/eval_*.py) under {cdir / 'evals'}", file=sys.stderr)
         return 1
+    grader_manifest = _eval_grader_manifest(overview.graders)
 
     base_url = parsed.base_url or os.environ.get("OPENAI_BASE_URL")
     model = parsed.model or os.environ.get("OPENAI_MODEL")
@@ -2430,17 +2621,17 @@ def _run_cartridge_cli(args: list[str]) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    grader_names = sorted(g.__name__ for g in overview.graders)
+    report = _build_eval_summary(
+        records=records,
+        grader_manifest=grader_manifest,
+        threshold=parsed.threshold,
+        output_dir=str(parsed.out) if parsed.out else None,
+    )
+    grader_names = [item["name"] for item in report["grader_manifest"]]
     header = f"{'case':22}" + "".join(f"{n:22}" for n in grader_names)
     if not parsed.json:
         print(header)
         print("-" * len(header))
-    below_threshold = False
-    integrity_failures: list[str] = []
-    case_reports: list[dict[str, Any]] = []
-    required_names = {
-        grader.__name__ for grader in overview.graders if _REQUIRED_EVAL_MARK in _get_marks(grader)
-    }
     for rec in records:
         scores = {r.name: r for r in rec.results}
         cells = ""
@@ -2450,8 +2641,6 @@ def _run_cartridge_cli(args: list[str]) -> int:
                 cells += f"{'-':22}"
             elif r.score is not None:
                 cells += f"{r.score:<22.2f}"
-                if r.score < parsed.threshold:
-                    below_threshold = True
             elif r.metrics:
                 # Metric grader (no pass/fail score) - show the numbers.
                 cells += f"{('; '.join(f'{k}={v:g}' for k, v in r.metrics.items())):22}"
@@ -2460,41 +2649,15 @@ def _run_cartridge_cli(args: list[str]) -> int:
         case_id = rec.case.id if rec.case is not None else "?"
         if not parsed.json:
             print(f"{case_id:22}{cells}")
-        for result in rec.results:
-            if _result_is_integrity_failure(
-                result,
-                required=result.name in required_names,
-            ):
-                integrity_failures.append(
-                    f"{case_id}/{result.name}: {result.label or 'invalid result'}"
-                )
-        case_reports.append(
-            {
-                "id": case_id,
-                "completed": rec.context.completed,
-                "results": [result.to_dict() for result in rec.results],
-            }
-        )
 
-    failed = below_threshold or bool(integrity_failures)
+    failed = not report["passed"]
     if parsed.json:
-        print(
-            json.dumps(
-                {
-                    "passed": not failed,
-                    "threshold": parsed.threshold,
-                    "cases": case_reports,
-                    "integrity_failures": integrity_failures,
-                    "output_dir": str(parsed.out) if parsed.out else None,
-                },
-                indent=2,
-            )
-        )
+        print(json.dumps(report, indent=2))
     elif parsed.out:
         print(f"\npersisted {len(records)} run(s) under {parsed.out}/")
-    if integrity_failures and not parsed.json:
+    if report["integrity_failures"] and not parsed.json:
         print("\nintegrity failures:")
-        for failure in integrity_failures:
+        for failure in report["integrity_failures"]:
             print(f"  - {failure}")
     if parsed.threshold > 0 and not parsed.json:
         print(f"threshold {parsed.threshold:.2f} → {'FAIL' if failed else 'PASS'}")

--- a/tests/test_eval_cartridge_cli.py
+++ b/tests/test_eval_cartridge_cli.py
@@ -70,6 +70,10 @@ def build(runtime=None):
 """
 
 _GRADERS = """\
+from looplet import eval_mark
+
+
+@eval_mark("smoke")
 def eval_completed(ctx):
     return ctx.completed
 
@@ -110,6 +114,7 @@ _CASE = {
         },
     },
     "expected": {"file_written": True},
+    "marks": ["regression"],
 }
 
 
@@ -330,15 +335,29 @@ def test_cli_run_json_emits_one_eval_report(tmp_path: Path, monkeypatch, capsys)
 
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "looplet.eval-summary"
+    assert payload["version"] == 1
+    assert payload["state"] == "pass"
     assert payload["passed"] is True
     assert payload["threshold"] == 1.0
     assert payload["output_dir"] == str(out)
     assert payload["integrity_failures"] == []
     assert payload["cases"][0]["id"] == "make_greeting"
+    assert payload["cases"][0]["marks"] == ["regression"]
     assert payload["cases"][0]["completed"] is True
-    assert {result["name"] for result in payload["cases"][0]["results"]} >= {
+    by_name = {result["name"]: result for result in payload["cases"][0]["results"]}
+    assert set(by_name) >= {
         "eval_completed",
         "eval_wrote_file",
+    }
+    assert by_name["eval_completed"]["marks"] == ["smoke"]
+    assert by_name["eval_completed"]["state"] == "pass"
+    assert by_name["eval_completed"]["required_status"] == "not_required"
+    manifest = {item["name"]: item for item in payload["grader_manifest"]}
+    assert manifest["eval_completed"] == {
+        "name": "eval_completed",
+        "marks": ["smoke"],
+        "required": False,
     }
 
 
@@ -358,11 +377,13 @@ def test_cli_run_json_preserves_threshold_failure_exit(tmp_path: Path, monkeypat
 
     assert rc == 1
     payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "fail"
     assert payload["passed"] is False
     zero = next(
         result for result in payload["cases"][0]["results"] if result["name"] == "eval_zero"
     )
     assert zero["score"] == 0.0
+    assert zero["state"] == "threshold_fail"
 
 
 def test_cli_run_unknown_case_returns_failure(tmp_path: Path, monkeypatch) -> None:
@@ -383,7 +404,7 @@ def test_cli_run_rejects_invalid_threshold_before_backend_setup(tmp_path: Path) 
     assert eval_cli(["run", str(cart), "--threshold", "nan"]) == 1
 
 
-def test_cli_run_fails_on_evaluator_error(tmp_path: Path, monkeypatch) -> None:
+def test_cli_run_fails_on_evaluator_error(tmp_path: Path, monkeypatch, capsys) -> None:
     cart = _make_cartridge(tmp_path)
     (cart / "evals" / "eval_broken.py").write_text(
         "def eval_broken(ctx):\n    raise RuntimeError('grader broke')\n"
@@ -396,7 +417,14 @@ def test_cli_run_fails_on_evaluator_error(tmp_path: Path, monkeypatch) -> None:
         "OpenAIBackend",
         lambda **kw: MockLLMBackend(responses=_scripted()),
     )
-    assert eval_cli(["run", str(cart)]) == 1
+    assert eval_cli(["run", str(cart), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    broken = next(
+        result for result in payload["cases"][0]["results"] if result["name"] == "eval_broken"
+    )
+    assert broken["state"] == "grader_error"
+    assert broken["error"] == "grader broke"
+    assert payload["passed"] is False
 
 
 def test_cli_run_fails_on_failing_verdict_label(tmp_path: Path, monkeypatch) -> None:
@@ -436,7 +464,7 @@ def test_cli_run_fails_when_required_judge_is_skipped(tmp_path: Path, monkeypatc
     assert "must not run" not in by_name["eval_required_judge"].explanation
 
 
-def test_cli_run_fails_on_collector_error(tmp_path: Path, monkeypatch) -> None:
+def test_cli_run_fails_on_collector_error(tmp_path: Path, monkeypatch, capsys) -> None:
     cart = _make_cartridge(tmp_path)
     (cart / "evals" / "collect_outcome.py").write_text(
         "def collect_broken(state, runtime):\n    raise RuntimeError('collector broke')\n"
@@ -449,7 +477,16 @@ def test_cli_run_fails_on_collector_error(tmp_path: Path, monkeypatch) -> None:
         "OpenAIBackend",
         lambda **kw: MockLLMBackend(responses=_scripted()),
     )
-    assert eval_cli(["run", str(cart)]) == 1
+    assert eval_cli(["run", str(cart), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    broken = next(
+        result
+        for result in payload["cases"][0]["results"]
+        if result["name"] == "collector:collect_broken"
+    )
+    assert broken["state"] == "collector_error"
+    assert broken["error"] == "RuntimeError: collector broke"
+    assert payload["passed"] is False
 
 
 # ── CLI preflight / error paths (no live model needed) ───────────

--- a/tests/test_eval_summary_schema.py
+++ b/tests/test_eval_summary_schema.py
@@ -1,0 +1,153 @@
+"""Stable state and manifest contract for `looplet eval run --json`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from looplet import EvalCase, EvalContext, EvalResult, EvalRunRecord, eval_mark
+from looplet.evals import (
+    _EVAL_RESULT_STATES,
+    _EVAL_SUMMARY_SCHEMA,
+    _EVAL_SUMMARY_VERSION,
+    _build_eval_summary,
+    _eval_grader_manifest,
+    _eval_summary_result,
+)
+
+
+def _result(state: str) -> tuple[EvalResult | None, dict[str, object]]:
+    cases: dict[str, tuple[EvalResult | None, dict[str, object]]] = {
+        "pass": (EvalResult(name="grader", score=1.0), {"score": 1.0}),
+        "explicit_fail": (
+            EvalResult(name="grader", score=0.0, label="fail"),
+            {"score": 0.0, "label": "fail"},
+        ),
+        "threshold_fail": (EvalResult(name="grader", score=0.4), {"score": 0.4}),
+        "skipped": (
+            EvalResult(name="grader", label="skipped", explanation="requires judge"),
+            {"label": "skipped", "explanation": "requires judge"},
+        ),
+        "missing": (None, {}),
+        "collector_error": (
+            EvalResult(name="collector:files", label="error", explanation="OSError: denied"),
+            {"label": "error", "explanation": "OSError: denied", "error": "OSError: denied"},
+        ),
+        "grader_error": (
+            EvalResult(name="grader", label="error", explanation="ValueError: bad"),
+            {"label": "error", "explanation": "ValueError: bad", "error": "ValueError: bad"},
+        ),
+        "metric_only": (
+            EvalResult(name="grader", metrics={"latency_ms": 12.0}),
+            {"metrics": {"latency_ms": 12.0}},
+        ),
+    }
+    return cases[state]
+
+
+def test_every_eval_summary_state_matches_its_golden_record() -> None:
+    assert _EVAL_RESULT_STATES == {
+        "pass",
+        "explicit_fail",
+        "threshold_fail",
+        "skipped",
+        "missing",
+        "collector_error",
+        "grader_error",
+        "metric_only",
+    }
+    for state in sorted(_EVAL_RESULT_STATES):
+        result, extra = _result(state)
+        collector = state == "collector_error"
+        name = "collector:files" if collector else "grader"
+        actual = _eval_summary_result(
+            result,
+            name=name,
+            marks=set(),
+            threshold=0.5,
+            collector=collector,
+        )
+        assert actual == {
+            "name": name,
+            "marks": [],
+            "required": False,
+            "required_status": "not_required",
+            "state": state,
+            **extra,
+        }
+
+
+def test_summary_uses_the_pre_run_manifest_to_report_a_missing_grader() -> None:
+    @eval_mark("accuracy")
+    def eval_present(ctx):
+        return True
+
+    @eval_mark("required", "release")
+    def eval_required_missing(ctx):
+        return True
+
+    record = EvalRunRecord(
+        case=EvalCase(id="case-1", task={}, marks=["smoke"]),
+        context=EvalContext(steps=[], stop_reason="done"),
+        results=[EvalResult(name="eval_present", score=1.0, label="pass")],
+        directory=Path("run"),
+    )
+    manifest = _eval_grader_manifest([eval_present, eval_required_missing])
+    getattr(eval_required_missing, "_eval_marks").clear()
+
+    report = _build_eval_summary(
+        records=[record],
+        grader_manifest=manifest,
+        threshold=0.5,
+        output_dir=None,
+    )
+
+    assert report["schema"] == _EVAL_SUMMARY_SCHEMA
+    assert report["version"] == _EVAL_SUMMARY_VERSION
+    assert report["state"] == "fail"
+    assert report["passed"] is False
+    assert report["cases"][0]["marks"] == ["smoke"]
+    assert report["grader_manifest"] == [
+        {"name": "eval_present", "marks": ["accuracy"], "required": False},
+        {
+            "name": "eval_required_missing",
+            "marks": ["release", "required"],
+            "required": True,
+        },
+    ]
+    missing = next(item for item in report["cases"][0]["results"] if item["state"] == "missing")
+    assert missing == {
+        "name": "eval_required_missing",
+        "marks": ["release", "required"],
+        "required": True,
+        "required_status": "failed",
+        "state": "missing",
+    }
+    assert report["integrity_failures"] == [
+        "case-1/eval_required_missing: grader missing from run result"
+    ]
+
+
+def test_required_metric_and_skipped_results_fail_without_changing_their_state() -> None:
+    for result in (
+        EvalResult(name="grader", metrics={"latency_ms": 12.0}),
+        EvalResult(name="grader", label="skipped"),
+    ):
+        item = _eval_summary_result(
+            result,
+            name="grader",
+            marks={"required"},
+            threshold=0.0,
+        )
+        assert item["state"] in {"metric_only", "skipped"}
+        assert item["required_status"] == "failed"
+
+
+def test_required_score_can_satisfy_the_required_gate_but_fail_cli_threshold() -> None:
+    item = _eval_summary_result(
+        EvalResult(name="grader", score=0.7),
+        name="grader",
+        marks={"required"},
+        threshold=0.9,
+    )
+    assert item["state"] == "threshold_fail"
+    assert item["required_status"] == "satisfied"


### PR DESCRIPTION
Closes #102.

## Summary
- define `looplet.eval-summary` v1 with a closed eight-state result vocabulary
- freeze the grader manifest before execution and report missing graders against it
- include case/grader marks, required status, scores, labels, and error details
- derive report state and process exit from the same result model

## Validation
- `make check` (2,424 passed, 2 skipped)
- `mkdocs build --strict`
- golden tests cover all eight states
- independent blocker review found no blockers
